### PR TITLE
Add support for external LLM APIs (Azure OpenAI, OpenAI) and fix SSL …

### DIFF
--- a/deploy/compose/.env
+++ b/deploy/compose/.env
@@ -7,6 +7,10 @@ export NVIDIA_API_KEY=${NGC_API_KEY}
 # ==========================
 # On-Prem NIM Endpoints
 # ==========================
+# Set LLM_API_KEY if non-NVIDIA hosted LLM API endpoint is being used
+# If not set, NVIDIA_API_KEY will be used as fallback
+# export LLM_API_KEY=""
+
 export APP_LLM_SERVERURL=nim-llm:8000
 export APP_FILTEREXPRESSIONGENERATOR_SERVERURL=nim-llm:8000
 export SUMMARY_LLM_SERVERURL=nim-llm:8000

--- a/deploy/compose/docker-compose-ingestor-server.yaml
+++ b/deploy/compose/docker-compose-ingestor-server.yaml
@@ -49,6 +49,10 @@ services:
       NGC_API_KEY: ${NGC_API_KEY:?"NGC_API_KEY is required"}
       NVIDIA_API_KEY: ${NGC_API_KEY:?"NGC_API_KEY is required"}
 
+      # Set LLM_API_KEY if non-NVIDIA hosted LLM API endpoint is being used
+      # If not set, NVIDIA_API_KEY will be used as fallback
+      LLM_API_KEY: ${LLM_API_KEY:-""}
+
       ##===Embedding Model specific configurations===
       # url on which embedding model is hosted. If "", Nvidia hosted API is used
       APP_EMBEDDINGS_SERVERURL: ${APP_EMBEDDINGS_SERVERURL-"nemoretriever-embedding-ms:8000"}

--- a/deploy/compose/docker-compose-rag-server.yaml
+++ b/deploy/compose/docker-compose-rag-server.yaml
@@ -103,6 +103,10 @@ services:
 
       NVIDIA_API_KEY: ${NGC_API_KEY:?"NGC_API_KEY is required"}
 
+      # Set LLM_API_KEY if non-NVIDIA hosted LLM API endpoint is being used
+      # If not set, NVIDIA_API_KEY will be used as fallback
+      LLM_API_KEY: ${LLM_API_KEY:-""}
+
       # Number of document chunks to insert in LLM prompt, used only when ENABLE_RERANKER is set to True
       APP_RETRIEVER_TOPK: ${APP_RETRIEVER_TOPK:-10}
 

--- a/deploy/compose/nvdev.env
+++ b/deploy/compose/nvdev.env
@@ -1,5 +1,8 @@
 # ==== Authentication ====
 export NVIDIA_API_KEY=${NGC_API_KEY}
+# Set LLM_API_KEY if non-NVIDIA hosted LLM API endpoint is being used
+# If not set, NVIDIA_API_KEY will be used as fallback
+# export LLM_API_KEY=""
 
 # === Internally NVIDIA hosted NIM Endpoints (for cloud deployment) ===
 export APP_LLM_MODELNAME=nvdev/nvidia/llama-3.3-nemotron-super-49b-v1.5

--- a/deploy/helm/nvidia-blueprint-rag/values.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/values.yaml
@@ -85,6 +85,11 @@ envVars:
   PROMPT_CONFIG_FILE: "/prompt.yaml"
   PROMETHEUS_MULTIPROC_DIR: "/tmp-data/prom_data"
 
+  ##===Authentication===
+  # Set LLM_API_KEY if non-NVIDIA hosted LLM API endpoint is being used
+  # If not set, NVIDIA_API_KEY will be used as fallback
+  LLM_API_KEY: ""
+
   ##===MINIO specific configurations used to store multimodal base64 content===
   MINIO_ENDPOINT: "rag-minio:9000"
   MINIO_ACCESSKEY: "minioadmin"
