### PR TITLE
Install futures3 as dependency to avoid file upload failure

### DIFF
--- a/notebooks/ingestion_api_usage.ipynb
+++ b/notebooks/ingestion_api_usage.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install requests"
+    "!pip install requests futures3"
    ]
   },
   {


### PR DESCRIPTION
## WHY?
Import from `concurrent.futures` will fail without the futures3 dependency, thus leading to file upload failure

```
import os
from concurrent.futures import ThreadPoolExecutor

def upload_file(file_path: str, collection_name: str):
    url = f"{BASE_URL}/documents"
    files = {"file": open(file_path, "rb")}
    params = {"collection_name": collection_name}
    response = requests.post(url, files=files, params=params)
    print(f"Uploading {os.path.basename(file_path)}...")
    print_response(response)

directory_path = "../data/dataset"  # Replace with your directory path
collection_name = "nvidia_blogs"

file_paths = [os.path.join(directory_path, f) for f in os.listdir(directory_path) if os.path.isfile(os.path.join(directory_path, f))]

with ThreadPoolExecutor() as executor:
    executor.map(lambda file: upload_file(file, collection_name), file_paths)
```

## Changes
Add `futures3` as dependency in step 1
