### PR TITLE
Fix for Batch zero update in status API

### DIFF
--- a/src/nvidia_rag/ingestor_server/ingestion_state_manager.py
+++ b/src/nvidia_rag/ingestor_server/ingestion_state_manager.py
@@ -59,12 +59,14 @@ class IngestionStateManager:
     async def update_batch_progress(
         self,
         batch_progress_response: dict[str, Any],
+        is_batch_zero: bool = False,
     ):
         async with self.asyncio_lock:
             self.total_documents_completed += len(
                 batch_progress_response.get("documents", [])
             )
-            self.total_batches_completed += 1
+            if not is_batch_zero:
+                self.total_batches_completed += 1
             self.documents_completed_list.extend(
                 batch_progress_response.get("documents", [])
             )

--- a/src/nvidia_rag/ingestor_server/main.py
+++ b/src/nvidia_rag/ingestor_server/main.py
@@ -281,6 +281,21 @@ class NvidiaRAGIngestor:
                 task_id = await INGESTION_TASK_HANDLER.submit_task(
                     _task, task_id=task_id
                 )
+                # Update initial batch progress response to indicate that the ingestion has started
+                batch_progress_response = await self.__build_ingestion_response(
+                    failures=[],
+                    filepaths=[],
+                    state_manager=state_manager,
+                    is_final_batch=False,
+                )
+                ingestion_state = await state_manager.update_batch_progress(
+                    batch_progress_response=batch_progress_response, is_batch_zero=True,
+                )
+                await INGESTION_TASK_HANDLER.set_task_status_and_result(
+                    task_id=state_manager.get_task_id(),
+                    status="PENDING",
+                    result=ingestion_state,
+                )
                 return {
                     "message": "Ingestion started in background",
                     "task_id": task_id,


### PR DESCRIPTION
### Problem
The Status API did not reflect total documents when ingestion was just started (batch 0), causing incomplete progress reporting for background ingestion tasks.

### Solution
Added is_batch_zero parameter to update_batch_progress() method to skip incrementing the batch counter for the initial batch while still tracking document counts correctly.

### Changes
Modified `IngestionStateManager.update_batch_progress()` to accept is_batch_zero flag
Updated background ingestion initialization in `main.py` to pass `is_batch_zero=True`
This ensures accurate progress tracking from the start of ingestion without inflating batch counts.