@@ -276,6 +281,11 @@ ingestor-server:
     MINIO_ENDPOINT: "rag-minio:9000"
     MINIO_ACCESSKEY: "minioadmin"
     MINIO_SECRETKEY: "minioadmin"
+
+    # === Authentication ===
+    # Set LLM_API_KEY if non-NVIDIA hosted LLM API endpoint is being used
+    # If not set, NVIDIA_API_KEY will be used as fallback
+    LLM_API_KEY: ""
 
     # === Embeddings Configurations ===
     APP_EMBEDDINGS_SERVERURL: "nemoretriever-embedding-ms:8000"

--- a/src/nvidia_rag/ingestor_server/health.py
+++ b/src/nvidia_rag/ingestor_server/health.py
@@ -81,7 +81,11 @@ async def check_service_health(
         if not url.startswith(("http://", "https://")):
             url = "http://" + url
 
-        async with aiohttp.ClientSession() as session:
+        # Disable SSL verification for external endpoints
+        # This only affects health monitoring UI, not actual LLM API calls
+        connector = aiohttp.TCPConnector(ssl=False)
+
+        async with aiohttp.ClientSession(connector=connector) as session:
             request_kwargs = {
                 "timeout": aiohttp.ClientTimeout(total=timeout),
                 "headers": headers or {},

--- a/src/nvidia_rag/rag_server/health.py
+++ b/src/nvidia_rag/rag_server/health.py
@@ -79,7 +79,11 @@ async def check_service_health(
         if not url.startswith(("http://", "https://")):
             url = "http://" + url
 
-        async with aiohttp.ClientSession() as session:
+        # Disable SSL verification for external endpoints
+        # This only affects health monitoring UI, not actual LLM API calls
+        connector = aiohttp.TCPConnector(ssl=False)
+
+        async with aiohttp.ClientSession(connector=connector) as session:
             request_kwargs = {
                 "timeout": aiohttp.ClientTimeout(total=timeout),
                 "headers": headers or {},

--- a/src/nvidia_rag/utils/llm.py
+++ b/src/nvidia_rag/utils/llm.py
@@ -153,9 +153,15 @@ def get_llm(**kwargs) -> LLM | SimpleChatModel:
         if url:
             logger.debug(f"Length of llm endpoint url string {url}")
             logger.info("Using llm model %s hosted at %s", kwargs.get("model"), url)
+
+            # For External endpoints, use LLM_API_KEY if available, otherwise fall back to NVIDIA_API_KEY
+            api_key = os.environ.get("LLM_API_KEY") or os.environ.get(
+                "NVIDIA_API_KEY", ""
+            )
             return ChatNVIDIA(
                 base_url=url,
                 model=kwargs.get("model"),
+                api_key=api_key if api_key else None,
                 temperature=kwargs.get("temperature", None),
                 top_p=kwargs.get("top_p", None),
                 max_tokens=kwargs.get("max_tokens", None),

--- a/tests/unit/test_utils/test_llm.py
+++ b/tests/unit/test_utils/test_llm.py
@@ -180,6 +180,7 @@ class TestGetLLM:
         mock_chatnvidia.assert_called_once_with(
             base_url="http://test-url:8000",
             model="test-model",
+            api_key=None,
             temperature=0.7,
             top_p=0.9,
             max_tokens=1024,
@@ -562,6 +563,7 @@ class TestLLMIntegration:
             mock_chatnvidia.assert_called_once_with(
                 base_url="http://test:8000",
                 model="meta/llama-3.1-8b-instruct",
+                api_key=None,
                 temperature=0.7,
                 top_p=0.9,
                 max_tokens=2048,


### PR DESCRIPTION
- Add LLM_API_KEY environment variable with fallback to NVIDIA_API_KEY for external LLM endpoints
- Update docker-compose, helm values, and environment files to support LLM_API_KEY
- Disable SSL verification in health monitoring (aiohttp) for external endpoints with self-signed certificates
- Add documentation for using external LLM APIs in change-model.md
- Update unit tests to reflect api_key parameter addition