### PR TITLE
docs: Tooling and doc updates to add the docs to docs.nvidia.com (release-v2.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the [NVIDIA RAG Blueprint](README.md) will be documented 
 
 To upgrade your version, see [Migration Guide](docs/migration_guide.md).
 
+> [!TIP]
+> To navigate this page more easily, click the outline button at the top of the page. (<img src="docs/assets/outline-button.png">)
+
 
 ## Version 2.3.0 (2025-10-14)
 

--- a/docs/accuracy_perf.md
+++ b/docs/accuracy_perf.md
@@ -50,9 +50,10 @@ By default, the ingestion server processes files in parallel batches, distributi
 This parallel processing architecture helps optimize throughput while managing system resources effectively.
 You can use the following environment variables to configure the batch processing behavior.
 
-> [!CAUTION]
-> These variables are not "set it and forget it" variables.
-> These variables require trial and error tuning for optimal performance.
+:::{caution}
+These variables are not "set it and forget it" variables.
+These variables require trial and error tuning for optimal performance.
+:::
 
 
 | Name                 | Default    | Description         | Advantages           | Disadvantages            |
@@ -60,9 +61,9 @@ You can use the following environment variables to configure the batch processin
 | `NV_INGEST_CONCURRENT_BATCHES` | 4 | Controls the number of parallel batch processing streams. | - You can increase this for systems with high memory capacity. <br/> | - Higher values require more system memory. <br/> - Requires careful tuning based on available system resources. <br/> |
 | `NV_INGEST_FILES_PER_BATCH` | 16 | Controls how many files are processed in a single batch during ingestion. | - Adjust this to helps optimize memory usage and processing efficiency. <br/> | - Setting this too high can cause memory pressure. <br/> - Setting this too low can reduce throughput. <br/> |
 
-> [!TIP]
-> For optimal resource utilization, `NV_INGEST_CONCURRENT_BATCHES` times `NV_INGEST_FILES_PER_BATCH` should approximately equal `MAX_INGEST_PROCESS_WORKERS`.
-
+:::{tip}
+For optimal resource utilization, `NV_INGEST_CONCURRENT_BATCHES` times `NV_INGEST_FILES_PER_BATCH` should approximately equal `MAX_INGEST_PROCESS_WORKERS`.
+:::
 
 
 ## Related Topics

--- a/docs/api-ingestor.md
+++ b/docs/api-ingestor.md
@@ -1,0 +1,22 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+# API - Ingestor Server Schema
+
+
+This documentation contains the OpenAPI reference for the ingestor server.
+
+:::{tip}
+To view this documentation on docs.nvidia.com, browse to [https://docs.nvidia.com/rag/latest/api-ingestor](https://docs.nvidia.com/rag/latest/api-ingestor).
+:::
+
+
+:::{swagger-plugin} ../docs/api_reference/openapi_schema_ingestor_server.json
+:::
+
+
+## Related Topics
+
+- [API - RAG Server Schema](api-rag.md)
+- [NVIDIA RAG Blueprint Documentation](index.md)

--- a/docs/api-rag.md
+++ b/docs/api-rag.md
@@ -1,0 +1,22 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+# API - RAG Server Schema
+
+
+This documentation contains the OpenAPI reference for the RAG server.
+
+:::{tip}
+To view this documentation on docs.nvidia.com, browse to [https://docs.nvidia.com/rag/latest/api-rag](https://docs.nvidia.com/rag/latest/api-rag).
+:::
+
+
+:::{swagger-plugin} ../docs/api_reference/openapi_schema_rag_server.json
+:::
+
+
+## Related Topics
+
+- [API - Ingestor Server Schema](api-ingestor.md)
+- [NVIDIA RAG Blueprint Documentation](index.md)

--- a/docs/audio_ingestion.md
+++ b/docs/audio_ingestion.md
@@ -4,9 +4,9 @@
 -->
 # Enable Audio Ingestion Support for NVIDIA RAG Blueprint
 
-Enabling audio ingestion support allows the [NVIDIA RAG Blueprint](readme.md) system to process and transcribe audio files (.mp3 and .wav) during document ingestion. This enables better search and retrieval capabilities for audio content in your documents.
+Enabling audio ingestion support allows the [NVIDIA RAG Blueprint](./readme.md) system to process and transcribe audio files (.mp3 and .wav) during document ingestion. This enables better search and retrieval capabilities for audio content in your documents.
 
-After you have [deployed the blueprint](readme.md#deploy), to enable audio ingestion support, follow these steps:
+After you have [deployed the blueprint](readme.md#deployment-options-for-rag-blueprint), to enable audio ingestion support, follow these steps:
 
 ## Using on-prem audio transcription model
 
@@ -40,8 +40,9 @@ After you have [deployed the blueprint](readme.md#deploy), to enable audio inges
    await upload_documents(collection_name="audio_data")
    ```
 
-> [!Note]
-> The audio transcription service requires GPU resources. Make sure you have sufficient GPU resources available before enabling this feature.
+:::{note}
+The audio transcription service requires GPU resources. Make sure you have sufficient GPU resources available before enabling this feature.
+:::
 
 ### Customizing GPU Usage for Audio Service (Optional)
 
@@ -65,8 +66,9 @@ deploy:
           capabilities: [gpu]
 ```
 
-> [!Note]
-> Ensure the specified GPU is available and has sufficient memory for the audio transcription model. The Riva ASR model typically requires at least 8GB of GPU memory.
+:::{note}
+Ensure the specified GPU is available and has sufficient memory for the audio transcription model. The Riva ASR model typically requires at least 8GB of GPU memory.
+:::
 
 ### Helm Flow
 
@@ -115,8 +117,9 @@ If you're using Helm for deployment, follow these steps to enable audio ingestio
       nv-ingest-riva-nim                  ClusterIP   10.103.184.78    <none>        9000/TCP,50051/TCP   4m27s
    ```
 
-> [!Important]
-> When using Helm deployment, the Riva NIM service requires an additional H100 or B200 GPU making the total GPU requirement to 9xH100 without MIG slicing.
+:::{important}
+When using Helm deployment, the Riva NIM service requires an additional H100 or B200 GPU making the total GPU requirement to 9xH100 without MIG slicing.
+:::
 
 ## Audio Segmentation:
 

--- a/docs/change-model.md
+++ b/docs/change-model.md
@@ -6,11 +6,9 @@
 
 You can change the LLM or embedding models for the [NVIDIA RAG Blueprint](readme.md) by using the following procedures.
 
-  - [Change the LLM Model](#change-the-llm-model)
-  - [Change the Embedding Model](#change-the-embedding-model)
-  - [On Premises Microservices](#on-premises-microservices)
-
-
+:::{tip}
+To navigate this page more easily, click the outline button at the top of the page. ![outline-button](assets/outline-button.png)
+:::
 
 ## For NVIDIA-Hosted Microservices
 
@@ -31,8 +29,9 @@ To get a list of valid model names, use one of the following methods:
   View the sample Python code and get the model name from the `model` argument to the `client.chat.completions.create` method.
 
 
-[!TIP]
+:::{tip}
 Follow steps in [For Helm Deployments](#for-helm-deployments) to change the inference model for Helm charts.
+:::
 
 
 ### Change the Embedding Model
@@ -59,7 +58,9 @@ To get a list of valid model names, use one of the following methods:
   Use the `get_available_models()` method to on an instance of an `NVIDIAEmbeddings` object to list the models.
   Refer to the package web page for sample code to list the models.
 
-[!TIP] Always use same embedding model or model having same tokinizers for both ingestion and retrieval to yield good accuracy.
+:::{tip}
+Always use same embedding model or model having same tokinizers for both ingestion and retrieval to yield good accuracy.
+:::
 
 
 
@@ -99,7 +100,7 @@ You can specify the model for NVIDIA NIM containers to use in the [nims.yaml](..
    export APP_EMBEDDINGS_MODELNAME=<>
    ```
 
-3. Follow the steps specified [here](deploy-docker-self-hosted.md#start-services-using-on-prem-models) to relaunch the containers with the updated models. Make sure to specify the correct model names using appropriate environment variables as shown in the earlier step.
+3. Follow the steps specified [here](deploy-docker-self-hosted.md#start-services-using-self-hosted-on-premises-models) to relaunch the containers with the updated models. Make sure to specify the correct model names using appropriate environment variables as shown in the earlier step.
 
 
 

--- a/docs/change-vectordb.md
+++ b/docs/change-vectordb.md
@@ -7,11 +7,11 @@
 The [NVIDIA RAG Blueprint](readme.md) supports multiple vector database backends including [Milvus](https://milvus.io/docs) and [Elasticsearch](https://www.elastic.co/elasticsearch/vector-database).
 Elasticsearch provides robust search capabilities and can be used as an alternative to Milvus for storing and retrieving document embeddings.
 
-After you have [deployed the blueprint](readme.md#Deployment-Options-for-RAG-Blueprint),
+After you have [deployed the blueprint](readme.md#deployment-options-for-rag-blueprint),
 use this documentation to configure Elasticsearch as your vector database.
 
-> [!TIP]
-> To navigate this page more easily, click the outline button at the top of the page. (<img src="assets/outline-button.png">)
+:::{tip}
+To navigate this page more easily, click the outline button at the top of the page. ![outline-button](assets/outline-button.png)
 
 
 ## Prerequisites and Important Considerations Before You Start
@@ -29,8 +29,9 @@ The following are some important notes to keep in mind before you switch from Mi
     sudo chown -R 1000:1000 deploy/compose/volumes/elasticsearch/
     ```
 
-    > [!NOTE]
-    > If the Elasticsearch container fails to start due to permission issues, you may optionally use `sudo chmod -R 777 deploy/compose/volumes/elasticsearch/` for broader access
+   :::{note}
+   If the Elasticsearch container fails to start due to permission issues, you may optionally use `sudo chmod -R 777 deploy/compose/volumes/elasticsearch/` for broader access
+   :::
 
 
 ## Docker Compose Configuration for Elasticsearch Vector Database
@@ -65,8 +66,9 @@ Use the following steps to configure Elasticsearch as your vector database in Do
 
 If you're using Helm for deployment, use the following steps to configure Elasticsearch as your vector database.
 
-> [!NOTE]
-> **Performance Consideration**: Slow VDB upload is observed in Helm deployments for Elasticsearch (ES). For more details, refer to the [troubleshooting documentation](./troubleshooting.md).
+:::{note}
+**Performance Consideration**: Slow VDB upload is observed in Helm deployments for Elasticsearch (ES). For more details, refer to the [troubleshooting documentation](./troubleshooting.md).
+:::
 
 1. Configure Elasticsearch as the vector database in [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml).
 
@@ -127,15 +129,17 @@ You should see a response that indicates the cluster status is green or yellow, 
 You can create your own custom vector database operators by implementing the `VDBRag` base class.
 This enables you to integrate with any vector database that isn't already supported.
 
-> [!CAUTION]
-> This section is for advanced developers who need to integrate custom vector databases beyond the supported database options.
+:::{caution}
+This section is for advanced developers who need to integrate custom vector databases beyond the supported database options.
+:::
 
 For a complete example, refer to [Custom VDB Operator Notebook](../notebooks/building_rag_vdb_operator.ipynb).
 
-> [!TIP]
-> Choose your integration path:
-> - Start with Library Mode for fastest iteration during development (recommended for most users).
-> - Advanced users who are comfortable with deployments can start directly with Server Mode. See: [Integrate Into NVIDIA RAG (Server Mode)](#integrate-custom-vector-database-into-nvidia-rag-servers-docker-mode).
+:::{tip}
+Choose your integration path:
+- Start with Library Mode for fastest iteration during development (recommended for most users).
+- Advanced users who are comfortable with deployments can start directly with Server Mode. See: [Integrate Into NVIDIA RAG (Server Mode)](#integrate-custom-vector-database-into-nvidia-rag-servers-docker-mode).
+:::
 
 
 ## Integrate Custom VDB in Library Mode (Developer-Friendly Approach)
@@ -341,10 +345,11 @@ That’s it—after these steps, both the RAG server and the Ingestor will use y
 
 ## Integrate Custom Vector Database Into NVIDIA RAG Servers (Helm/Kubernetes Mode)
 
-> [!WARNING]
-> **Advanced Developer Guide - Production Use Only**
->
-> This section is for **advanced developers** with Kubernetes and Helm experience. Recommended for production environments only. For development and testing, use the [Docker Compose approach](#integrate-custom-vector-database-into-nvidia-rag-servers-docker-mode) instead.
+:::{warning}
+**Advanced Developer Guide - Production Use Only**
+
+This section is for **advanced developers** with Kubernetes and Helm experience. Recommended for production environments only. For development and testing, use the [Docker Compose approach](#integrate-custom-vector-database-into-nvidia-rag-servers-docker-mode) instead.
+:::
 
 Before proceeding with Helm deployment, ensure you have completed the implementation steps mentioned above, including:
 
@@ -374,8 +379,9 @@ Once your custom vector database implementation is complete, you need to build c
        image: your-registry/your-ingestor-server:your-tag
    ```
 
-   > [!TIP]
-   > Use a public registry for easier deployment and accessibility.
+   :::{tip}
+   Use a public registry for easier deployment and accessibility.
+   :::
 
 2. **Build Ingestor server and RAG server image:**
    ```bash
@@ -449,8 +455,9 @@ Update your [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml) fil
      version: 1.0.0
    ```
 
-   > [!NOTE]
-   > Replace `your-custom-vdb`, `https://your-helm-repo.com/charts`, and `1.0.0` with your actual chart name, repository URL, and version.
+   :::{note}
+   Replace `your-custom-vdb`, `https://your-helm-repo.com/charts`, and `1.0.0` with your actual chart name, repository URL, and version.
+   :::
 
 3. **Add Helm repository and update dependencies:**
    ```bash
@@ -545,8 +552,9 @@ If you encounter issues during deployment:
 
 You can integrate your own vector database with NVIDIA RAG by implementing only the retrieval functionality while managing ingestion separately. This approach allows you to use existing RAG server, [RAG UI](user-interface.md), and ingestor server components with your custom vector database backend.
 
-> [!NOTE]
-> This approach is ideal when you have an existing vector database with pre-indexed documents and want to leverage NVIDIA RAG's retrieval and generation capabilities without implementing full ingestion workflows into Nvidia RAG Blueprint.
+:::{note}
+This approach is ideal when you have an existing vector database with pre-indexed documents and want to leverage NVIDIA RAG's retrieval and generation capabilities without implementing full ingestion workflows into Nvidia RAG Blueprint.
+:::
 
 ## Implementation Requirements
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+import os
+import sys
+
+project = " NVIDIA-RAG-blueprint"
+copyright = "2025, NVIDIA Corporation"
+author = "NVIDIA Corporation"
+release = "2.3.0"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "myst_parser",  # For our markdown docs
+    "sphinx.ext.viewcode",  # For adding a link to view source code in docs
+    "sphinx.ext.doctest",  # Allows testing in docstrings
+    "sphinx.ext.napoleon",  # For google style docstrings
+    "sphinx_copybutton",  # For copy button in code blocks
+    "swagger_plugin_for_sphinx", # For parsing and presenting OpenAPI specs
+]
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# -- Options for MyST Parser (Markdown) --------------------------------------
+# MyST Parser settings
+myst_enable_extensions = [
+    "dollarmath",  # Enables dollar math for inline math
+    "amsmath",  # Enables LaTeX math for display mode
+    "colon_fence",  # Enables code blocks using ::: delimiters instead of ```
+    "deflist",  # Supports definition lists with term: definition format
+    "fieldlist",  # Enables field lists for metadata like :author: Name
+    "tasklist",  # Adds support for GitHub-style task lists with [ ] and [x]
+]
+myst_heading_anchors = 5  # Generates anchor links for headings up to level 5
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "nvidia_sphinx_theme"
+html_theme_options = {
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/NVIDIA-AI-Blueprints/rag",
+            "icon": "fa-brands fa-github",
+        }
+    ],
+    "switcher": {
+        "json_url": "../versions1.json",
+        "version_match": release,
+    },
+    "extra_head": {
+        """
+    <script src="https://assets.adobedtm.com/5d4962a43b79/c1061d2c5e7b/launch-191c2462b890.min.js" ></script>
+    """
+    },
+    "extra_footer": {
+        """
+    <script type="text/javascript">if (typeof _satellite !== "undefined") {_satellite.pageBottom();}</script>
+    """
+    },
+}
+
+# Add any paths that contain custom static files (such as style sheets) here,
+html_css_files = ["swagger-nvidia.css"]
+
+# These folders are copied to the documentation's HTML output
+html_static_path = ['css']
+
+# Include these files in the root of the built documentation
+html_extra_path = ["project.json", "versions1.json"]

--- a/docs/css/swagger-nvidia.css
+++ b/docs/css/swagger-nvidia.css
@@ -1,0 +1,4 @@
+.swagger-ui pre.version {
+  background-color: unset;
+  border: unset;
+}

--- a/docs/custom-metadata.md
+++ b/docs/custom-metadata.md
@@ -2,7 +2,6 @@
   SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
   SPDX-License-Identifier: Apache-2.0
 -->
-
 # Advanced Metadata Filtering with Natural Language Generation
 
 The [NVIDIA RAG Blueprint](readme.md) features **advanced metadata filtering with natural language generation**, enabling you to:
@@ -130,7 +129,9 @@ This notebook demonstrates:
 - **🎯 Milvus**: Designed for simplicity with automated natural language filter generation, perfect for users who want straightforward metadata filtering
 - **🚀 Elasticsearch**: Provides full access to enterprise-grade search capabilities, ideal for advanced users who need complex querying, analytics, and fine-grained control
 
-**📝 Note**: The UI supports basic arithmetic filter operators to showcase functionality, while the RAG-Server API provides full support for all mentioned operators and advanced features.
+:::{note}
+The UI supports basic arithmetic filter operators to showcase functionality, while the RAG-Server API provides full support for all mentioned operators and advanced features.
+:::
 
 ## Natural Language Filter Generation
 
@@ -224,7 +225,9 @@ The system gracefully handles filter generation failures:
 - **Unique**: Each field name must be unique within the schema
 - **Case-sensitive**: Field names are case-sensitive
 
-**Note**: The `filename` field is automatically added to all collections if you don't define it in your schema. You can also define your own `filename` field in your schema, and the system will use your definition instead of the automatic one.
+:::{note}
+The `filename` field is automatically added to all collections if you don't define it in your schema. You can also define your own `filename` field in your schema, and the system will use your definition instead of the automatic one.
+:::
 
 #### Field Properties
 - **`name`**: Field identifier (required)
@@ -318,7 +321,9 @@ The system validates metadata during ingestion:
 - **Unknown fields**: Files with metadata fields not defined in the schema will fail validation
 - **Error handling**: Invalid metadata causes document rejection with detailed errors
 
-**Note**: The system uses strict validation. Any metadata fields not defined in the schema will cause the entire file to fail ingestion.
+:::{note}
+The system uses strict validation. Any metadata fields not defined in the schema will cause the entire file to fail ingestion.
+:::
 
 ## Filter Expression Syntax
 
@@ -329,7 +334,9 @@ Filter expressions use the format: `content_metadata["field_name"] operator valu
 **Milvus Filter Syntax Documentation:**
 See the [Milvus Filtering Explained](https://milvus.io/docs/boolean.md#Filtering-Explained) guide for full details.
 
-**💡 Note:** This document contains extensive examples throughout - from quick start examples, natural language filter generation, to complex expressions and API usage examples.
+:::{note}
+This document contains extensive examples throughout - from quick start examples, natural language filter generation, to complex expressions and API usage examples.
+:::
 
 
 ### Supported Operators by Type
@@ -422,7 +429,9 @@ filter_expr = [
 ]
 ```
 
-**Note**: Elasticsearch filters use the `metadata.content_metadata.field_name` format and support standard Elasticsearch query types like `term`, `range`, `wildcard`, `terms`, etc.
+:::{note}
+Elasticsearch filters use the `metadata.content_metadata.field_name` format and support standard Elasticsearch query types like `term`, `range`, `wildcard`, `terms`, etc.
+:::
 
 **Advanced Elasticsearch Support**: All ES queries are supported. Advanced developers who are familiar with Elasticsearch can refer to the [official Elasticsearch query and filter documentation](https://www.elastic.co/docs/explore-analyze/query-filter) and write any query or filter anything they need. This advanced functionality is intended for experienced Elasticsearch users.
 
@@ -507,32 +516,36 @@ export APP_FILTEREXPRESSIONGENERATOR_SERVERURL=""
 
 #### Search with Filter Generation
 
-```http
-POST /v1/search
-Content-Type: application/json
-
-{
-    "query": "Show me AI documents with rating above 4.0",
-    "collection_names": ["research_papers"],
-    "enable_filter_generator": true,
-    "reranker_top_k": 10,
-    "vdb_top_k": 100
-}
+```bash
+curl -X "POST" "http://$${RAG_HOSTNAME}/v1/search" \
+    -H 'accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -d '
+    {
+        "query": "Show me AI documents with rating above 4.0",
+        "collection_names": ["research_papers"],
+        "enable_filter_generator": true,
+        "reranker_top_k": 10,
+        "vdb_top_k": 100
+    }'
 ```
 
 #### Generate with Filter Generation
 
-```http
-POST /v1/generate
-Content-Type: application/json
-
-{
-    "messages": [{"role": "user", "content": "What are the latest engineering updates?"}],
-    "use_knowledge_base": true,
-    "collection_names": ["research_papers"],
-    "enable_filter_generator": true
-}
+```bash
+curl -X "POST" "http://$${RAG_HOSTNAME}/v1/generate" \
+    -H 'accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -d '
+    {
+        "messages": [{"role": "user", "content": "What are the latest engineering updates?"}],
+        "use_knowledge_base": true,
+        "collection_names": ["research_papers"],
+        "enable_filter_generator": true
+    }'
 ```
+
+
 
 ## Summary
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -6,11 +6,13 @@
 
 This guide provides comprehensive debugging guidance for the [NVIDIA RAG Blueprint](readme.md), helping you verify that your deployment is working correctly and troubleshoot issues when they arise.
 
-[!NOTE]: This guide is mostly intended for developers who are working with docker setup.
+:::{note}
+This guide is mostly intended for developers who are working with docker setup.
+:::
 
 ## How to Verify Your RAG System is Running Correctly
 
-After you have [deployed the blueprint](readme.md#deploy), you need to verify that all components are healthy and functioning properly.
+After you have [deployed the blueprint](readme.md#deployment-options-for-rag-blueprint), you need to verify that all components are healthy and functioning properly.
 
 ### Get detailed health status of all dependencies
 
@@ -316,4 +318,4 @@ df -h
 
 - [Troubleshooting](troubleshooting.md)
 - [Best Practices for Common Settings](accuracy_perf.md).
-- [Changelog](../CHANGELOG.md)
+- [Changelog](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/CHANGELOG.md)

--- a/docs/deploy-docker-nvidia-hosted.md
+++ b/docs/deploy-docker-nvidia-hosted.md
@@ -7,11 +7,13 @@
 Use this documentation to deploy the [NVIDIA RAG Blueprint](readme.md) with Docker Compose for a single node deployment, and using NVIDIA-hosted models for testing and experimenting.
 For other deployment options, refer to [Deployment Options](readme.md#deployment-options-for-rag-blueprint).
 
-> [!TIP]
-> If you want to run the RAG Blueprint with [NVIDIA AI Workbench](https://docs.nvidia.com/ai-workbench/user-guide/latest/overview/introduction.html), use [Quickstart for NVIDIA AI Workbench](../deploy/workbench/README.md).
+:::{tip}
+If you want to run the RAG Blueprint with [NVIDIA AI Workbench](https://docs.nvidia.com/ai-workbench/user-guide/latest/overview/introduction.html), use [Quickstart for NVIDIA AI Workbench](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/deploy/workbench/README.md).
+:::
 
-> [!NOTE]
-> When using NVIDIA-hosted endpoints, you might encounter rate limiting with larger file ingestions (>10 files). For details, see [Troubleshoot](troubleshooting.md).
+:::{note}
+When using NVIDIA-hosted endpoints, you might encounter rate limiting with larger file ingestions (>10 files). For details, see [Troubleshoot](troubleshooting.md).
+:::
 
 
 

--- a/docs/deploy-docker-self-hosted.md
+++ b/docs/deploy-docker-self-hosted.md
@@ -8,8 +8,9 @@ Use the following documentation to get started quickly with the [NVIDIA RAG Blue
 In this walkthrough you deploy the NVIDIA RAG Blueprint with Docker Compose for a single node deployment, and using self-hosted on-premises models.
 For other deployment options, refer to [Deployment Options](readme.md#deployment-options-for-rag-blueprint).
 
-> [!TIP]
-> If you want to run the RAG Blueprint with [NVIDIA AI Workbench](https://docs.nvidia.com/ai-workbench/user-guide/latest/overview/introduction.html), use [Quickstart for NVIDIA AI Workbench](../deploy/workbench/README.md).
+:::{tip}
+If you want to run the RAG Blueprint with [NVIDIA AI Workbench](https://docs.nvidia.com/ai-workbench/user-guide/latest/overview/introduction.html), use [Quickstart for NVIDIA AI Workbench](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/deploy/workbench/README.md).
+:::
 
 
 ## Prerequisites
@@ -90,8 +91,9 @@ Use the following procedure to start all containers needed for this blueprint.
 
 6. Start all required NIMs by running the following code.
 
-    > [!WARNING]
-    > Do not attempt this step unless you have completed the previous steps.
+   :::{warning}
+   Do not attempt this step unless you have completed the previous steps.
+   :::
 
    ```bash
    USERID=$(id -u) docker compose -f deploy/compose/nims.yaml up -d
@@ -99,8 +101,9 @@ Use the following procedure to start all containers needed for this blueprint.
 
    The NIM LLM service can take 30 mins to start for the first time as the model is downloaded and cached. Subsequent deployments can take 2-5 minutes, depending on the GPU profile.
 
-    > [!TIP]
-    > The models are downloaded and cached in the path specified by `MODEL_DIRECTORY`.
+   :::{tip}
+   The models are downloaded and cached in the path specified by `MODEL_DIRECTORY`.
+   :::
 
 
 7. Check the status of the deployment by running the following code. Wait until all services are up and the `nemoretriever-ranking-ms`, `nemoretriever-embedding-ms` and `nim-llm-ms`  NIMs are in healthy state before proceeding further.

--- a/docs/deploy-helm.md
+++ b/docs/deploy-helm.md
@@ -124,12 +124,13 @@ To verify a deployment, use the following procedure.
     rag-zipkin-5dc8d6d977-nqvvc                                 1/1     Running   0             23m
     ```
 
-    > [!Note]
-    > It takes approximately 5 minutes for all pods to come up. You can check Kuberenetes events by running the following code.
-    >
-    > ```sh
-    > kubectl get events -n rag
-    > ```
+   :::{note}
+   It takes approximately 5 minutes for all pods to come up. You can check Kubernetes events by running the following code. 
+   
+   ```sh
+   kubectl get events -n rag
+   ```
+   :::
 
 2.  List services by running the following code.
 
@@ -221,9 +222,10 @@ helm uninstall rag -n rag
 
 For troubleshooting issues with Helm deployment, refer to [Troubleshooting](troubleshooting.md).
 
-> [!NOTE]
-> If the `rag-nim-llm-0` is in a `CrashLoopBackOff` after deployment, then set the model profile explicitly to avoid any errors with NIM LLM pod deployment.
-> To set NIM LLM profile according to the GPU type and count, refer to [NIM Model Profile Configuration](model-profiles.md).
+:::{note}
+If the `rag-nim-llm-0` is in a `CrashLoopBackOff` after deployment, then set the model profile explicitly to avoid any errors with NIM LLM pod deployment. 
+To set NIM LLM profile according to the GPU type and count, refer to [NIM Model Profile Configuration](model-profiles.md).
+:::
 
 
 

--- a/docs/deploy-nim-operator.md
+++ b/docs/deploy-nim-operator.md
@@ -80,7 +80,9 @@ For other deployment options, refer to [Deployment Options](readme.md#deployment
 
    - **GPU Sharing with Dynamic Resource Allocation(DRA)**
 
-      > [!TIP] With DRA Setup, All NIM Service can run on 3 GPUs with atleast 80GB memory, it could be A100 or H100 or B200
+      :::{tip}
+      With DRA Setup, All NIM Service can run on 3 GPUs with atleast 80GB memory, it could be A100 or H100 or B200
+      :::
 
       - Prerequisite: [NVIDIA DRA Driver](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/25.3.4/dra-intro-install.html)
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,0 +1,43 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+:orphan:
+# Documentation Development
+
+- [Documentation Development](#documentation-development)
+  - [Build the Documentation](#build-the-documentation)
+  - [Live Building](#live-building)
+
+## Build the Documentation
+
+The following sections describe how to set up and build the documentation.
+
+Switch to the documentation source folder and generate HTML output.
+
+```sh
+uv run --group docs sphinx-build . _build/html
+```
+
+* The resulting HTML files are generated in a `_build/html` folder that is created under the project `docs/` folder.
+* The generated python API docs are placed in `apidocs` under the `docs/` folder.
+
+## Live Building
+
+When writing documentation, it can be helpful to serve the documentation and have it update live while you edit.
+
+To do so, run:
+
+```sh
+uv run --group docs sphinx-autobuild . _build/html --port 12345 --host 0.0.0.0
+```
+
+Open a web browser and go to `http://${HOST_WHERE_SPHINX_COMMAND_RUN}:12345` to view the output.
+
+## Documentation Version
+
+The three files below control the version switcher. Before you attempt to publish a new version of the documentation, update these files to match the latest version numbers.
+
+* docs/versions1.json
+* docs/project.json
+* docs/conf.py

--- a/docs/hybrid_search.md
+++ b/docs/hybrid_search.md
@@ -6,7 +6,7 @@
 
 You can enable hybrid search for [NVIDIA RAG Blueprint](readme.md). Hybrid search enables higher accuracy for documents having more domain specific technical jargons. It combines sparse and dense representations to leverage the strengths of both retrieval methods—sparse models (e.g., BM25) excel at keyword matching, while dense embeddings (e.g., vector-based search) capture semantic meaning. This allows hybrid search to retrieve relevant documents even when technical jargon or synonyms are used.
 
-After you have [deployed the blueprint](readme.md#deploy), to enable hybrid search support for Milvus Vector Database, developers can follow below steps:
+After you have [deployed the blueprint](readme.md#deployment-options-for-rag-blueprint), to enable hybrid search support for Milvus Vector Database, developers can follow below steps:
 
 # Steps
 
@@ -48,5 +48,6 @@ helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvidia/blueprint/c
   -f deploy/helm/nvidia-blueprint-rag/values.yaml
 ```
 
-**📝 Note:**
+:::{note}
 Preexisting collections in Milvus created using search type `dense` won't work, when the search type is changed to `hybrid`. If you are switching the search type, ensure you are creating new collection and re-uploading documents before doing retrieval.
+:::

--- a/docs/image_captioning.md
+++ b/docs/image_captioning.md
@@ -6,16 +6,16 @@
 
 You can enable image captioning support for [NVIDIA RAG Blueprint](readme.md). Enabling image captioning will yield higher accuracy for querstions relevant to images in the ingested documents at the cost of higher ingestion latency.
 
-After you have [deployed the blueprint](readme.md#deploy), to enable image captioning support, you have the following options:
-- [Enable image captioning support](#enable-image-captioning-support)
+After you have [deployed the blueprint](readme.md#deployment-options-for-rag-blueprint), to enable image captioning support, you have the following options:
+
   - [Using on-prem VLM model (Recommended)](#using-on-prem-vlm-model-recommended)
   - [Using cloud hosted VLM model](#using-cloud-hosted-vlm-model)
   - [Using Helm chart deployment (On-prem only)](#using-helm-chart-deployment-on-prem-only)
 
-> [!WARNING]
->
-> B200 GPUs are not supported for image captioning support for ingested documents.
-> For this feature, use H100 or A100 GPUs instead.
+:::{warning}
+B200 GPUs are not supported for image captioning support for ingested documents.
+For this feature, use H100 or A100 GPUs instead.
+:::
 
 
 ## Using on-prem VLM model (Recommended)
@@ -59,7 +59,10 @@ After you have [deployed the blueprint](readme.md#deploy), to enable image capti
    docker compose -f deploy/compose/docker-compose-ingestor-server.yaml up -d
    ```
 
-[!TIP]: You can change the model name and model endpoint in case of an externally hosted VLM model by setting these two environment variables and restarting the ingestion services
+:::{tip}
+You can change the model name and model endpoint in case of an externally hosted VLM model by setting these two environment variables and restarting the ingestion services
+:::
+
 ```bash
 export APP_NVINGEST_CAPTIONMODELNAME="<vlm_nim_http_endpoint_url>"
 export APP_NVINGEST_CAPTIONMODELNAME="<model_name>"
@@ -96,8 +99,10 @@ To enable image captioning in Helm-based deployments by using an on-prem VLM mod
    -f deploy/helm/nvidia-blueprint-rag/values.yaml
    ```
 
-> [!Note]
-> Enabling the on-prem VLM model increases the total GPU requirement to 9xH100 GPUs.
+:::{note}
+Enabling the on-prem VLM model increases the total GPU requirement to 9xH100 GPUs.
+:::
 
-> [!Warning]
-> With [image captioning enabled](image_captioning.md), uploaded files will fail to get ingested, if they do not contain any graphs, charts, tables or plots. This is currently a known limitation.
+:::{warning}
+With [image captioning enabled](image_captioning.md), uploaded files will fail to get ingested, if they do not contain any graphs, charts, tables or plots. This is currently a known limitation.
+:::

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,157 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+# NVIDIA RAG Blueprint Documentation
+
+
+Welcome to the [NVIDIA RAG Blueprint](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/README.md) documentation. You can learn more here, including how to get started with the RAG Blueprint, how to customize the RAG Blueprint, and how to troubleshoot the RAG Blueprint.
+
+- To view this documentation on docs.nvidia.com, browse to [NVIDIA RAG Blueprint Documentation](https://docs.nvidia.com/rag/latest/).
+- To view this documentation on GitHub, browse to [NVIDIA RAG Blueprint Documentation](readme.md).
+
+
+
+```{toctree}
+   :name: NVIDIA RAG Blueprint
+   :caption: NVIDIA RAG Blueprint
+   :maxdepth: 1
+   :hidden:
+
+   Overview <https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/README.md>
+   Release Notes <https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/CHANGELOG.md>
+   Support Matrix <support-matrix.md>
+```
+
+
+```{toctree}
+   :name: Get Started
+   :caption: Get Started
+   :maxdepth: 1
+   :hidden:
+
+   Get an API Key <api-key.md>
+   Deploy with Docker (Self-Hosted Models) <deploy-docker-self-hosted.md>
+   Web User Interface <user-interface.md>
+   Notebooks <notebooks.md>
+```
+
+
+```{toctree}
+   :name: Deployment Options for RAG Blueprint
+   :caption: Deployment Options for RAG Blueprint
+   :maxdepth: 1
+   :hidden:
+
+   Deploy with Docker (NVIDIA-Hosted Models) <deploy-docker-nvidia-hosted.md>
+   Deploy on Kubernetes with Helm <deploy-helm.md>
+   Deploy on Kubernetes with Helm from the repository <deploy-helm-from-repo.md>
+   Deploy on Kubernetes with Helm and MIG Support <mig-deployment.md>
+   Deploy on Kubernetes with NIM Operator <deploy-nim-operator.md>
+```
+
+
+```{toctree}
+   :name: Common configurations
+   :caption: Common configurations
+   :maxdepth: 1
+   :hidden:
+
+   Best Practices for Common Settings <accuracy_perf.md>
+   Change the LLM or Embedding Model <change-model.md>
+   Customize LLM Parameters at Runtime <llm-params.md>
+   Customize Prompts <prompt-customization.md>
+   Model Profiles for Hardware Configurations <model-profiles.md>
+   Multi-Collection Retrieval <multi-collection-retrieval.md>
+   Multi-Turn Conversation Support <multiturn.md>
+   Query rewriting to improve the accuracy of multi-turn conversations <query_rewriter.md>
+   Reasoning in Nemotron LLM model <enable-nemotron-thinking.md>
+   Self-reflection to improve accuracy <self-reflection.md>
+   Summarization <summarization.md>
+```
+
+
+```{toctree}
+   :name: Data Ingestion & Processing
+   :caption: Data Ingestion & Processing
+   :maxdepth: 1
+   :hidden:
+
+   Audio Ingestion Support <audio_ingestion.md>
+   Custom metadata Support <custom-metadata.md>
+   File System Access to Extraction Results <mount-ingestor-volume.md>
+   Multimodal Embedding Support (Early Access) <vlm-embed.md>
+   NeMo Retriever OCR for Enhanced Text Extraction (Early Access) <nemoretriever-ocr.md>
+   PDF Extraction with Nemoretriever Parse <nemoretriever-parse-extraction.md>
+   Text-Only Ingestion <text_only_ingest.md>
+   Deploy NV-Ingest Standalone <nv-ingest-standalone.md>
+```
+
+
+```{toctree}
+   :name: Vector Database and Retrieval
+   :caption: Vector Database and Retrieval
+   :maxdepth: 1
+   :hidden:
+
+   Change the Vector Database <change-vectordb.md>
+   Hybrid Search <hybrid_search.md>
+   Milvus Configuration <milvus-configuration.md>
+   Query Decomposition <query_decomposition.md>
+```
+
+
+```{toctree}
+   :name: Multimodal and Advanced Generation
+   :caption: Multimodal and Advanced Generation
+   :maxdepth: 1
+   :hidden:
+
+   Image captioning support for ingested documents <image_captioning.md>
+   VLM based inferencing in RAG <vlm.md>
+```
+
+
+```{toctree}
+   :name: Governance
+   :caption: Governance
+   :maxdepth: 1
+   :hidden:
+
+   NeMo Guardrails for input/output <nemo-guardrails.md>
+```
+
+
+```{toctree}
+   :name: Observability and Telemetry
+   :caption: Observability and Telemetry
+   :maxdepth: 1
+   :hidden:
+
+   Observability <observability.md>
+```
+
+
+```{toctree}
+   :name: Troubleshoot RAG Blueprint
+   :caption: Troubleshoot RAG Blueprint
+   :maxdepth: 1
+   :hidden:
+
+   Troubleshoot <troubleshooting.md>
+   RAG Pipeline Debugging Guide <debugging.md>
+   Migrate from a Previous Version <migration_guide.md>
+```
+
+
+```{toctree}
+   :name: Reference
+   :caption: Reference
+   :maxdepth: 1
+   :hidden:
+
+   Use the Python Package <python-client.md>
+   Milvus Collection Schema Requirements <milvus-schema.md>
+   API - Ingestor Server Schema <api-ingestor.md>
+   API - RAG Server Schema <api-rag.md>
+```

--- a/docs/llm-params.md
+++ b/docs/llm-params.md
@@ -6,7 +6,7 @@
 # Customize LLM Parameters at Runtime for NVIDIA RAG Blueprint
 
 The [NVIDIA RAG Blueprint](readme.md) server exposes an OpenAI-compatible API, using which developers can customize different LLM parameters at runtime.
-For full details, see [APIs for RAG Server](./api_reference/openapi_schema_rag_server.json).
+For full details, see [APIs for RAG Server](./api-rag.md).
 
 Use the `/generate` endpoint in the RAG server of a RAG pipeline to generate responses to prompts.
 

--- a/docs/mig-deployment.md
+++ b/docs/mig-deployment.md
@@ -17,9 +17,10 @@ Before you deploy, verify that you have the following:
 
 * A Kubernetes cluster with NVIDIA H100 GPUs
 
-    > [!NOTE]
-    > This section showcases MIG support for `NVIDIA H100 80GB HBM3` GPU. The MIG profiles used in the `mig-config.yaml` are specific to this GPU.
-    > Refer to the [MIG User Guide](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/) for MIG profiles of other GPU types.
+   :::{note}
+   This section showcases MIG support for `NVIDIA H100 80GB HBM3` GPU. The MIG profiles used in the `mig-config.yaml` are specific to this GPU.
+   Refer to the [MIG User Guide](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/) for MIG profiles of other GPU types.
+   :::
 
 1. [Get an API Key](api-key.md).
 
@@ -79,8 +80,9 @@ Edit the MIG configuration file [`mig-config.yaml`](../deploy/helm/mig-slicing/m
 The following example enables a balanced configuration.
 
 
-> [!NOTE]
-> This example uses a balanced slicing strategy:  3 slices of 2g.20gb on GPU 0, 3 slices of 2g.20gb on GPU 1, 3 slices of 2g.20gb on GPU 2 and 1 slice of 7g.80gb on GPU 3.
+:::{note}
+This example uses a balanced slicing strategy:  3 slices of 2g.20gb on GPU 0, 3 slices of 2g.20gb on GPU 1, 3 slices of 2g.20gb on GPU 2 and 1 slice of 7g.80gb on GPU 3.
+:::
 
 ```yaml
 apiVersion: v1
@@ -158,13 +160,15 @@ helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvidia/blueprint/c
   -f mig-slicing/values-mig.yaml
 ```
 
-> [!NOTE]
-> If the `rag-nim-llm-0` is in a `CrashLoopBackOff` after deployment, then set the model profile explicitly to avoid any errros with NIM LLM pod deployment.
-> Refer to [NIM Model Profile Configuration](model-profiles.md) to set NIM LLM profile according to the GPU type and count.
+:::{note}
+If the `rag-nim-llm-0` is in a `CrashLoopBackOff` after deployment, then set the model profile explicitly to avoid any errors with NIM LLM pod deployment.
+Refer to [NIM Model Profile Configuration](model-profiles.md) to set NIM LLM profile according to the GPU type and count.
+:::
 
-> [!NOTE]
-> Due to a known issue with MIG support, currently the ingestion profile has been scaled down while deploying the chart with MIG slicing.
-> This is expected to affect the ingestion performance during bulk ingestion, specifically large bulk ingestion jobs might fail.
+:::{note}
+Due to a known issue with MIG support, currently the ingestion profile has been scaled down while deploying the chart with MIG slicing.
+This is expected to affect the ingestion performance during bulk ingestion, specifically large bulk ingestion jobs might fail.
+:::
 
 
 

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -6,8 +6,8 @@
 
 This documentation contains the information to upgrade [NVIDIA RAG Blueprint](readme.md) from previous versions.
 
-> [!TIP]
-> To navigate this page more easily, click the outline button at the top of the page. (<img src="assets/outline-button.png">)
+:::{tip}
+To navigate this page more easily, click the outline button at the top of the page. [outline-button](assets/outline-button.png)
 
 
 ## Migration Guide: v2.2.0 to v2.3.0
@@ -54,7 +54,7 @@ In RAG 2.1.0, the the behavior of POST /documents API which can be used to uploa
 
 ### API Changes
 
-Updated openapi schemas are available [here](./api_reference/).
+Updated OpenAPI schemas are available [here](api-rag.md) and [here](api-ingestor.md).
 
 ### 2.1 Changed Endpoints and Features
 
@@ -88,7 +88,7 @@ This guide outlines the key changes and steps required for migration.
 
 ### 2. API Changes
 
-Updated openapi schemas are available [here](./api_reference/).
+Updated OpenAPI schemas are available [here](api-rag.md) and [here](api-ingestor.md).
 
 
 #### 2.1 New Endpoints and Features
@@ -137,7 +137,7 @@ Updated openapi schemas are available [here](./api_reference/).
 
 #### Step 1: Deploy Two Separate Containers
 
-Ensure that you run two separate containers for **RAG Server** and **Ingestion Server** by following the appropriate [deployment guide](readme.md#deploy).
+Ensure that you run two separate containers for **RAG Server** and **Ingestion Server** by following the appropriate [deployment guide](readme.md#deployment-options-for-rag-blueprint).
 
 #### Step 2: Update API Calls
 

--- a/docs/milvus-configuration.md
+++ b/docs/milvus-configuration.md
@@ -160,7 +160,9 @@ ingestor-server:
 
 If you require GPU index-building, ensure the Milvus image variant supports GPU (for example, keep a `-gpu` tag where applicable). `rag-server` can be deployed with either CPU or GPU images for inference; search will be served on CPU for collections indexed with GPU when `APP_VECTORSTORE_ENABLEGPUSEARCH` is set to `False`.
 
-Note: When `adapt_for_cpu` is in effect, your search requests must supply an `ef` parameter.
+:::{note}
+When `adapt_for_cpu` is in effect, your search requests must supply an `ef` parameter.
+:::
 
 
 ## (Optional) Customize the Milvus Endpoint
@@ -228,8 +230,9 @@ If you encounter GPU_CAGRA errors that cannot be resolved by when switching to C
    docker compose -f deploy/compose/docker-compose-ingestor-server.yaml up -d
    ```
 
-[!NOTE]
+:::{note}
 This will delete all existing vector data, so ensure you have backups if needed.
+:::
 
 
 

--- a/docs/milvus-schema.md
+++ b/docs/milvus-schema.md
@@ -7,7 +7,9 @@
 
 When you create a collection in Milvus to use with the [NVIDIA RAG Blueprint](readme.md) server, there are specific schema requirements that must be followed to ensure compatibility with the search and generate APIs. This document outlines the required fields and their configurations.
 
-> **Note**: If you are using either LangChain's Milvus integration or NVIDIA's nv-ingest tool for data ingestion, these schema requirements are automatically handled for you. Both tools will create and configure the collection with the correct schema fields. You only need to ensure these requirements when manually creating collections or using custom ingestion methods.
+:::{note}
+If you are using either LangChain's Milvus integration or NVIDIA's nv-ingest tool for data ingestion, these schema requirements are automatically handled for you. Both tools will create and configure the collection with the correct schema fields. You only need to ensure these requirements when manually creating collections or using custom ingestion methods.
+:::
 
 
 

--- a/docs/mount-ingestor-volume.md
+++ b/docs/mount-ingestor-volume.md
@@ -62,7 +62,9 @@ Each `.jsonl` file contains structured extraction metadata including text segmen
 
 ---
 
-**Note**: This is an advanced feature for custom processing workflows. Standard RAG functionality stores results directly in the vector database.
+:::{note}
+This is an advanced feature for custom processing workflows. Standard RAG functionality stores results directly in the vector database.
+:::
 
 ## Helm (Kubernetes)
 

--- a/docs/multiturn.md
+++ b/docs/multiturn.md
@@ -5,7 +5,7 @@
 # Multi-Turn Conversation Support in NVIDIA RAG Blueprint
 
 The [NVIDIA RAG Blueprint](readme.md) server exposes an OpenAI-compatible API, using which developers can provide custom conversation history.
-For full details, see [APIs for RAG Server](./api_reference/openapi_schema_rag_server.json).
+For full details, see [APIs for RAG Server](api-rag.md).
 
 Use the `/generate` endpoint in the RAG server of a RAG pipeline to generate responses to prompts using custom conversation history.
 
@@ -48,4 +48,6 @@ The following example payload includes a `messages` parameter that passes a cust
 }
 ```
 
-[!TIP]: For better accuracy of multi-turn queries, consider [enabling query rewriting](./query_rewriter.md).
+:::{tip}
+For better accuracy of multi-turn queries, consider [enabling query rewriting](./query_rewriter.md).
+:::

--- a/docs/nemo-guardrails.md
+++ b/docs/nemo-guardrails.md
@@ -6,10 +6,10 @@
 
 This guide provides step-by-step instructions to enable NeMo Guardrails for the [NVIDIA RAG Blueprint](readme.md), enabling you to control and safeguard LLM interactions.
 
-> [!WARNING]
->
-> B200 GPUs are not supported for NeMo Guardrails for guardrails at input/output.
-> For this feature, use H100 or A100 GPUs instead.
+:::{warning}
+B200 GPUs are not supported for NeMo Guardrails for guardrails at input/output.
+For this feature, use H100 or A100 GPUs instead.
+:::
 
 
 NeMo Guardrails is a framework that provides safety and security measures for LLM applications. When enabled, it provides:
@@ -60,17 +60,17 @@ To deploy all guardrails services on your own dedicated hardware, use the follow
 
 1. The RAG Server must be running before you start NeMo Guardrails services.
 
-    > [!Note]
-    > For self-hosted deployment, the default NIM service must be up and running. 
-    > If you're unable to run the NIM service locally, 
-    > you can use NVIDIA's cloud-hosted LLM by exporting the NIM endpoint URL.
-    > 
-    > ```bash
-    > # Use NVIDIA-hosted LLM
-    > export NIM_ENDPOINT_URL=https://integrate.api.nvidia.com/v1
-    > # Or provide your own custom NIM endpoint URL
-    > # export NIM_ENDPOINT_URL=<your-custom-nim-endpoint-url>
-    > ```
+   :::{note}
+   For self-hosted deployment, the default NIM service must be up and running. 
+   If you're unable to run the NIM service locally, 
+   you can use NVIDIA's cloud-hosted LLM by exporting the NIM endpoint URL.
+   
+   ```bash
+   # Use NVIDIA-hosted LLM
+   export NIM_ENDPOINT_URL=https://integrate.api.nvidia.com/v1
+   # Or provide your own custom NIM endpoint URL
+   # export NIM_ENDPOINT_URL=<your-custom-nim-endpoint-url>
+   ```
 
 2. Set the environment variable to enable guardrails by running the following code.
 
@@ -114,8 +114,9 @@ To deploy all guardrails services on your own dedicated hardware, use the follow
     export TOPIC_CONTROL_GPU_ID=1   # Choose GPU ID for topic control model
     ```
 
-    > [!Note]
-    > Each model requires a dedicated GPU with at least 48GB of memory. Select GPUs with sufficient available memory.
+   :::{note}
+   Each model requires a dedicated GPU with at least 48GB of memory. Select GPUs with sufficient available memory.
+   :::
 
 8. Start the NeMo Guardrails service by running the following code.
 

--- a/docs/nemoretriever-ocr.md
+++ b/docs/nemoretriever-ocr.md
@@ -8,8 +8,9 @@ You can enable NeMO Retriever OCR for your [NVIDIA RAG Blueprint](readme.md). Ne
 
 For more information about NeMo Retriever OCR, refer to [NeMo Retriever OCR v1 Container](https://build.nvidia.com/nvidia/nemoretriever-ocr-v1).
 
-> [!Note]
-> **Early Access**: Currently, the NeMo Retriever OCR v1 container is in early access preview.
+:::{note}
+**Early Access**: Currently, the NeMo Retriever OCR v1 container is in early access preview.
+:::
 
 
 ## Key Benefits of NeMo Retriever OCR
@@ -40,8 +41,9 @@ For more information about NeMo Retriever OCR, refer to [NeMo Retriever OCR v1 C
    export OCR_MODEL_NAME=scene_text_ensemble
    ```
 
-   > [!Warning]
-   > **Critical Health Check Requirement**: Even when using gRPC protocol (`OCR_INFER_PROTOCOL=grpc`), you must also export the `OCR_HTTP_ENDPOINT` because the health check from nv-ingest uses HTTP.
+   :::{warning}
+   **Critical Health Check Requirement**: Even when using gRPC protocol (`OCR_INFER_PROTOCOL=grpc`), you must also export the `OCR_HTTP_ENDPOINT` because the health check from nv-ingest uses HTTP.
+   :::
 
 3. **Stop Paddle OCR deployment if already running**:
    ```bash
@@ -80,8 +82,9 @@ For more information about NeMo Retriever OCR, refer to [NeMo Retriever OCR v1 C
 
 4. **Test Document Ingestion**: Use the [ingestion API usage notebook](../notebooks/ingestion_api_usage.ipynb) to verify functionality.
 
-> [!Note]
-> **Default Behavior**: Paddle OCR is the default OCR service and runs automatically when you start the NIMs. To use NeMo Retriever OCR instead, you must explicitly start it with the `--profile nemoretriever-ocr` flag.
+:::{note}
+**Default Behavior**: Paddle OCR is the default OCR service and runs automatically when you start the NIMs. To use NeMo Retriever OCR instead, you must explicitly start it with the `--profile nemoretriever-ocr` flag.
+:::
 
 ### Helm Deployment to Enable NeMo Retriever OCR
 

--- a/docs/nemoretriever-parse-extraction.md
+++ b/docs/nemoretriever-parse-extraction.md
@@ -7,10 +7,10 @@
 
 For enhanced PDF extraction capabilities, you can use the Nemoretriever Parse service with the [NVIDIA RAG Blueprint](readme.md). This service provides improved PDF parsing and structure understanding compared to the default PDF extraction method.
 
-> [!WARNING]
->
-> B200 GPUs are not supported for PDF extraction with Nemoretriever Parse.
-> For this feature, use H100 or A100 GPUs instead.
+:::{warning}
+B200 GPUs are not supported for PDF extraction with Nemoretriever Parse.
+For this feature, use H100 or A100 GPUs instead.
+:::
 
 
 
@@ -56,8 +56,9 @@ For enhanced PDF extraction capabilities, you can use the Nemoretriever Parse se
 
 5. You can now ingest PDF files using the [ingestion API usage notebook](../notebooks/ingestion_api_usage.ipynb).
 
-> [!Note]
-> When using NVIDIA hosted endpoints, you may encounter rate limiting with larger file ingestions (>10 files).
+:::{note}
+When using NVIDIA hosted endpoints, you may encounter rate limiting with larger file ingestions (>10 files).
+:::
 
 ## Using Helm
 
@@ -94,5 +95,6 @@ The `APP_NVINGEST_PDFEXTRACTMETHOD` environment variable supports the following 
 - `pdfium`: Uses the default PDFium-based extraction
 - `None`: Uses the default extraction method
 
-> [!Note]
-> The Nemoretriever Parse service requires GPU resources. Make sure you have sufficient GPU resources available before enabling this feature.
+:::{note}
+The Nemoretriever Parse service requires GPU resources. Make sure you have sufficient GPU resources available before enabling this feature.
+:::

--- a/docs/nv-ingest-standalone.md
+++ b/docs/nv-ingest-standalone.md
@@ -25,16 +25,21 @@ When using NV-Ingest in standalone mode, consider the following limitations:
 
 1. Ensure you have Docker and Docker Compose installed. For details, refer to [Get Started](deploy-docker-self-hosted.md).
 2. Have Python 3.12 or later installed
-   > ℹ️ If you're using **Python 3.13**, make sure you've `python3.13-dev` installed.
+
+   :::{tip}
+   If you're using **Python 3.13**, make sure you've `python3.13-dev` installed.
+   :::
+
 3. [Get an API Key](api-key.md).
 4. Install a package manager (either uv or pip):
-```bash
-# Option 1: Install uv (recommended for faster installation)
-pip install uv
 
-# Option 2: Use pip (comes with Python)
-# No additional installation needed
-```
+   ```bash
+   # Option 1: Install uv (recommended for faster installation)
+   pip install uv
+
+   # Option 2: Use pip (comes with Python)
+   # No additional installation needed
+   ```
 
 ## Deployment Steps using Docker
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -38,16 +38,16 @@ Use the following procedure to enable observability with Docker.
         APP_TRACING_ENABLED: "True"
     ```
 
-4. Start the RAG Server by following the instructions in the appropriate [deployment guide](readme.md#deploy).
+4. Start the RAG Server by following the instructions in the appropriate [deployment guide](readme.md#deployment-options-for-rag-blueprint).
 
 
 ## View Traces in Zipkin
 
 After tracing is enabled and the system is running, you can **view the traces** in **Zipkin** by opening:
 
-  <p align="center">
-  <img src="./assets/zipkin_ui.png" width="750">
-  </p>
+```{image} assets/zipkin_ui.png
+:width: 750px
+```
 
 Open the Zipkin UI at: **http://localhost:9411**
 

--- a/docs/project.json
+++ b/docs/project.json
@@ -1,0 +1,1 @@
+{"name": "NVIDIA-RAG-blueprint", "version": "2.3.0"}

--- a/docs/prompt-customization.md
+++ b/docs/prompt-customization.md
@@ -135,7 +135,7 @@ query_rewriter_prompt:
     <custom prompt instructions>
 ```
 
-After the required changes have been made, you can deploy the Helm chart from source by following the steps [here](deploy-helm-from-repo.md#deploy-the-rag-helm-chart-from-the-repository).
+After the required changes have been made, you can deploy the Helm chart from source by following the steps [here](deploy-helm-from-repo.md).
 
 
 ## Example: Access a Prompt in code
@@ -177,5 +177,6 @@ prompts = get_prompts()
 chat_template = prompts.get("chat_template", {}).get("system", "")
 ```
 
-**Tip:**
+:::{tip}
 You will need to rebuild the containers for any changes in source code.
+:::

--- a/docs/python-client.md
+++ b/docs/python-client.md
@@ -5,7 +5,7 @@
 # Use the NVIDIA RAG Blueprint Python Package
 
 Use this documentation to learn about the [NVIDIA RAG Blueprint](readme.md) Python Package. 
-For a notebook that walks you through these code examples, see [NVIDIA RAG Python Package](/notebooks/rag_library_usage.ipynb).
+For a notebook that walks you through these code examples, see [NVIDIA RAG Python Package](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/notebooks/rag_library_usage.ipynb).
 
 
 ## Set logging level
@@ -298,7 +298,7 @@ print(response)
 ## Customize prompts
 
 Import the prompt utility which allows us to access different preset prompts. 
-For information about the preset prompts, see [Default Prompts Overview](docs/prompt-customization.md#default-prompts-overview). 
+For information about the preset prompts, see [Default Prompts Overview](prompt-customization.md#default-prompts-overview). 
 
 ```python
 from nvidia_rag.utils.llm import get_prompts  

--- a/docs/query_decomposition.md
+++ b/docs/query_decomposition.md
@@ -111,9 +111,10 @@ This query requires multiple interconnected steps:
 ## How Query Decomposition Works
 To visualize how query decomposition works, see the diagram below:
 
-![Query Decomposition Flow](assets/query_decomposition.jpeg)
+```{figure} assets/query_decomposition.jpeg
 
-**Figure:** *Query Decomposition Flow — The system breaks down a complex query into subqueries, processes each iteratively, and synthesizes a comprehensive answer.*
+Query Decomposition Flow — The system breaks down a complex query into subqueries, processes each iteratively, and synthesizes a comprehensive answer.
+```
 
 
 ### Core Algorithm
@@ -131,5 +132,6 @@ To visualize how query decomposition works, see the diagram below:
 
 
 
-> [!IMPORTANT]
-> Query decomposition is not available for direct LLM calls (when `use_kb=false`). This feature requires the knowledge base integration to process subqueries and retrieve relevant documents. For direct LLM interactions, queries are processed without decomposition.
+:::{important}
+Query decomposition is not available for direct LLM calls (when `use_kb=false`). This feature requires the knowledge base integration to process subqueries and retrieve relevant documents. For direct LLM interactions, queries are processed without decomposition.
+:::

--- a/docs/query_rewriter.md
+++ b/docs/query_rewriter.md
@@ -6,9 +6,8 @@
 
 You can enable query rewriting for the [NVIDIA RAG Blueprint](readme.md). Query rewriting enables higher accuracy for multiturn queries by making an additional LLM call to decontextualize the incoming question, before sending it to the retrieval pipeline.
 
-After you have [deployed the blueprint](readme.md#deploy), to enable query rewriting support, developers have the following options:
+After you have [deployed the blueprint](readme.md#deployment-options-for-rag-blueprint), to enable query rewriting support, developers have the following options:
 
-- [Enable query rewriting support](#enable-query-rewriting-support)
   - [Using on-prem model (Recommended)](#using-on-prem-model-recommended)
   - [Using cloud hosted model](#using-cloud-hosted-model)
   - [Using Helm Chart (on-prem only)](#using-helm-chart-on-prem-only)
@@ -50,7 +49,10 @@ After you have [deployed the blueprint](readme.md#deploy), to enable query rewri
    docker compose -f deploy/compose/docker-compose-rag-server.yaml up -d
    ```
 
-[!TIP]: You can change the model name and model endpoint in case of an externally hosted LLM model by setting these two environment variables and restarting the rag services
+:::{tip}
+You can change the model name and model endpoint in case of an externally hosted LLM model by setting these two environment variables and restarting the rag services
+:::
+
 ```bash
 export APP_QUERYREWRITER_SERVERURL="<llm_nim_http_endpoint_url>"
 export APP_QUERYREWRITER_MODELNAME="<model_name>"
@@ -61,8 +63,9 @@ export APP_QUERYREWRITER_MODELNAME="<model_name>"
 
 This section describes how to enable Query Rewriting when you deploy by using Helm, using an on-prem deployment of the LLM model.
 
-> [!NOTE]
-> Only on-prem deployment of the LLM is supported. The model must be deployed separately using the NIM LLM Helm chart.
+:::{note}
+Only on-prem deployment of the LLM is supported. The model must be deployed separately using the NIM LLM Helm chart.
+:::
 
 ### 1. Enable Query Rewriter in `rag-server` Helm deployment
 1. Modify the [values.yaml](../deploy/helm/nvidia-blueprint-rag/values.yaml) file, in the `envVars` section, and set the following values.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -2,15 +2,19 @@
   SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
   SPDX-License-Identifier: Apache-2.0
 -->
+:orphan:
 # NVIDIA RAG Blueprint Documentation
 
 
 Welcome to the NVIDIA RAG Blueprint documentation. You can learn more here, including how to get started with the RAG Blueprint, how to customize the RAG Blueprint, and how to troubleshoot the RAG Blueprint.
 
+- To view this documentation on docs.nvidia.com, browse to [NVIDIA RAG Blueprint Documentation](https://docs.nvidia.com/rag/latest/).
+- To view this documentation on GitHub, browse to [NVIDIA RAG Blueprint Documentation](readme.md).
+
 
 ## Release Notes
 
-For the release notes, refer to the [Changelog](../CHANGELOG.md).
+For the release notes, refer to the [Changelog](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/CHANGELOG.md).
 
 
 ## Support Matrix

--- a/docs/self-reflection.md
+++ b/docs/self-reflection.md
@@ -144,8 +144,9 @@ If you don't have sufficient GPU resources for on-premises deployment, you can u
 5. Open the [RAG UI](user-interface.md) and test the reflection capability.
 
 
-[!NOTE]
+:::{note}
 When using NVIDIA-hosted models, you must obtain an API key. See [Get an API Key](api-key.md) for instructions.
+:::
 
 ## Reflection Support via Helm Deployment
 

--- a/docs/summarization.md
+++ b/docs/summarization.md
@@ -12,18 +12,18 @@ When uploading documents to the vector store using the ingestion API (`POST /doc
 
 ### Example: Uploading Documents with Summarization
 
-```http
-POST /v1/documents
-Content-Type: multipart/form-data
-
-- documents: [file1.pdf, file2.docx, ...]
-- data: '{
-    "collection_name": "my_collection",
-    "blocking": false,
-    "split_options": {"chunk_size": 512, "chunk_overlap": 150},
-    "custom_metadata": [],
-    "generate_summary": true
-}'
+```bash
+curl -X "POST" "http://$${RAG_HOSTNAME}/v1/documents" \
+    -H 'accept: multipart/form-data' \
+    -H 'Content-Type: multipart/form-data' \
+    - documents: [file1.pdf, file2.docx, ...] \
+    - data: '{
+        "collection_name": "my_collection",
+        "blocking": false,
+        "split_options": {"chunk_size": 512, "chunk_overlap": 150},
+        "custom_metadata": [],
+        "generate_summary": true
+    }'
 ```
 
 - **generate_summary**: Set to `true` to enable summary generation for each uploaded document. The summary generation always happens asynchronously in the backend after the ingestion is complete. The ingestion status is reported to be completed irrespective of whether summarization has been successfully completed or not.
@@ -59,9 +59,18 @@ GET /v1/summary?collection_name=<collection>&file_name=<filename>&blocking=<bool
 
 ### Example Request
 
-```http
-GET /v1/summary?collection_name=my_collection&file_name=file1.pdf&blocking=true&timeout=60
+```bash
+curl -X "GET" --globoff \ 
+  "http://$${RAG_HOSTNAME}/v1/summary?collection_name=my_collection&file_name=file1.pdf&blocking=true&timeout=60" \
+  -H 'accept: application/json'
 ```
+
+```python
+endpoint = f"http://$${RAG_HOSTNAME}/v1/summary?collection_name=my_collection&file_name=file1.pdf&blocking=true&timeout=60"
+response = requests.get(endpoint).json()
+response
+```
+
 
 #### Python Example with library mode
 

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -6,10 +6,10 @@
 
 This documentation contains the system requirements for the [NVIDIA RAG Blueprint](readme.md).
 
-> [!IMPORTANT]
-> You can deploy the RAG Blueprint with Docker, Helm, or NIM Operator, and target dedicated hardware or a Kubernetes cluster.
-> Some requirements are different depending on your target system and deployment method.
-
+:::{important}
+You can deploy the RAG Blueprint with Docker, Helm, or NIM Operator, and target dedicated hardware or a Kubernetes cluster. 
+Some requirements are different depending on your target system and deployment method. 
+:::
 
 ## Operating System
 
@@ -37,8 +37,9 @@ By default, the RAG Blueprint deploys the NIM microservices locally ([self-hoste
  - 3 x A100 SXM
  - 2 x RTX PRO 6000
 
-> [!TIP] You can also modify the RAG Blueprint to use [NVIDIA-hosted](deploy-docker-nvidia-hosted.md) NIM microservices.
-
+:::{tip}
+You can also modify the RAG Blueprint to use [NVIDIA-hosted](deploy-docker-nvidia-hosted.md) NIM microservices.
+:::
 
 ## Hardware Requirements (Kubernetes)
 
@@ -67,8 +68,9 @@ The following are requirements and recommendations for the individual components
   - NeMo Retriever Graphic Elements v1 [Support Matrix](https://docs.nvidia.com/nim/ingestion/object-detection/latest/support-matrix.html#nemo-retriever-graphic-elements-v1)
   - NeMo Retriever Table Structure v1 [Support Matrix](https://docs.nvidia.com/nim/ingestion/object-detection/latest/support-matrix.html#nemo-retriever-table-structure-v1)
 
-> [!TIP] To switch between Paddle OCR and NeMo Retriever OCR, see [NeMo Retriever OCR](nemoretriever-ocr.md).
-
+:::{tip}
+To switch between Paddle OCR and NeMo Retriever OCR, see [NeMo Retriever OCR](nemoretriever-ocr.md).
+:::
 
 
 ## Related Topics

--- a/docs/text_only_ingest.md
+++ b/docs/text_only_ingest.md
@@ -59,7 +59,7 @@ You can enable text-only ingestion for the [NVIDIA RAG Blueprint](readme.md). Fo
 
 6. After ingestion completes, you can try out the queries relevant to the text in the documents using [retrieval notebook](../notebooks/retriever_api_usage.ipynb).
 
-**📝 Note:**
+:::{note}
 In case you are [interacting with cloud hosted models](deploy-docker-nvidia-hosted.md) and want to enable text only mode, then in step 2, just export these specific environment variables as shown below:
    ```bash
    export APP_EMBEDDINGS_SERVERURL=""
@@ -68,6 +68,7 @@ In case you are [interacting with cloud hosted models](deploy-docker-nvidia-host
    export YOLOX_HTTP_ENDPOINT="https://ai.api.nvidia.com/v1/cv/nvidia/nemoretriever-page-elements-v2"
    export YOLOX_INFER_PROTOCOL="http"
    ```
+:::
 
 # Enable text only ingestion support in Helm
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,12 +7,13 @@
 The following issues might arise when you work with the [NVIDIA RAG Blueprint](readme.md).
 
 
-> [!NOTE]
-> For the full list of known issues, see [Known Issues](../CHANGELOG.md#all-known-issues)
+:::{note}
+For the full list of known issues, see [Known Issues](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/CHANGELOG.md#all-known-issues)
+:::
 
-
-> [!TIP]
-> To navigate this page more easily, click the outline button at the top of the page. (<img src="assets/outline-button.png">)
+:::{tip}
+To navigate this page more easily, click the outline button at the top of the page. ![outline-button](assets/outline-button.png)
+:::
 
 
 
@@ -33,10 +34,9 @@ export NV_INGEST_MAX_UTIL=8
 docker compose -f deploy/compose/docker-compose-ingestor-server.yaml up -d 
 ```
 
-> [!NOTE]
-> This can reduce the page-per-second performance for the ingestion. For maximum performance, [on-prem deployment](deploy-docker-self-hosted.md) is recommended.
-
-
+:::{note}
+This can reduce the page-per-second performance for the ingestion. For maximum performance, [on-prem deployment](deploy-docker-self-hosted.md) is recommended.
+:::
 
 ## Confidence threshold filtering issues
 
@@ -166,8 +166,9 @@ These issues can be addressed by adding the following instruction to the `rag_ch
 Handling Missing Information: If the context does not contain the answer, you must state directly that you do not have information on the specific subject of the user's query. For example, if the query is about the "capital of France", your response should be "I did not find information about capital of France." Do not add any other words, apologies, or explanations.
 ```
 
-> [!IMPORTANT]
-> Adding this information may impact response accuracy, especially when partial information is available instead of complete information in the retrieved context. The system may become more conservative in providing answers, potentially refusing to respond even when some relevant information exists in the context.
+:::{important}
+Adding this information may impact response accuracy, especially when partial information is available instead of complete information in the retrieved context. The system may become more conservative in providing answers, potentially refusing to respond even when some relevant information exists in the context.
+:::
 
 
 
@@ -217,7 +218,7 @@ kube-prometheus-stack:
 
 ## Out of memory issues while deploying nim-llm service
 
-If you run into `torch.OutOfMemoryError: CUDA out of memory.` while deploying the model, this is most likely due to wrong model profile being auto selected during deployment. Refer to steps in the appropriate [deployment guide](readme.md#deploy) and set the correct profile using `NIM_MODEL_PROFILE` variable.
+If you run into `torch.OutOfMemoryError: CUDA out of memory.` while deploying the model, this is most likely due to wrong model profile being auto selected during deployment. Refer to steps in the appropriate [deployment guide](readme.md#deployment-options-for-rag-blueprint) and set the correct profile using `NIM_MODEL_PROFILE` variable.
 
 
 
@@ -262,4 +263,4 @@ Please contact your NVIDIA representative to get more credits.
 ## Related Topics
 
 - [Debugging](debugging.md)
-- [Changelog](../CHANGELOG.md)
+- [Changelog](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/CHANGELOG.md)

--- a/docs/user-interface.md
+++ b/docs/user-interface.md
@@ -4,41 +4,42 @@
 -->
 # User Interface for NVIDIA RAG Blueprint
 
-After you [deploy the NVIDIA RAG Blueprint](readme.md#deploy), 
+After you [deploy the NVIDIA RAG Blueprint](readme.md#deployment-options-for-rag-blueprint), 
 use the following procedure to start testing and experimenting in the NVIDIA RAG Blueprint User Interface (RAG UI).
 
-> [!Important]
-> The RAG UI is provided as a sample and for experimentation only. It is not intended for your production environment. 
-
+:::{important}
+The RAG UI is provided as a sample and for experimentation only. It is not intended for your production environment. 
+:::
 
 1. Open a web browser and navigate to `http://localhost:8090` for a local deployment or `http://<workstation-ip-address>:8090` for a remote deployment. 
 
    The RAG UI appears.
 
-    <p align="left">
-        <img src="assets/ui-empty.png" width="750">
-    </p>
+   ```{image} assets/ui-empty.png
+   :width: 750px
+   ```
 
 2. Click **New Collection** to add a new collection of documents. The **Create New Collection** dialog appears.
 
-    <p align="left">
-        <img src="assets/ui-create-new.png" width="750">
-    </p>
+   ```{image} assets/ui-create-new.png
+   :width: 750px
+   ```
 
 3. Choose some files to upload in the collection.  Wait while the files are ingested.
 
-    > [!NOTE]
-    > The UI file upload interface has a hard limit of **100 files per upload batch**. When selecting more than 100 files, only the first 100 are processed. For bulk uploads beyond this limit, use multiple upload batches or the [programmatic API](../notebooks/ingestion_api_usage.ipynb).
+   :::{note}
+   The UI file upload interface has a hard limit of **100 files per upload batch**. When selecting more than 100 files, only the first 100 are processed. For bulk uploads beyond this limit, use multiple upload batches or the [programmatic API](../notebooks/ingestion_api_usage.ipynb).
+   :::
 
 4. Create two collections, one named *test_collection_1* and one named *test_collection_2*.
 
 5. For **Collections**, add the two collections that you created.
 
 6. In **Ask a question about your documents**, submit a query related (or not) to the documents that you uploaded to the collections.  You can query a minimum of 1 and a maximum of 5 collections. You should see results similar to the following.
-
-    <p align="left">
-        <img src="assets/ui-query-response.png" width="750">
-    </p>
+   
+   ```{image} assets/ui-query-response.png
+   :width: 750 px
+   ```
 
 7. (Optional) Click **Sources** to view the documents that were used to generate the answer.
 

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,0 +1,7 @@
+[
+    {
+        "preferred": true,
+        "version": "2.3.0",
+        "url": "../2.3.0"
+    }
+]

--- a/docs/vlm-embed.md
+++ b/docs/vlm-embed.md
@@ -14,11 +14,13 @@ In this documentation you do the following:
 
 Requirements: An NVIDIA GPU and a valid `NGC_API_KEY`.
 
-> [!Note]
-> **Early Access**: Currently, `nvidia/llama-3.2-nemoretriever-1b-vlm-embed-v1` is in early access preview.
+:::{note}
+**Early Access**: Currently, `nvidia/llama-3.2-nemoretriever-1b-vlm-embed-v1` is in early access preview.
+:::
 
-[!NOTE]
+:::{note}
 **PDF Support Only**: The VLM embedding feature is currently only supported for PDF documents. Other document formats (Word, PowerPoint, etc.) are not supported with VLM embedding.
+:::
 
 ## Limitations
 
@@ -109,8 +111,9 @@ docker compose -f deploy/compose/docker-compose-ingestor-server.yaml up -d
 
 Extractor captures each page as a single image (`APP_NVINGEST_EXTRACTPAGEASIMAGE="True"`); embedder processes page images via `APP_NVINGEST_IMAGE_ELEMENTS_MODALITY="image"`. Other extraction types are disabled to avoid duplicating content.
 
-> [!NOTE]
-> Citations don't work in the `generate` and `search` APIs of the RAG server with this configuration.
+:::{note}
+Citations don't work in the `generate` and `search` APIs of the RAG server with this configuration.
+:::
 
 ```bash
 # Treat each page as a single image (turn off other extractors)

--- a/docs/vlm.md
+++ b/docs/vlm.md
@@ -7,10 +7,10 @@
 The Vision-Language Model (VLM) inference feature in the [NVIDIA RAG Blueprint](readme.md) enhances the system's ability to understand and reason about visual content that is **automatically retrieved from the knowledge base**. Unlike traditional image upload systems, this feature operates on **image citations** that are internally discovered during the retrieval process.
 
 
-> [!WARNING]
->
-> B200 GPUs are not supported for VLM based inferencing in RAG.
-> For this feature, use H100 or A100 GPUs instead.
+:::{warning}
+B200 GPUs are not supported for VLM based inferencing in RAG.
+For this feature, use H100 or A100 GPUs instead.
+:::
 
 
 
@@ -48,8 +48,9 @@ The VLM feature is particularly beneficial when your knowledge base contains:
 - **Mixed content documents**: PDFs containing both text and images
 - **Image-heavy content**: Catalogs, product documentation, visual guides
 
-> [!Note]
-> **Latency Impact**: Enabling VLM inference will increase response latency due to additional image processing and VLM model inference time. Consider this trade-off between accuracy and speed based on your use case requirements.
+:::{note}
+**Latency Impact**: Enabling VLM inference will increase response latency due to additional image processing and VLM model inference time. Consider this trade-off between accuracy and speed based on your use case requirements.
+:::
 
 ---
 
@@ -124,8 +125,9 @@ deploy:
           capabilities: [gpu]
 ```
 
-> [!Note]
-> Ensure the specified GPU is available and has sufficient memory for the VLM model.
+:::{note}
+Ensure the specified GPU is available and has sufficient memory for the VLM model.
+:::
 
 ---
 
@@ -170,9 +172,10 @@ Continue following the rest of the steps in [Deploy with Docker (NVIDIA-Hosted M
 
 ## Using Helm Chart Deployment
 
-> [!Note]
-> On prem deployment of the VLM model requires an additional 1xH100 or 1xB200 GPU in default deployment configuration.
-> If MIG slicing is enabled on the cluster, ensure to assign a dedicated slice to the VLM. Check [mig-deployment.md](./mig-deployment.md) and  [values-mig.yaml](../deploy/helm/mig-slicing/values-mig.yaml) for more information.
+:::{note}
+On prem deployment of the VLM model requires an additional 1xH100 or 1xB200 GPU in default deployment configuration.
+If MIG slicing is enabled on the cluster, ensure to assign a dedicated slice to the VLM. Check [mig-deployment.md](./mig-deployment.md) and  [values-mig.yaml](../deploy/helm/mig-slicing/values-mig.yaml) for more information. 
+:::
 
 To enable VLM inference in Helm-based deployments, follow these steps:
 
@@ -214,9 +217,9 @@ To enable VLM inference in Helm-based deployments, follow these steps:
     ```
 
 
-> [!Note]
-> For local VLM inference, ensure the VLM NIM service is running and accessible at the configured `APP_VLM_SERVERURL`. For remote endpoints, the `NGC_API_KEY` is required for authentication.
-
+:::{note}
+For local VLM inference, ensure the VLM NIM service is running and accessible at the configured `APP_VLM_SERVERURL`. For remote endpoints, the `NGC_API_KEY` is required for authentication.
+:::
 
 
 ### **When VLM Processing Occurs**
@@ -363,14 +366,15 @@ helm upgrade --install rag -n <namespace> https://helm.ngc.nvidia.com/nvidia/blu
   -f deploy/helm/nvidia-blueprint-rag/values.yaml
 ```
 
-> [!Note]
-> In this mode, the RAG server will use the VLM output as the final response. Keep the embedding and reranker services enabled as in the default chart configuration. If you use a local VLM, also set `APP_VLM_SERVERURL` (for example, `http://nim-vlm:8000/v1`) and enable the `nim-vlm` subchart as shown above.
-
+:::{note}
+In this mode, the RAG server will use the VLM output as the final response. Keep the embedding and reranker services enabled as in the default chart configuration. If you use a local VLM, also set `APP_VLM_SERVERURL` (for example, `http://nim-vlm:8000/v1`) and enable the `nim-vlm` subchart as shown above.
+:::
 
 ### Conversation history and context limitations
 
-> [!Warning]
-> Conversation history is not passed to the VLM. The VLM receives only the current prompt and the cited image(s), and its effective context window is limited. When `APP_VLM_RESPONSE_AS_FINAL_ANSWER` is set to `true` and the user query depends on prior turns or broader textual context, the VLM will not decontextualize the query and may produce incomplete or off-target answers.
+:::{warning}
+Conversation history is not passed to the VLM. The VLM receives only the current prompt and the cited image(s), and its effective context window is limited. When `APP_VLM_RESPONSE_AS_FINAL_ANSWER` is set to `true` and the user query depends on prior turns or broader textual context, the VLM will not decontextualize the query and may produce incomplete or off-target answers.
+:::
 
 Mitigations:
 - Rephrase or rewrite the user query to be self-contained before sending to the VLM (e.g., enable query rewriting upstream).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,3 +137,14 @@ quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
+
+[dependency-groups]
+docs = [
+    "myst-parser>=4.0.1",
+    "nvidia-sphinx-theme>=0.0.8",
+    "sphinx>=8.2.3",
+    "sphinx-autobuild>=2025.8.25",
+    "sphinx-autodoc2>=0.5.0",
+    "sphinx-copybutton>=0.5.2",
+    "swagger-plugin-for-sphinx>=5.2.0",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'darwin'",
@@ -14,6 +14,18 @@ resolution-markers = [
     "python_full_version < '3.12.4' and sys_platform == 'darwin'",
     "python_full_version < '3.12.4' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version < '3.12.4' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12.4' and sys_platform != 'darwin' and sys_platform != 'linux')",
+]
+
+[[package]]
+name = "accessible-pygments"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c1/bbac6a50d02774f91572938964c582fff4270eee73ab822a4aeea4d8b11b/accessible_pygments-0.0.5.tar.gz", hash = "sha256:40918d3e6a2b619ad424cb91e556bd3bd8865443d9f22f1dcdf79e33c8046872", size = 1377899, upload-time = "2024-05-10T11:23:10.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/3f/95338030883d8c8b91223b4e21744b04d11b161a3ef117295d8241f50ab4/accessible_pygments-0.0.5-py3-none-any.whl", hash = "sha256:88ae3211e68a1d0b011504b2ffc1691feafce124b845bd072ab6f9f66f34d4b7", size = 1395903, upload-time = "2024-05-10T11:23:08.421Z" },
 ]
 
 [[package]]
@@ -87,6 +99,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
+name = "alabaster"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/f8/d9c74d0daf3f742840fd818d69cfae176fa332022fd44e3469487d5a9420/alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e", size = 24210, upload-time = "2024-07-26T18:15:03.762Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl", hash = "sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b", size = 13929, upload-time = "2024-07-26T18:15:02.05Z" },
 ]
 
 [[package]]
@@ -203,6 +224,15 @@ wheels = [
 ]
 
 [[package]]
+name = "astroid"
+version = "3.3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/74/dfb75f9ccd592bbedb175d4a32fc643cf569d7c218508bfbd6ea7ef9c091/astroid-3.3.11.tar.gz", hash = "sha256:1e5a5011af2920c7c67a53f65d536d65bfa7116feeaf2354d8b94f29573bb0ce", size = 400439, upload-time = "2025-07-13T18:04:23.177Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/0f/3b8fdc946b4d9cc8cc1e8af42c4e409468c84441b933d037e101b3d72d86/astroid-3.3.11-py3-none-any.whl", hash = "sha256:54c760ae8322ece1abd213057c4b5bba7c49818853fc901ef09719a60dbf9dec", size = 275612, upload-time = "2025-07-13T18:04:21.07Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -241,12 +271,34 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/6b/d52e42361e1aa00709585ecc30b3f9684b3ab62530771402248b1b1d6240/babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d", size = 9951852, upload-time = "2025-02-01T15:17:41.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2", size = 10182537, upload-time = "2025-02-01T15:17:37.39Z" },
+]
+
+[[package]]
 name = "backoff"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/e9/df2358efd7659577435e2177bfa69cba6c33216681af51a707193dec162a/beautifulsoup4-4.14.2.tar.gz", hash = "sha256:2a98ab9f944a11acee9cc848508ec28d9228abfd522ef0fad6a02a72e0ded69e", size = 625822, upload-time = "2025-09-29T10:05:42.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/fe/3aed5d0be4d404d12d36ab97e2f1791424d9ca39c2f754a6285d59a3b01d/beautifulsoup4-4.14.2-py3-none-any.whl", hash = "sha256:5ef6fa3a8cbece8488d66985560f97ed091e22bbc4e9c2338508a9d5de6d4515", size = 106392, upload-time = "2025-09-29T10:05:43.771Z" },
 ]
 
 [[package]]
@@ -470,6 +522,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.21.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444, upload-time = "2024-04-23T18:57:18.24Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408, upload-time = "2024-04-23T18:57:14.835Z" },
 ]
 
 [[package]]
@@ -811,6 +872,43 @@ wheels = [
 ]
 
 [[package]]
+name = "imageio"
+version = "2.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "numpy", version = "2.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/47/57e897fb7094afb2d26e8b2e4af9a45c7cf1a405acdeeca001fdf2c98501/imageio-2.37.0.tar.gz", hash = "sha256:71b57b3669666272c818497aebba2b4c5f20d5b37c81720e5e1a56d59c492996", size = 389963, upload-time = "2025-01-20T02:42:37.089Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/bd/b394387b598ed84d8d0fa90611a90bee0adc2021820ad5729f7ced74a8e2/imageio-2.37.0-py3-none-any.whl", hash = "sha256:11efa15b87bc7871b61590326b2d635439acc321cf7f8ce996f812543ce10eed", size = 315796, upload-time = "2025-01-20T02:42:34.931Z" },
+]
+
+[[package]]
+name = "imageio-ffmpeg"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/bd/c3343c721f2a1b0c9fc71c1aebf1966a3b7f08c2eea8ed5437a2865611d6/imageio_ffmpeg-0.6.0.tar.gz", hash = "sha256:e2556bed8e005564a9f925bb7afa4002d82770d6b08825078b7697ab88ba1755", size = 25210, upload-time = "2025-01-16T21:34:32.747Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/58/87ef68ac83f4c7690961bce288fd8e382bc5f1513860fc7f90a9c1c1c6bf/imageio_ffmpeg-0.6.0-py3-none-macosx_10_9_intel.macosx_10_9_x86_64.whl", hash = "sha256:9d2baaf867088508d4a3458e61eeb30e945c4ad8016025545f66c4b5aaef0a61", size = 24932969, upload-time = "2025-01-16T21:34:20.464Z" },
+    { url = "https://files.pythonhosted.org/packages/40/5c/f3d8a657d362cc93b81aab8feda487317da5b5d31c0e1fdfd5e986e55d17/imageio_ffmpeg-0.6.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1ae3173414b5fc5f538a726c4e48ea97edc0d2cdc11f103afee655c463fa742", size = 21113891, upload-time = "2025-01-16T21:34:00.277Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e7/1925bfbc563c39c1d2e82501d8372734a5c725e53ac3b31b4c2d081e895b/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1d47bebd83d2c5fc770720d211855f208af8a596c82d17730aa51e815cdee6dc", size = 25632706, upload-time = "2025-01-16T21:33:53.475Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c7e46fcec401dd990405049d2e2f475e2b397779df2519b544b8aab515195282", size = 29498237, upload-time = "2025-01-16T21:34:13.726Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/13/59da54728351883c3c1d9fca1710ab8eee82c7beba585df8f25ca925f08f/imageio_ffmpeg-0.6.0-py3-none-win32.whl", hash = "sha256:196faa79366b4a82f95c0f4053191d2013f4714a715780f0ad2a68ff37483cc2", size = 19652251, upload-time = "2025-01-16T21:34:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c6/fa760e12a2483469e2bf5058c5faff664acf66cadb4df2ad6205b016a73d/imageio_ffmpeg-0.6.0-py3-none-win_amd64.whl", hash = "sha256:02fa47c83703c37df6bfe4896aab339013f62bf02c5ebf2dce6da56af04ffc0a", size = 31246824, upload-time = "2025-01-16T21:34:28.6Z" },
+]
+
+[[package]]
+name = "imagesize"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/84/62473fb57d61e31fef6e36d64a179c8781605429fd927b5dd608c997be31/imagesize-1.4.1.tar.gz", hash = "sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a", size = 1280026, upload-time = "2022-07-01T12:21:05.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/62/85c4c919272577931d407be5ba5d71c20f0b616d31a0befe0ae45bb79abd/imagesize-1.4.1-py2.py3-none-any.whl", hash = "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b", size = 8769, upload-time = "2022-07-01T12:21:02.467Z" },
+]
+
+[[package]]
 name = "importlib-metadata"
 version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -829,6 +927,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -1063,112 +1173,78 @@ wheels = [
 ]
 
 [[package]]
-name = "llama-index-core"
-version = "0.10.45"
+name = "markdown-it-py"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')",
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
-]
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version >= '3.13'" },
-    { name = "dataclasses-json", marker = "python_full_version >= '3.13'" },
-    { name = "deprecated", marker = "python_full_version >= '3.13'" },
-    { name = "dirtyjson", marker = "python_full_version >= '3.13'" },
-    { name = "fsspec", marker = "python_full_version >= '3.13'" },
-    { name = "httpx", marker = "python_full_version >= '3.13'" },
-    { name = "llamaindex-py-client", marker = "python_full_version >= '3.13'" },
-    { name = "nest-asyncio", marker = "python_full_version >= '3.13'" },
-    { name = "networkx", marker = "python_full_version >= '3.13'" },
-    { name = "nltk", marker = "python_full_version >= '3.13'" },
-    { name = "numpy", version = "2.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "openai", marker = "python_full_version >= '3.13'" },
-    { name = "pandas", marker = "python_full_version >= '3.13'" },
-    { name = "pillow", marker = "python_full_version >= '3.13'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.13'" },
-    { name = "requests", marker = "python_full_version >= '3.13'" },
-    { name = "sqlalchemy", extra = ["asyncio"], marker = "python_full_version >= '3.13'" },
-    { name = "tenacity", marker = "python_full_version >= '3.13'" },
-    { name = "tiktoken", marker = "python_full_version >= '3.13'" },
-    { name = "tqdm", marker = "python_full_version >= '3.13'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.13'" },
-    { name = "typing-inspect", marker = "python_full_version >= '3.13'" },
-    { name = "wrapt", marker = "python_full_version >= '3.13'" },
+    { name = "mdurl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/6b/1cd00e76b5bdc0060567fdc2c41e9ba6f29a17ec90c36afc5ac9540a4306/llama_index_core-0.10.45.tar.gz", hash = "sha256:f32d0448e7193ff45c8e84abd49493be030998fc8f1a0cab069387deef3e577c", size = 15109807, upload-time = "2024-06-14T22:43:47.813Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/fc/75b116bafcf13346378fbaa138dc3c96226c672ccb123b32c4abba6ba3b3/llama_index_core-0.10.45-py3-none-any.whl", hash = "sha256:8c800c7221322b8e1cbbbc13325039b5fe3575d4b0e0be14ac9a8f1e5d14fee3", size = 15436131, upload-time = "2024-06-14T22:43:39.897Z" },
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
 ]
 
 [[package]]
-name = "llama-index-core"
-version = "0.10.68.post1"
+name = "markupsafe"
+version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12.4' and python_full_version < '3.13' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12.4' and python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "(python_full_version >= '3.12.4' and python_full_version < '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12.4' and python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'linux')",
-    "python_full_version < '3.12.4' and sys_platform == 'darwin'",
-    "python_full_version < '3.12.4' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "(python_full_version < '3.12.4' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12.4' and sys_platform != 'darwin' and sys_platform != 'linux')",
-]
-dependencies = [
-    { name = "aiohttp", marker = "python_full_version < '3.13'" },
-    { name = "dataclasses-json", marker = "python_full_version < '3.13'" },
-    { name = "deprecated", marker = "python_full_version < '3.13'" },
-    { name = "dirtyjson", marker = "python_full_version < '3.13'" },
-    { name = "fsspec", marker = "python_full_version < '3.13'" },
-    { name = "httpx", marker = "python_full_version < '3.13'" },
-    { name = "nest-asyncio", marker = "python_full_version < '3.13'" },
-    { name = "networkx", marker = "python_full_version < '3.13'" },
-    { name = "nltk", marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "pandas", marker = "python_full_version < '3.13'" },
-    { name = "pillow", marker = "python_full_version < '3.13'" },
-    { name = "pydantic", marker = "python_full_version < '3.13'" },
-    { name = "pyyaml", marker = "python_full_version < '3.13'" },
-    { name = "requests", marker = "python_full_version < '3.13'" },
-    { name = "sqlalchemy", extra = ["asyncio"], marker = "python_full_version < '3.13'" },
-    { name = "tenacity", marker = "python_full_version < '3.13'" },
-    { name = "tiktoken", marker = "python_full_version < '3.13'" },
-    { name = "tqdm", marker = "python_full_version < '3.13'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-    { name = "typing-inspect", marker = "python_full_version < '3.13'" },
-    { name = "wrapt", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/eb/2e92bca6a585cc024795918869f808609341ba3ab38526f29114c15c1361/llama_index_core-0.10.68.post1.tar.gz", hash = "sha256:1215106973f2fb7651c10827c27ca3f47c03ccfae3b8653c5476d454d5ba8cd0", size = 1317441, upload-time = "2024-08-21T21:52:21.825Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/bb/524971a3f038701b8751b71f0ff825a8df82c0f511d3860cb58a8fe93045/llama_index_core-0.10.68.post1-py3-none-any.whl", hash = "sha256:1befe1324f0fa1c3a2cfc1e4d38adb0cd0c3b2948badfb2be826da048a3bdbaf", size = 1566336, upload-time = "2024-08-21T21:52:19.278Z" },
-]
-
-[[package]]
-name = "llama-index-embeddings-nvidia"
-version = "0.1.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "llama-index-core", version = "0.10.45", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "llama-index-core", version = "0.10.68.post1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/7b/01680981eda1d3f662451d86e9e2ab4cd1c64777f948c1c124473208b62a/llama_index_embeddings_nvidia-0.1.5.tar.gz", hash = "sha256:1b6d4d679a2176b8a174af21724c90d560ff417375b20e6bd8045200b45ccd54", size = 5579, upload-time = "2024-08-12T14:46:51.979Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/f7/3a5b84110761c7e4a5259b272775b98bcb41c7b5856ac19be1fd8b9c2bfd/llama_index_embeddings_nvidia-0.1.5-py3-none-any.whl", hash = "sha256:6fbe1efba56d96e67d434b77043f98f585a01d11067c1ea8fb52219609b6b1c3", size = 5885, upload-time = "2024-08-12T14:46:50.646Z" },
-]
-
-[[package]]
-name = "llamaindex-py-client"
-version = "0.1.19"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "httpx", marker = "python_full_version >= '3.13'" },
-    { name = "pydantic", marker = "python_full_version >= '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/1b/9dbd37e1c2efb21e91047b2ae7379e309e45a884ed35aa5d3e754ea69cb3/llamaindex_py_client-0.1.19.tar.gz", hash = "sha256:73f74792bb8c092bae6dc626627a09ac13a099fa8d10f8fcc83e17a2b332cca7", size = 54097, upload-time = "2024-04-26T15:59:05.413Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/9c/a1a3086f023a8957ebd527c98d9356b6dd9409edef827ffdeee484f47abf/llamaindex_py_client-0.1.19-py3-none-any.whl", hash = "sha256:fd9416fd78b97209bf323bc3c7fab314499778563e7274f10853ad560563d10e", size = 141926, upload-time = "2024-04-26T15:59:02.888Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -1181,6 +1257,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ab/5e/5e53d26b42ab75491cda89b871dab9e97c840bf12c63ec58a1919710cd06/marshmallow-3.26.1.tar.gz", hash = "sha256:e6d8affb6cb61d39d26402096dc0aee12d5a26d490a121f118d2e81dc0719dc6", size = 221825, upload-time = "2025-02-03T15:32:25.093Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/34/75/51952c7b2d3873b44a0028b1bd26a25078c18f92f256608e8d1dc61b39fd/marshmallow-3.26.1-py3-none-any.whl", hash = "sha256:3350409f20a70a7e4e11a27661187b77cdcaeb20abca41c1454fe33636bea09c", size = 50878, upload-time = "2025-02-03T15:32:22.295Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -1295,36 +1392,20 @@ wheels = [
 ]
 
 [[package]]
-name = "nest-asyncio"
-version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
-]
-
-[[package]]
-name = "networkx"
-version = "3.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/4f/ccdb8ad3a38e583f214547fd2f7ff1fc160c43a75af88e6aec213404b96a/networkx-3.5.tar.gz", hash = "sha256:d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037", size = 2471065, upload-time = "2025-05-29T11:35:07.804Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/8d/776adee7bbf76365fdd7f2552710282c79a4ead5d2a46408c9043a2b70ba/networkx-3.5-py3-none-any.whl", hash = "sha256:0030d386a9a06dee3565298b4a734b68589749a544acbb6c412dc9e2489ec6ec", size = 2034406, upload-time = "2025-05-29T11:35:04.961Z" },
-]
-
-[[package]]
-name = "nltk"
-version = "3.9.1"
+name = "myst-parser"
+version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "joblib" },
-    { name = "regex" },
-    { name = "tqdm" },
+    { name = "docutils" },
+    { name = "jinja2" },
+    { name = "markdown-it-py" },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/87/db8be88ad32c2d042420b6fd9ffd4a149f9a0d7f0e86b3f543be2eeeedd2/nltk-3.9.1.tar.gz", hash = "sha256:87d127bd3de4bd89a4f81265e5fa59cb1b199b27440175370f7417d2bc7ae868", size = 2904691, upload-time = "2024-08-18T19:48:37.769Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/66/7d9e26593edda06e8cb531874633f7c2372279c3b0f46235539fe546df8b/nltk-3.9.1-py3-none-any.whl", hash = "sha256:4fa26829c5b00715afe3061398a8989dc643b92ce7dd93fb4585a70930d168a1", size = 1505442, upload-time = "2024-08-18T19:48:21.909Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/df/76d0321c3797b54b60fef9ec3bd6f4cfd124b9e422182156a1dd418722cf/myst_parser-4.0.1-py3-none-any.whl", hash = "sha256:9134e88959ec3b5780aedf8a99680ea242869d012e8821db3126d427edc9c95d", size = 84579, upload-time = "2025-02-12T10:53:02.078Z" },
 ]
 
 [[package]]
@@ -1541,6 +1622,17 @@ rag = [
     { name = "pyarrow" },
 ]
 
+[package.dev-dependencies]
+docs = [
+    { name = "myst-parser" },
+    { name = "nvidia-sphinx-theme" },
+    { name = "sphinx" },
+    { name = "sphinx-autobuild" },
+    { name = "sphinx-autodoc2" },
+    { name = "sphinx-copybutton" },
+    { name = "swagger-plugin-for-sphinx" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "azure-core", marker = "extra == 'all'", specifier = ">=1.35.0" },
@@ -1610,6 +1702,29 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = "==0.32.0" },
 ]
 provides-extras = ["rag", "ingest", "all"]
+
+[package.metadata.requires-dev]
+docs = [
+    { name = "myst-parser", specifier = ">=4.0.1" },
+    { name = "nvidia-sphinx-theme", specifier = ">=0.0.8" },
+    { name = "sphinx", specifier = ">=8.2.3" },
+    { name = "sphinx-autobuild", specifier = ">=2025.8.25" },
+    { name = "sphinx-autodoc2", specifier = ">=0.5.0" },
+    { name = "sphinx-copybutton", specifier = ">=0.5.2" },
+    { name = "swagger-plugin-for-sphinx", specifier = ">=5.2.0" },
+]
+
+[[package]]
+name = "nvidia-sphinx-theme"
+version = "0.0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydata-sphinx-theme" },
+    { name = "sphinx" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/74/996dbc314da8ed670cd5e040d0b4b5be79ff1fc3db3fe25e63134deebe9a/nvidia_sphinx_theme-0.0.8-py3-none-any.whl", hash = "sha256:18f117aa154a3a156251a75647279c541464f3e75f7df2ae283e720cc7d0bc2c", size = 140678, upload-time = "2025-03-24T21:56:25.621Z" },
+]
 
 [[package]]
 name = "onnxruntime"
@@ -2305,6 +2420,33 @@ wheels = [
 ]
 
 [[package]]
+name = "pydata-sphinx-theme"
+version = "0.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "accessible-pygments" },
+    { name = "babel" },
+    { name = "beautifulsoup4" },
+    { name = "docutils" },
+    { name = "pygments" },
+    { name = "sphinx" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/20/bb50f9de3a6de69e6abd6b087b52fa2418a0418b19597601605f855ad044/pydata_sphinx_theme-0.16.1.tar.gz", hash = "sha256:a08b7f0b7f70387219dc659bff0893a7554d5eb39b59d3b8ef37b8401b7642d7", size = 2412693, upload-time = "2024-12-17T10:53:39.537Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/0d/8ba33fa83a7dcde13eb3c1c2a0c1cc29950a048bfed6d9b0d8b6bd710b4c/pydata_sphinx_theme-0.16.1-py3-none-any.whl", hash = "sha256:225331e8ac4b32682c18fcac5a57a6f717c4e632cea5dd0e247b55155faeccde", size = 6723264, upload-time = "2024-12-17T10:53:35.645Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
 name = "pymilvus"
 version = "2.5.8"
 source = { registry = "https://pypi.org/simple" }
@@ -2557,6 +2699,15 @@ wheels = [
 ]
 
 [[package]]
+name = "roman-numerals-py"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/76/48fd56d17c5bdbdf65609abbc67288728a98ed4c02919428d4f52d23b24b/roman_numerals_py-3.1.0.tar.gz", hash = "sha256:be4bf804f083a4ce001b5eb7e3c0862479d10f94c936f6c4e5f250aa5ff5bd2d", size = 9017, upload-time = "2025-02-22T07:34:54.333Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/97/d2cbbaa10c9b826af0e10fdf836e1bf344d9f0abb873ebc34d1f49642d3f/roman_numerals_py-3.1.0-py3-none-any.whl", hash = "sha256:9da2ad2fb670bcf24e81070ceb3be72f6c11c440d73bd579fbeca1e9f330954c", size = 7742, upload-time = "2025-02-22T07:34:52.422Z" },
+]
+
+[[package]]
 name = "safetensors"
 version = "0.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2713,6 +2864,148 @@ wheels = [
 ]
 
 [[package]]
+name = "snowballstemmer"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/a7/9810d872919697c9d01295633f5d574fb416d47e535f258272ca1f01f447/snowballstemmer-3.0.1.tar.gz", hash = "sha256:6d5eeeec8e9f84d4d56b847692bacf79bc2c8e90c7f80ca4444ff8b6f2e52895", size = 105575, upload-time = "2025-05-09T16:34:51.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/78/3565d011c61f5a43488987ee32b6f3f656e7f107ac2782dd57bdd7d91d9a/snowballstemmer-3.0.1-py3-none-any.whl", hash = "sha256:6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064", size = 103274, upload-time = "2025-05-09T16:34:50.371Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "8.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals-py" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/ad/4360e50ed56cb483667b8e6dadf2d3fda62359593faabbe749a27c4eaca6/sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348", size = 8321876, upload-time = "2025-03-02T22:31:59.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/53/136e9eca6e0b9dc0e1962e2c908fbea2e5ac000c2a2fbd9a35797958c48b/sphinx-8.2.3-py3-none-any.whl", hash = "sha256:4405915165f13521d875a8c29c8970800a0141c14cc5416a38feca4ea5d9b9c3", size = 3589741, upload-time = "2025-03-02T22:31:56.836Z" },
+]
+
+[[package]]
+name = "sphinx-autobuild"
+version = "2025.8.25"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+    { name = "sphinx" },
+    { name = "starlette" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/3c/a59a3a453d4133777f7ed2e83c80b7dc817d43c74b74298ca0af869662ad/sphinx_autobuild-2025.8.25.tar.gz", hash = "sha256:9cf5aab32853c8c31af572e4fecdc09c997e2b8be5a07daf2a389e270e85b213", size = 15200, upload-time = "2025-08-25T18:44:55.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/20/56411b52f917696995f5ad27d2ea7e9492c84a043c5b49a3a3173573cd93/sphinx_autobuild-2025.8.25-py3-none-any.whl", hash = "sha256:b750ac7d5a18603e4665294323fd20f6dcc0a984117026d1986704fa68f0379a", size = 12535, upload-time = "2025-08-25T18:44:54.164Z" },
+]
+
+[[package]]
+name = "sphinx-autodoc2"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "astroid" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/5f/5350046d1aa1a56b063ae08b9ad871025335c9d55fe2372896ea48711da9/sphinx_autodoc2-0.5.0.tar.gz", hash = "sha256:7d76044aa81d6af74447080182b6868c7eb066874edc835e8ddf810735b6565a", size = 115077, upload-time = "2023-11-27T07:27:51.407Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/e6/48d47961bbdae755ba9c17dfc65d89356312c67668dcb36c87cfadfa1964/sphinx_autodoc2-0.5.0-py3-none-any.whl", hash = "sha256:e867013b1512f9d6d7e6f6799f8b537d6884462acd118ef361f3f619a60b5c9e", size = 43385, upload-time = "2023-11-27T07:27:49.929Z" },
+]
+
+[[package]]
+name = "sphinx-copybutton"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039, upload-time = "2023-04-14T08:10:22.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/48/1ea60e74949eecb12cdd6ac43987f9fd331156388dcc2319b45e2ebb81bf/sphinx_copybutton-0.5.2-py3-none-any.whl", hash = "sha256:fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e", size = 13343, upload-time = "2023-04-14T08:10:20.844Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-applehelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/6e/b837e84a1a704953c62ef8776d45c3e8d759876b4a84fe14eba2859106fe/sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1", size = 20053, upload-time = "2024-07-29T01:09:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5", size = 119300, upload-time = "2024-07-29T01:08:58.99Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-devhelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/d2/5beee64d3e4e747f316bae86b55943f51e82bb86ecd325883ef65741e7da/sphinxcontrib_devhelp-2.0.0.tar.gz", hash = "sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad", size = 12967, upload-time = "2024-07-29T01:09:23.417Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl", hash = "sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2", size = 82530, upload-time = "2024-07-29T01:09:21.945Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-htmlhelp"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9", size = 22617, upload-time = "2024-07-29T01:09:37.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8", size = 98705, upload-time = "2024-07-29T01:09:36.407Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-jsmath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787, upload-time = "2019-01-21T16:10:16.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071, upload-time = "2019-01-21T16:10:14.333Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-qthelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/bc/9104308fc285eb3e0b31b67688235db556cd5b0ef31d96f30e45f2e51cae/sphinxcontrib_qthelp-2.0.0.tar.gz", hash = "sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab", size = 17165, upload-time = "2024-07-29T01:09:56.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl", hash = "sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb", size = 88743, upload-time = "2024-07-29T01:09:54.885Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-serializinghtml"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.35"
 source = { registry = "https://pypi.org/simple" }
@@ -2748,6 +3041,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1a/4c/9b5764bd22eec91c4039ef4c55334e9187085da2d8a2df7bd570869aae18/starlette-0.41.3.tar.gz", hash = "sha256:0e4ab3d16522a255be6b28260b938eae2482f98ce5cc934cb08dce8dc3ba5835", size = 2574159, upload-time = "2024-11-18T19:45:04.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/00/2b325970b3060c7cecebab6d295afe763365822b1306a12eeab198f74323/starlette-0.41.3-py3-none-any.whl", hash = "sha256:44cedb2b7c77a9de33a8b74b2b90e9f50d11fcf25d8270ea525ad71a25374ff7", size = 73225, upload-time = "2024-11-18T19:45:02.027Z" },
+]
+
+[[package]]
+name = "swagger-plugin-for-sphinx"
+version = "5.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "jinja2" },
+    { name = "sphinx" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/04/4e09392f114fa4e1ef07a05c73dc69f32e1cae0db0ddbf3870439e0ae974/swagger_plugin_for_sphinx-5.2.0.tar.gz", hash = "sha256:1d68c0a62d10e6f814ebc6741df8876d74c444490e27206deb23bd76ad17434d", size = 15967, upload-time = "2025-10-10T05:33:20.635Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/6f/14be3aea9402e5a4c39ce3068a3b40cd3ea56fa5fa1aa0afaca77f47654a/swagger_plugin_for_sphinx-5.2.0-py3-none-any.whl", hash = "sha256:8a0070e13a02d66c8443757906fb73c224d385000c3dcf4822e7b82dd690c34c", size = 11259, upload-time = "2025-10-10T05:33:19.439Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This is tooling and doc updates to enable building and publishing the documentation to docs.nvidia.com.

This MR targets release-v2.3.0 for updating the release docs.