### PR TITLE
VectorDB Auth token support through REST API

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -579,6 +579,126 @@ jobs:
           docker compose -f deploy/compose/observability.yaml down || true
 
       # ========================================================================
+      # MILVUS VDB AUTH VIA REST TESTS
+      # ========================================================================
+      - name: Configure Milvus VDB auth
+        run: |
+          echo "Configuring Milvus authentication and override compose..."
+          # Set auth credentials for the servers (running in Docker)
+          echo "APP_VECTORSTORE_USERNAME=root" >> $GITHUB_ENV
+          echo "APP_VECTORSTORE_PASSWORD=Milvus" >> $GITHUB_ENV
+          # Set auth token for the integration tests (running on host)
+          echo "VDB_AUTH_TOKEN=root:Milvus" >> $GITHUB_ENV
+          echo "MILVUS_ROOT_TOKEN=root:Milvus" >> $GITHUB_ENV
+          
+          # Stop and clean up existing Milvus containers and volumes
+          echo "Stopping and cleaning up existing Milvus containers..."
+          docker compose -f tests/integration/vectordb.yaml down -v || true
+          
+          # Remove the old data directories to ensure clean start with auth
+          echo "Cleaning up old Milvus data directories..."
+          sudo rm -rf /tmp/milvus-${MILVUS_VERSION}/volumes/milvus || true
+          sudo rm -rf /tmp/milvus-${MILVUS_VERSION}/volumes/etcd || true
+          
+          # Ensure milvus.yaml exists in tests/integration by copying from running container
+          # Since we stopped the container, we need to start a temporary one to extract config
+          mkdir -p tests/integration
+          if [ ! -f tests/integration/milvus.yaml ]; then
+            echo "Creating temporary Milvus container to extract config..."
+            docker run --rm -d --name milvus-temp milvusdb/milvus:${MILVUS_VERSION:-v2.6.2-gpu} sleep 60
+            docker cp milvus-temp:/milvus/configs/milvus.yaml tests/integration/milvus.yaml
+            docker stop milvus-temp || true
+          fi
+          
+          # Update authentication settings in milvus.yaml
+          sed -i 's/authorizationEnabled:.*/authorizationEnabled: true/' tests/integration/milvus.yaml
+          sed -i 's/defaultRootPassword:.*/defaultRootPassword: Milvus/' tests/integration/milvus.yaml
+          echo "MILVUS_CONFIG_FILE=$(pwd)/tests/integration/milvus.yaml" >> $GITHUB_ENV
+          
+          # Verify the changes
+          echo "Verifying milvus.yaml authentication settings:"
+          grep -A2 "security:" tests/integration/milvus.yaml | head -5
+          
+          # Update vectordb.yaml to comment out data volume and enable config volume
+          sed -i 's|- \${DOCKER_VOLUME_DIRECTORY:-.}/volumes/milvus:/var/lib/milvus|# - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/milvus:/var/lib/milvus|' tests/integration/vectordb.yaml
+          sed -i 's|# - \${MILVUS_CONFIG_FILE:-./milvus.yaml}:/milvus/configs/milvus.yaml|- ${MILVUS_CONFIG_FILE:-./milvus.yaml}:/milvus/configs/milvus.yaml|' tests/integration/vectordb.yaml
+      
+      - name: Restart vector database with auth
+        run: |
+          echo "Starting vector database with authentication enabled..."
+          docker compose -f tests/integration/vectordb.yaml up -d
+          echo "Waiting for Milvus services to be ready..."
+          sleep 60
+          docker ps
+          echo "Checking Milvus logs..."
+          docker logs --tail 100 milvus-standalone || true
+          docker logs --tail 50 milvus-etcd || true
+          docker logs --tail 50 milvus-minio || true
+
+      - name: Restart services for Milvus VDB auth tests
+        env:
+          CI_NV_RAG_BLUEPRINT_KEY: ${{ secrets.CI_NV_RAG_BLUEPRINT_KEY }}
+        run: |
+          echo "Restarting rag/ingestor services to pick up Milvus auth configuration..."
+          docker compose -f deploy/compose/docker-compose-rag-server.yaml down || true
+          docker compose -f deploy/compose/docker-compose-ingestor-server.yaml down || true
+          sleep 5
+          docker compose -f deploy/compose/docker-compose-rag-server.yaml up -d --build
+          docker compose -f deploy/compose/docker-compose-ingestor-server.yaml up -d --build
+          sleep 30
+          docker ps
+
+      - name: Run Milvus VDB Auth tests
+        env:
+          APP_VECTORSTORE_URL: http://localhost:19530
+        run: |
+          source venv/bin/activate
+          echo "Running Milvus VDB Auth tests..."
+          echo "APP_VECTORSTORE_URL set to: $APP_VECTORSTORE_URL"
+          python -m tests.integration.main --sequence milvus_vdb_auth_through_rest_api
+          echo "Milvus VDB Auth tests completed"
+
+      - name: Collect logs after Milvus VDB auth tests
+        if: always()
+        run: |
+          mkdir -p logs/milvus-vdb-auth
+          docker logs rag-server > logs/milvus-vdb-auth/rag-server.log 2>&1 || true
+          docker logs ingestor-server > logs/milvus-vdb-auth/ingestor-server.log 2>&1 || true
+          docker logs milvus-standalone > logs/milvus-vdb-auth/milvus.log 2>&1 || true
+          docker logs milvus-etcd > logs/milvus-vdb-auth/etcd.log 2>&1 || true
+          docker logs milvus-minio > logs/milvus-vdb-auth/minio.log 2>&1 || true
+          cp tests/integration/integration_test.log logs/milvus-vdb-auth/ 2>/dev/null || true
+      
+      - name: Revert Milvus VDB auth configurations
+        if: always()
+        run: |
+          echo "Reverting Milvus VDB auth configurations..."
+          # Stop Milvus with auth enabled
+          docker compose -f tests/integration/vectordb.yaml down -v || true
+          
+          # Clean up auth-specific data to ensure fresh start
+          sudo rm -rf /tmp/milvus-${MILVUS_VERSION}/volumes/milvus || true
+          sudo rm -rf /tmp/milvus-${MILVUS_VERSION}/volumes/etcd || true
+          
+          # Remove the auth config file
+          rm -f tests/integration/milvus.yaml || true
+          
+          # Revert vectordb.yaml to original state
+          sed -i 's|- \${MILVUS_CONFIG_FILE:-./milvus.yaml}:/milvus/configs/milvus.yaml|# - ${MILVUS_CONFIG_FILE:-./milvus.yaml}:/milvus/configs/milvus.yaml|' tests/integration/vectordb.yaml
+          sed -i 's|# - \${DOCKER_VOLUME_DIRECTORY:-.}/volumes/milvus:/var/lib/milvus|- \${DOCKER_VOLUME_DIRECTORY:-.}/volumes/milvus:/var/lib/milvus|' tests/integration/vectordb.yaml
+          
+          # Restart Milvus without auth for subsequent tests
+          echo "Restarting Milvus without authentication for subsequent tests..."
+          docker compose -f tests/integration/vectordb.yaml up -d
+          sleep 30
+          
+          # Unset auth environment variables
+          echo "APP_VECTORSTORE_USERNAME=" >> $GITHUB_ENV
+          echo "APP_VECTORSTORE_PASSWORD=" >> $GITHUB_ENV
+          echo "VDB_AUTH_TOKEN=" >> $GITHUB_ENV
+          echo "MILVUS_ROOT_TOKEN=" >> $GITHUB_ENV
+
+      # ========================================================================
       # UPLOAD ALL LOGS
       # ========================================================================
       

--- a/docs/change-vectordb.md
+++ b/docs/change-vectordb.md
@@ -263,7 +263,93 @@ helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprin
 For detailed HELM deployment instructions, see [Helm Deployment Guide](deploy-helm.md).
 
 
-## Define Your Own Vector Database
+## Using VDB Auth Token at Runtime via APIs (Elasticsearch)
+
+When using Elasticsearch as the vector database, you can pass a per-request VDB authentication token via the HTTP `Authorization` header. The servers forward this token to Elasticsearch for that request. This enables per-user RBAC or per-request scoping without changing server env configuration.
+
+Prerequisite:
+- Ensure Elasticsearch authentication is enabled so security is enforced. In Elasticsearch this typically requires `xpack.security.enabled=true`. See the "Elasticsearch Authentication" section above for enabling security via Docker Compose or Helm and for obtaining API keys or setting credentials.
+
+### Auth priority in Elasticsearch VDB
+The Elasticsearch VDB operator resolves auth in this order:
+- Bearer auth from the incoming request `Authorization` header (preferred)
+- API Key from config (`APP_VECTORSTORE_APIKEY` or `APP_VECTORSTORE_APIKEY_ID`/`APP_VECTORSTORE_APIKEY_SECRET`)
+- Basic auth username/password from config (`APP_VECTORSTORE_USERNAME`/`APP_VECTORSTORE_PASSWORD`)
+
+If a bearer token is present, it takes precedence over API key and basic auth for that request.
+
+### Header format
+- Preferred: `Authorization: Bearer <token>`
+- Also accepted: `Authorization: <token>`
+
+What the token represents depends on your Elasticsearch security setup:
+- If using Elasticsearch API keys, you can pass the base64-encoded `id:secret` string as the bearer value.
+- If using a proxy or custom gateway, the bearer value may be an access token minted by your gateway.
+- If using basic auth only, prefer configuring it via env variables; per-request basic via header is not supported by the server wrapper—use bearer or API key via header instead.
+
+### Ingestor Server examples (Elasticsearch)
+
+- List documents:
+
+```bash
+curl -G "$INGESTOR_URL/v1/documents" \
+  -H "Authorization: Bearer ${ES_VDB_TOKEN}" \
+  --data-urlencode "collection_name=es_demo_collection"
+```
+
+- Delete a collection:
+
+```bash
+curl -X DELETE "$INGESTOR_URL/v1/collections" \
+  -H "Authorization: Bearer ${ES_VDB_TOKEN}" \
+  --data-urlencode "collection_names=es_demo_collection"
+```
+
+Notes:
+- Set `ES_VDB_TOKEN` to your runtime credential (e.g., base64 of `id:secret` for ES API keys).
+- You may also set `vdb_endpoint` on requests if you need to override the configured `APP_VECTORSTORE_URL`.
+
+### RAG Server examples (Elasticsearch)
+
+- Search:
+
+```bash
+curl -X POST "$RAG_URL/v1/search" \
+  -H "Authorization: Bearer ${ES_VDB_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "what is vector search?",
+    "use_knowledge_base": true,
+    "collection_names": ["es_demo_collection"],
+    "vdb_endpoint": "'"$APP_VECTORSTORE_URL"'",
+    "reranker_top_k": 0,
+    "vdb_top_k": 3
+  }'
+```
+
+- Generate with streaming:
+
+```bash
+curl -N -X POST "$RAG_URL/v1/generate" \
+  -H "Authorization: Bearer ${ES_VDB_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [{"role":"user","content":"Give a short summary of vector databases"}],
+    "use_knowledge_base": true,
+    "collection_names": ["es_demo_collection"],
+    "vdb_endpoint": "'"$APP_VECTORSTORE_URL"'",
+    "reranker_top_k": 0,
+    "vdb_top_k": 3
+  }'
+```
+
+### Troubleshooting
+- If you receive authentication/authorization errors from Elasticsearch, verify your token (API key validity, scopes, and expiration).
+- Ensure the server is not also configured with conflicting credentials for the same request; bearer token from the header takes precedence at runtime.
+- Confirm that `APP_VECTORSTORE_NAME=elasticsearch` and `APP_VECTORSTORE_URL` are set correctly.
+- If using Helm, see the [Elasticsearch Authentication](#elasticsearch-authentication) section above for configuring API key or basic auth as defaults when a runtime header is not supplied.
+
+# Define Your Own Vector Database
 
 You can create your own custom vector database operators by implementing the `VDBRag` base class.
 This enables you to integrate with any vector database that isn't already supported.

--- a/src/nvidia_rag/ingestor_server/main.py
+++ b/src/nvidia_rag/ingestor_server/main.py
@@ -181,6 +181,7 @@ class NvidiaRAGIngestor:
         filepaths: list[str] | None = None,
         bypass_validation: bool = False,
         metadata_schema: list[dict[str, Any]] | None = None,
+        vdb_auth_token: str = "",
     ) -> VDBRag:
         """
         Prepare the VDBRag object for ingestion.
@@ -199,6 +200,7 @@ class NvidiaRAGIngestor:
                 all_file_paths=filepaths,
                 metadata_schema=metadata_schema,
                 config=self.config,
+                vdb_auth_token=vdb_auth_token,
             )
             return vdb_op, collection_name
 
@@ -222,6 +224,7 @@ class NvidiaRAGIngestor:
         summary_options: dict[str, Any] | None = None,
         additional_validation_errors: list[dict[str, Any]] | None = None,
         documents_catalog_metadata: list[dict[str, Any]] | None = None,
+        vdb_auth_token: str = "",
     ) -> dict[str, Any]:
         """Upload documents to the vector store.
 
@@ -252,6 +255,7 @@ class NvidiaRAGIngestor:
             vdb_endpoint=vdb_endpoint,
             collection_name=collection_name,
             filepaths=filepaths,
+            vdb_auth_token=vdb_auth_token,
         )
         vdb_op.create_document_info_collection()
 
@@ -302,6 +306,7 @@ class NvidiaRAGIngestor:
                         additional_validation_errors=additional_validation_errors,
                         state_manager=state_manager,
                         documents_catalog_metadata=documents_catalog_metadata,
+                        vdb_auth_token=vdb_auth_token,
                     )
 
                 task_id = await INGESTION_TASK_HANDLER.submit_task(
@@ -367,6 +372,7 @@ class NvidiaRAGIngestor:
         additional_validation_errors: list[dict[str, Any]] | None = None,
         state_manager: IngestionStateManager | None = None,
         documents_catalog_metadata: list[dict[str, Any]] | None = None,
+        vdb_auth_token: str = "",
     ) -> dict[str, Any]:
         """
         Main function called by ingestor server to ingest
@@ -423,7 +429,8 @@ class NvidiaRAGIngestor:
                     custom_metadata=custom_metadata,
                     filepaths=filepaths,
                     metadata_schema=metadata_schema,
-                )
+                    vdb_auth_token=vdb_auth_token,
+                )   
 
             if not validation_status:
                 failed_filenames = set()
@@ -495,7 +502,7 @@ class NvidiaRAGIngestor:
                             "error_message": f"Document {filename} already exists. Use update document API instead.",
                         }
                     )
-
+                
                 # Check for unsupported file formats (.rst, .rtf, etc.)
                 not_supported_formats = (".rst", ".rtf", ".org")
                 if filename.endswith(not_supported_formats):
@@ -761,6 +768,7 @@ class NvidiaRAGIngestor:
         summary_options: dict[str, Any] | None = None,
         additional_validation_errors: list[dict[str, Any]] | None = None,
         documents_catalog_metadata: list[dict[str, Any]] | None = None,
+        vdb_auth_token: str = "",
     ) -> dict[str, Any]:
         """Upload a document to the vector store. If the document already exists, it will be replaced.
 
@@ -799,10 +807,11 @@ class NvidiaRAGIngestor:
                     [file_name],
                     collection_name=collection_name,
                     include_upload_path=True,
+                    vdb_auth_token=vdb_auth_token,
                 )
             else:
                 response = self.delete_documents(
-                    [file], collection_name=collection_name
+                    [file], collection_name=collection_name, vdb_auth_token=vdb_auth_token,
                 )
 
             if response["total_documents"] == 0:
@@ -828,6 +837,7 @@ class NvidiaRAGIngestor:
             summary_options=summary_options,
             additional_validation_errors=additional_validation_errors,
             documents_catalog_metadata=documents_catalog_metadata,
+            vdb_auth_token=vdb_auth_token,
         )
         return response
 
@@ -936,6 +946,7 @@ class NvidiaRAGIngestor:
         created_by: str = "",
         business_domain: str = "",
         status: str = "Active",
+        vdb_auth_token: str = "",
     ) -> str:
         """
         Main function called by ingestor server to create a new collection in vector-DB
@@ -949,6 +960,7 @@ class NvidiaRAGIngestor:
         vdb_op, collection_name = self.__prepare_vdb_op_and_collection_name(
             vdb_endpoint=vdb_endpoint,
             collection_name=collection_name,
+            vdb_auth_token=vdb_auth_token,
         )
 
         if metadata_schema is None:
@@ -1148,6 +1160,7 @@ class NvidiaRAGIngestor:
         vdb_endpoint: str | None = None,
         embedding_dimension: int | None = None,
         collection_type: str = "text",
+        vdb_auth_token: str = "",
     ) -> dict[str, Any]:
         """
         Main function called by ingestor server to create new collections in vector-DB
@@ -1161,6 +1174,7 @@ class NvidiaRAGIngestor:
         vdb_op, _ = self.__prepare_vdb_op_and_collection_name(
             vdb_endpoint=vdb_endpoint,
             collection_name="",
+            vdb_auth_token=vdb_auth_token,
         )
         try:
             if not len(collection_names):
@@ -1219,6 +1233,7 @@ class NvidiaRAGIngestor:
         self,
         collection_names: list[str],
         vdb_endpoint: str | None = None,
+        vdb_auth_token: str = "",
     ) -> dict[str, Any]:
         """
         Main function called by ingestor server to delete collections in vector-DB
@@ -1233,6 +1248,7 @@ class NvidiaRAGIngestor:
             vdb_op, _ = self.__prepare_vdb_op_and_collection_name(
                 vdb_endpoint=vdb_endpoint,
                 collection_name="",
+                vdb_auth_token=vdb_auth_token,
             )
 
             response = vdb_op.delete_collections(collection_names)
@@ -1275,6 +1291,7 @@ class NvidiaRAGIngestor:
     def get_collections(
         self,
         vdb_endpoint: str | None = None,
+        vdb_auth_token: str = "",
     ) -> dict[str, Any]:
         """
         Main function called by ingestor server to get all collections in vector-DB.
@@ -1293,6 +1310,7 @@ class NvidiaRAGIngestor:
             vdb_op, _ = self.__prepare_vdb_op_and_collection_name(
                 vdb_endpoint=vdb_endpoint,
                 collection_name="",
+                vdb_auth_token=vdb_auth_token,
             )
             # Fetch collections from vector store
             collection_info = vdb_op.get_collection()
@@ -1330,6 +1348,7 @@ class NvidiaRAGIngestor:
         collection_name: str | None = None,
         vdb_endpoint: str | None = None,
         bypass_validation: bool = False,
+        vdb_auth_token: str = "",
     ) -> dict[str, Any]:
         """
         Retrieves filenames stored in the vector store.
@@ -1347,6 +1366,7 @@ class NvidiaRAGIngestor:
                 vdb_endpoint=vdb_endpoint,
                 collection_name=collection_name,
                 bypass_validation=bypass_validation,
+                vdb_auth_token=vdb_auth_token,
             )
             documents_list = vdb_op.get_documents(collection_name)
 
@@ -1397,6 +1417,7 @@ class NvidiaRAGIngestor:
         collection_name: str | None = None,
         vdb_endpoint: str | None = None,
         include_upload_path: bool = False,
+        vdb_auth_token: str = "",
     ) -> dict[str, Any]:
         """Delete documents from the vector index.
         It's called when the DELETE endpoint of `/documents` API is invoked.
@@ -1417,6 +1438,7 @@ class NvidiaRAGIngestor:
             vdb_op, collection_name = self.__prepare_vdb_op_and_collection_name(
                 vdb_endpoint=vdb_endpoint,
                 collection_name=collection_name,
+                vdb_auth_token=vdb_auth_token,
             )
 
             logger.info(

--- a/src/nvidia_rag/rag_server/main.py
+++ b/src/nvidia_rag/rag_server/main.py
@@ -219,6 +219,7 @@ class NvidiaRAG:
         vdb_endpoint: str | None = None,
         embedding_model: str | None = None,
         embedding_endpoint: str | None = None,
+        vdb_auth_token: str = "",
     ) -> VDBRag:
         """
         Prepare the VDBRag object for generation.
@@ -249,6 +250,7 @@ class NvidiaRAG:
             vdb_endpoint=vdb_endpoint or self.config.vector_store.url,
             embedding_model=document_embedder,
             config=self.config,
+            vdb_auth_token=vdb_auth_token,
         )
 
     def _validate_collections_exist(
@@ -274,6 +276,7 @@ class NvidiaRAG:
         self,
         messages: list[dict[str, Any]],
         use_knowledge_base: bool = True,
+        vdb_auth_token: str = "",
         temperature: float | None = None,
         top_p: float | None = None,
         min_tokens: int | None = None,
@@ -419,6 +422,7 @@ class NvidiaRAG:
             vdb_endpoint=vdb_endpoint,
             embedding_model=embedding_model,
             embedding_endpoint=embedding_endpoint,
+            vdb_auth_token=vdb_auth_token,
         )
 
         # Validate boolean and float parameters
@@ -517,6 +521,7 @@ class NvidiaRAG:
         collection_name: str = "",
         collection_names: list[str] | None = None,
         vdb_endpoint: str | None = None,
+        vdb_auth_token: str = "",
         enable_query_rewriting: bool | None = None,
         enable_reranker: bool | None = None,
         enable_filter_generator: bool | None = None,
@@ -598,6 +603,7 @@ class NvidiaRAG:
             vdb_endpoint=vdb_endpoint,
             embedding_model=embedding_model,
             embedding_endpoint=embedding_endpoint,
+            vdb_auth_token=vdb_auth_token,
         )
 
         if messages is None:

--- a/src/nvidia_rag/utils/vdb/__init__.py
+++ b/src/nvidia_rag/utils/vdb/__init__.py
@@ -33,6 +33,7 @@ def _get_vdb_op(
     embedding_model: str | None = None,  # Needed in case of retrieval
     metadata_schema: list[dict[str, Any]] | None = None,
     config: NvidiaRAGConfig | None = None,
+    vdb_auth_token: str | None = None,
 ):
     """
     Get VDBRag class object based on configuration.
@@ -87,11 +88,16 @@ def _get_vdb_op(
             gpu_search=config.vector_store.enable_gpu_search,
             # Authentication for Milvus
             username=config.vector_store.username,
-            password=config.vector_store.password.get_secret_value() if config.vector_store.password is not None else "",
+            password=(
+                config.vector_store.password.get_secret_value()
+                if config.vector_store.password is not None
+                else ""
+            ),
             # Custom metadata configurations (optional)
             meta_dataframe=csv_file_path,
             meta_source_field=meta_source_field,
             meta_fields=meta_fields,
+            auth_token=vdb_auth_token,
         )
 
     elif config.vector_store.name == "elasticsearch":
@@ -106,6 +112,7 @@ def _get_vdb_op(
             index_name=collection_name,
             es_url=vdb_endpoint or config.vector_store.url,
             hybrid=config.vector_store.search_type == SearchType.HYBRID,
+            auth_token=vdb_auth_token,
             meta_dataframe=meta_dataframe,
             meta_source_field=meta_source_field,
             meta_fields=meta_fields,

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -2,3 +2,4 @@ aiohttp>=3.8.0
 tabulate>=0.9.0
 pyyaml>=6.0.2
 tiktoken>=0.12.0
+pymilvus>=2.5.8

--- a/tests/integration/test_cases/cleanup.py
+++ b/tests/integration/test_cases/cleanup.py
@@ -232,17 +232,20 @@ class CleanupModule(BaseTestModule):
         """Delete documents from a collection"""
         async with aiohttp.ClientSession() as session:
             try:
-                params = {"collection_name": collection_name}
+                # DELETE /v1/documents expects query params:
+                # collection_name=<name>&document_names=<file1>&document_names=<file2>...
+                params = [("collection_name", collection_name)]
+                for name in file_names:
+                    params.append(("document_names", name))
                 logger.info(
                     f"🗑️ Deleting documents from collection '{collection_name}':"
                 )
-                logger.info(f"📋 Delete request params: {json.dumps(params, indent=2)}")
+                logger.info(f"📋 Delete request params: {params}")
                 logger.info(f"📁 Files to delete: {json.dumps(file_names, indent=2)}")
 
                 async with session.delete(
                     f"{self.ingestor_server_url}/v1/documents",
-                    params=params,
-                    json=file_names,
+                    params=params
                 ) as response:
                     result = await response.json()
                     if response.status == 200:
@@ -270,9 +273,10 @@ class CleanupModule(BaseTestModule):
                     f"📋 Collections to delete: {json.dumps(collection_names, indent=2)}"
                 )
 
-                async with session.delete(
-                    f"{self.ingestor_server_url}/v1/collections", json=collection_names
-                ) as response:
+                # DELETE /v1/collections expects query params:
+                # collection_names=<col1>&collection_names=<col2>...
+                params = [("collection_names", name) for name in collection_names]
+                async with session.delete(f"{self.ingestor_server_url}/v1/collections", params=params) as response:
                     result = await response.json()
                     if response.status == 200:
                         logger.info("✅ Collections deleted successfully:")

--- a/tests/integration/test_cases/milvus_vdb_auth.py
+++ b/tests/integration/test_cases/milvus_vdb_auth.py
@@ -1,0 +1,640 @@
+import os
+import time
+
+from pymilvus import MilvusClient
+
+# Try to import NvidiaRAGConfig from the codebase used by the servers.
+# Fallback to minimal env-based defaults if unavailable in this test discovery environment.
+try:
+    from nvidia_rag.utils.configuration import NvidiaRAGConfig  # type: ignore
+except Exception:
+    def NvidiaRAGConfig():  # type: ignore
+        class _DummyCfg:
+            class embeddings:
+                dimensions = int(os.getenv("EMBEDDING_DIM", "1536"))
+            class vector_store:
+                url = os.getenv("APP_VECTORSTORE_URL", "http://milvus:19530")
+        return _DummyCfg()
+
+from ..base import BaseTestModule, TestStatus, test_case
+import aiohttp
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _milvus_root_token() -> str:
+    # Root/admin token in form "user:password"
+    return os.getenv("MILVUS_ROOT_TOKEN", os.getenv("VDB_AUTH_TOKEN", "root:Milvus"))
+
+
+def _milvus_uri() -> str:
+    return os.getenv("APP_VECTORSTORE_URL", NvidiaRAGConfig().vector_store.url)
+
+
+def _create_user(client: MilvusClient, user: str, password: str):
+    try:
+        users = client.list_users()
+        if user not in users:
+            client.create_user(user_name=user, password=password)
+    except Exception:
+        # Retry once to avoid transient connection issues
+        time.sleep(1.0)
+        users = client.list_users()
+        if user not in users:
+            client.create_user(user_name=user, password=password)
+
+
+def _create_role(client: MilvusClient, role: str):
+    try:
+        roles = client.list_roles()
+        if role not in roles:
+            client.create_role(role_name=role)
+    except Exception:
+        # Some Milvus versions create role implicitly on grant; ignore errors
+        pass
+
+
+def _grant_role(client: MilvusClient, role: str, user: str):
+    client.grant_role(role_name=role, user_name=user)
+
+
+def _grant_collection_privilege(client: MilvusClient, role: str, object_type: str, object_name: str, privilege: str):
+    # Valid privilege examples include (for object_type="Collection"): "All", "CreateIndex", "DropCollection", "Search", "Query", "Insert"
+    client.grant_privilege(role_name=role, object_type=object_type, privilege=privilege, object_name=object_name)
+
+
+class MilvusVdbAuthModule(BaseTestModule):
+    """Milvus VDB auth tests via API using Authorization header bearer tokens."""
+
+    @test_case(78, "Milvus Auth Setup (users/roles) and Create Collection")
+    async def _test_milvus_auth_setup_and_create_collection(self) -> bool:
+        """Create test users/roles and collection as admin."""
+        logger.info("\n=== Test 71: Milvus Auth Setup (users/roles) and Create Collection ===")
+        start = time.time()
+        cfg = NvidiaRAGConfig()
+
+        # Prepare identities (use fixed names to avoid relying on random suffixes)
+        self.collection_name = "auth_it"
+        self.reader_user = "reader"
+        self.reader_pwd = "pwd_reader"
+        self.reader_role = "role_reader"
+        self.writer_user = "writer"
+        self.writer_pwd = "pwd_writer"
+        self.writer_role = "role_writer"
+
+        try:
+            client = MilvusClient(uri=_milvus_uri(), token=_milvus_root_token())
+            _create_user(client, self.reader_user, self.reader_pwd)
+            _create_user(client, self.writer_user, self.writer_pwd)
+            _create_role(client, self.reader_role)
+            _create_role(client, self.writer_role)
+            _grant_role(client, self.reader_role, self.reader_user)
+            _grant_role(client, self.writer_role, self.writer_user)
+
+            # Create collection using API (admin header)
+            payload = {
+                "collection_name": self.collection_name,
+                "embedding_dimension": cfg.embeddings.dimensions,
+            }
+            headers = {"Authorization": f"Bearer {_milvus_root_token()}"}
+            async with aiohttp.ClientSession() as session:
+                async with session.post(f"{self.ingestor_server_url}/v1/collection", json=payload, headers=headers) as resp:
+                    result = await resp.json()
+                    if resp.status == 200:
+                        logger.info(f"✅ Collection '{self.collection_name}' created")
+                        self.add_test_result(
+                            self._test_milvus_auth_setup_and_create_collection.test_number,
+                            self._test_milvus_auth_setup_and_create_collection.test_name,
+                            f"Create users/roles and a collection {self.collection_name} for auth tests.",
+                            ["POST /v1/collection"],
+                            ["collection_name", "embedding_dimension"],
+                            time.time() - start,
+                            TestStatus.SUCCESS,
+                        )
+                        return True
+                    else:
+                        logger.error(f"❌ Failed to create collection: {resp.status} {result}")
+                        self.add_test_result(
+                            self._test_milvus_auth_setup_and_create_collection.test_number,
+                            self._test_milvus_auth_setup_and_create_collection.test_name,
+                            f"Create users/roles and a collection {self.collection_name} for auth tests.",
+                            ["POST /v1/collection"],
+                            ["collection_name", "embedding_dimension"],
+                            time.time() - start,
+                            TestStatus.FAILURE,
+                            f"status={resp.status} body={json.dumps(result)}",
+                        )
+                        return False
+        except Exception as e:
+            logger.error(f"❌ Exception during auth setup: {e}")
+            self.add_test_result(
+                self._test_milvus_auth_setup_and_create_collection.test_number,
+                self._test_milvus_auth_setup_and_create_collection.test_name,
+                f"Create users/roles and a collection for auth tests.",
+                ["POST /v1/collection"],
+                ["collection_name", "embedding_dimension"],
+                time.time() - start,
+                TestStatus.FAILURE,
+                str(e),
+            )
+            return False
+
+    @test_case(79, "Access denied without privileges (reader)")
+    async def _test_reader_denied_without_privileges(self) -> bool:
+        """Reader should not be able to list documents without grants."""
+        logger.info("\n=== Test 72: Access denied without privileges (reader) ===")
+        start = time.time()
+        try:
+            headers = {"Authorization": f"Bearer {self.reader_user}:{self.reader_pwd}"}
+            async with aiohttp.ClientSession() as session:
+                async with session.get(f"{self.ingestor_server_url}/v1/collections", headers=headers) as resp:
+                    # Assert expected authorization/privilege error content from response body
+                    try:
+                        body = await resp.json()
+                        message = str(body.get("message") or body.get("error") or body.get("detail") or body).lower()
+                        body_text = json.dumps(body)
+                    except Exception:
+                        body_text = await resp.text()
+                        message = body_text.lower()
+                    has_denial = any(substr in message for substr in ("denied", "not authorized", "permission", "privilege"))
+                    if has_denial:
+                        self.add_test_result(
+                            self._test_reader_denied_without_privileges.test_number,
+                            self._test_reader_denied_without_privileges.test_name,
+                            "GET /v1/collections should be denied for reader without privileges.",
+                            ["GET /v1/collections"],
+                            [],
+                            time.time() - start,
+                            TestStatus.SUCCESS,
+                        )
+                        return True
+                    else:
+                        self.add_test_result(
+                            self._test_reader_denied_without_privileges.test_number,
+                            self._test_reader_denied_without_privileges.test_name,
+                            "GET /v1/collections should be denied for reader without privileges.",
+                            ["GET /v1/collections"],
+                            [],
+                            time.time() - start,
+                            TestStatus.FAILURE,
+                            f"Unexpected response body: {body_text}",
+                        )
+                        return False
+        except Exception as e:
+            # If server maps auth error to exception => success expected
+            self.add_test_result(
+                self._test_reader_denied_without_privileges.test_number,
+                self._test_reader_denied_without_privileges.test_name,
+                "GET /v1/collections should be denied for reader without privileges.",
+                ["GET /v1/collections"],
+                [],
+                time.time() - start,
+                TestStatus.SUCCESS,
+            )
+            return True
+
+    @test_case(80, "Grant read privileges and verify access")
+    async def _test_grant_read_and_verify(self) -> bool:
+        """Grant reader access and verify documents listing succeeds."""
+        logger.info("\n=== Test 73: Grant read privileges and verify access ===")
+        start = time.time()
+        try:
+            client = MilvusClient(uri=_milvus_uri(), token=_milvus_root_token())
+            for priv in ("Query", "Search", "DescribeCollection", "Load"):
+                try:
+                    if priv == "DescribeCollection":
+                        _grant_collection_privilege(client, self.reader_role, "Global", self.collection_name, privilege=priv)
+                    else:
+                        _grant_collection_privilege(client, self.reader_role, "Collection", self.collection_name, privilege=priv)
+                except Exception:
+                    pass
+
+            headers = {"Authorization": f"Bearer {self.reader_user}:{self.reader_pwd}"}
+            async with aiohttp.ClientSession() as session:
+                async with session.get(f"{self.ingestor_server_url}/v1/collections", headers=headers) as resp:
+                    result = await resp.json()
+                    if resp.status == 200:
+                        self.add_test_result(
+                            self._test_grant_read_and_verify.test_number,
+                            self._test_grant_read_and_verify.test_name,
+                            "GET /v1/collections should succeed after granting read privileges.",
+                            ["GET /v1/collections"],
+                            [],
+                            time.time() - start,
+                            TestStatus.SUCCESS,
+                        )
+                        return True
+                    else:
+                        self.add_test_result(
+                            self._test_grant_read_and_verify.test_number,
+                            self._test_grant_read_and_verify.test_name,
+                            "GET /v1/collections should succeed after granting read privileges.",
+                            ["GET /v1/collections"],
+                            [],
+                            time.time() - start,
+                            TestStatus.FAILURE,
+                            f"status={resp.status} body={json.dumps(result)}",
+                        )
+                        return False
+        except Exception as e:
+            self.add_test_result(
+                self._test_grant_read_and_verify.test_number,
+                self._test_grant_read_and_verify.test_name,
+                "GET /v1/collections should succeed after granting read privileges.",
+                ["GET /v1/collections"],
+                [],
+                time.time() - start,
+                TestStatus.FAILURE,
+                str(e),
+            )
+            return False
+
+    @test_case(81, "Writer cannot drop collection without privilege (API)")
+    async def _test_writer_cannot_drop_via_api(self) -> bool:
+        """Writer without drop privilege should get non-200 on DELETE /v1/collections."""
+        logger.info("\n=== Test 74: Writer cannot drop collection without privilege (API) ===")
+        start = time.time()
+        try:
+            headers = {"Authorization": f"Bearer {self.writer_user}:{self.writer_pwd}"}
+            params = [("collection_names", self.collection_name)]
+            async with aiohttp.ClientSession() as session:
+                async with session.delete(f"{self.ingestor_server_url}/v1/collections", params=params, headers=headers) as resp:
+                    # Assert expected authorization/privilege error content from response body
+                    try:
+                        body = await resp.json()
+                        message = str(body).lower()
+                    except Exception:
+                        body_text = await resp.text()
+                        message = body_text.lower()
+                    has_denial = any(substr in message for substr in ("denied", "not authorized", "permission", "privilege"))
+                    if has_denial:
+                        self.add_test_result(
+                            self._test_writer_cannot_drop_via_api.test_number,
+                            self._test_writer_cannot_drop_via_api.test_name,
+                            "DELETE /v1/collections should be denied for writer without drop privilege.",
+                            ["DELETE /v1/collections"],
+                            ["collection_names"],
+                            time.time() - start,
+                            TestStatus.SUCCESS,
+                        )
+                        return True
+                    else:
+                        self.add_test_result(
+                            self._test_writer_cannot_drop_via_api.test_number,
+                            self._test_writer_cannot_drop_via_api.test_name,
+                            "DELETE /v1/collections should be denied for writer without drop privilege.",
+                            ["DELETE /v1/collections"],
+                            ["collection_names"],
+                            time.time() - start,
+                            TestStatus.FAILURE,
+                            f"Unexpected response body: {body_text}",
+                        )
+                        return False
+        except Exception:
+            # If server maps auth to exception => success expected
+            self.add_test_result(
+                self._test_writer_cannot_drop_via_api.test_number,
+                self._test_writer_cannot_drop_via_api.test_name,
+                "DELETE /v1/collections should be denied for writer without drop privilege.",
+                ["DELETE /v1/collections"],
+                ["collection_names"],
+                time.time() - start,
+                TestStatus.SUCCESS,
+            )
+            return True
+
+    @test_case(82, "Writer can drop collection with privilege (API)")
+    async def _test_writer_can_drop_via_api(self) -> bool:
+        """Writer with DropCollection privilege should be able to delete the collection via API."""
+        logger.info("\n=== Test 75: Writer can drop collection with privilege (API) ===")
+        start = time.time()
+        try:
+            # Grant writer the DropCollection (or All) privilege
+            client = MilvusClient(uri=_milvus_uri(), token=_milvus_root_token())
+            try:
+                _grant_collection_privilege(client, self.writer_role, "Global", self.collection_name, privilege="DropCollection")
+            except Exception:
+                pass
+
+            headers = {"Authorization": f"Bearer {self.writer_user}:{self.writer_pwd}"}
+            params = [("collection_names", self.collection_name)]
+            async with aiohttp.ClientSession() as session:
+                async with session.delete(f"{self.ingestor_server_url}/v1/collections", params=params, headers=headers) as resp:
+                    result = await resp.json()
+                    if resp.status == 200:
+                        self.add_test_result(
+                            self._test_writer_can_drop_via_api.test_number,
+                            self._test_writer_can_drop_via_api.test_name,
+                            "DELETE /v1/collections should succeed for writer with DropCollection privilege.",
+                            ["DELETE /v1/collections"],
+                            ["collection_names"],
+                            time.time() - start,
+                            TestStatus.SUCCESS,
+                        )
+                        return True
+                    else:
+                        self.add_test_result(
+                            self._test_writer_can_drop_via_api.test_number,
+                            self._test_writer_can_drop_via_api.test_name,
+                            "DELETE /v1/collections should succeed for writer with DropCollection privilege.",
+                            ["DELETE /v1/collections"],
+                            ["collection_names"],
+                            time.time() - start,
+                            TestStatus.FAILURE,
+                            f"status={resp.status} body={json.dumps(result)}",
+                        )
+                        return False
+        except Exception as e:
+            self.add_test_result(
+                self._test_writer_can_drop_via_api.test_number,
+                self._test_writer_can_drop_via_api.test_name,
+                "DELETE /v1/collections should succeed for writer with DropCollection privilege.",
+                ["DELETE /v1/collections"],
+                ["collection_names"],
+                time.time() - start,
+                TestStatus.FAILURE,
+                str(e),
+            )
+            return False
+
+    @test_case(83, "RAG search denied without privileges (reader)")
+    async def _test_rag_search_denied_without_privileges(self) -> bool:
+        """Reader should not be able to perform RAG search without grants on a new collection."""
+        logger.info("\n=== Test 76: RAG search denied without privileges (reader) ===")
+        start = time.time()
+        cfg = NvidiaRAGConfig()
+        temp_collection = "auth_rag"
+        try:
+            # Create temp collection via ingestor API as admin
+            headers_admin = {"Authorization": f"Bearer {_milvus_root_token()}"}
+            payload = {"collection_name": temp_collection, "embedding_dimension": cfg.embeddings.dimensions}
+            async with aiohttp.ClientSession() as session:
+                async with session.post(f"{self.ingestor_server_url}/v1/collection", json=payload, headers=headers_admin) as c_resp:
+                    _ = await c_resp.json()
+                    if c_resp.status != 200:
+                        raise RuntimeError(f"Failed to create temp collection {temp_collection}")
+
+            # Call RAG /search as reader (should be denied)
+            headers_reader = {"Authorization": f"Bearer {self.reader_user}:{self.reader_pwd}"}
+            search_payload = {
+                "query": "test access",
+                "collection_names": [temp_collection],
+                "messages": [],
+            }
+            async with aiohttp.ClientSession() as session:
+                async with session.post(f"{self.rag_server_url}/v1/search", json=search_payload, headers=headers_reader) as resp:
+                    # Assert expected authorization/privilege error content from response body
+                    try:
+                        body = await resp.json()
+                        message = str(body.get("message") or body.get("error") or body.get("detail") or body).lower()
+                        body_text = json.dumps(body)
+                    except Exception:
+                        body_text = await resp.text()
+                        message = body_text.lower()
+                    # Treat presence of any error-like phrasing as access denial success
+                    error_markers = (
+                        "denied",
+                        "not authorized",
+                        "permission",
+                        "privilege",
+                        "error",
+                        "fail",
+                        "illegal",
+                        "unavailable",
+                    )
+                    has_error = any(substr in message for substr in error_markers)
+                    if has_error:
+                        self.add_test_result(
+                            self._test_rag_search_denied_without_privileges.test_number,
+                            self._test_rag_search_denied_without_privileges.test_name,
+                            "POST /v1/search should be denied for reader without privileges.",
+                            ["POST /v1/search"],
+                            ["query", "collection_names"],
+                            time.time() - start,
+                            TestStatus.SUCCESS,
+                        )
+                        return True
+                    else:
+                        self.add_test_result(
+                            self._test_rag_search_denied_without_privileges.test_number,
+                            self._test_rag_search_denied_without_privileges.test_name,
+                            "POST /v1/search should be denied for reader without privileges.",
+                            ["POST /v1/search"],
+                            ["query", "collection_names"],
+                            time.time() - start,
+                            TestStatus.FAILURE,
+                            f"Unexpected response body: {body_text}",
+                        )
+                        return False
+        except Exception as e:
+            self.add_test_result(
+                self._test_rag_search_denied_without_privileges.test_number,
+                self._test_rag_search_denied_without_privileges.test_name,
+                "POST /v1/search should be denied for reader without privileges.",
+                ["POST /v1/search"],
+                ["query", "collection_names"],
+                time.time() - start,
+                TestStatus.SUCCESS,
+                str(e),
+            )
+            return True
+        finally:
+            # cleanup temp collection as admin
+            try:
+                headers_admin = {"Authorization": f"Bearer {_milvus_root_token()}"}
+                params = [("collection_names", temp_collection)]
+                async with aiohttp.ClientSession() as session:
+                    await session.delete(f"{self.ingestor_server_url}/v1/collections", params=params, headers=headers_admin)
+            except Exception:
+                pass
+
+    @test_case(84, "RAG search allowed after privileges (reader)")
+    async def _test_rag_search_allowed_after_privileges(self) -> bool:
+        """Grant reader access and verify RAG search succeeds on a new collection."""
+        logger.info("\n=== Test 77: RAG search allowed after privileges (reader) ===")
+        start = time.time()
+        cfg = NvidiaRAGConfig()
+        temp_collection = "auth_rag"
+        try:
+            # Create temp collection via ingestor API as admin
+            headers_admin = {"Authorization": f"Bearer {_milvus_root_token()}"}
+            payload = {"collection_name": temp_collection, "embedding_dimension": cfg.embeddings.dimensions}
+            async with aiohttp.ClientSession() as session:
+                async with session.post(f"{self.ingestor_server_url}/v1/collection", json=payload, headers=headers_admin) as c_resp:
+                    _ = await c_resp.json()
+                    if c_resp.status != 200:
+                        raise RuntimeError(f"Failed to create temp collection {temp_collection}")
+
+            # Grant reader privileges to this temp collection
+            client = MilvusClient(uri=_milvus_uri(), token=_milvus_root_token())
+            for priv in ("Query", "Search", "DescribeCollection", "Load", "GetLoadState"):
+                try:
+                    if priv == "DescribeCollection":
+                        _grant_collection_privilege(client, self.reader_role, "Global", temp_collection, privilege=priv)
+                    else:
+                        _grant_collection_privilege(client, self.reader_role, "Collection", temp_collection, privilege=priv)
+                except Exception:
+                    pass
+
+            # Call RAG /search as reader (should succeed)
+            headers_reader = {"Authorization": f"Bearer {self.reader_user}:{self.reader_pwd}"}
+            search_payload = {
+                "query": "what is milvus?",
+                "collection_names": [temp_collection],
+                "messages": [],
+            }
+            async with aiohttp.ClientSession() as session:
+                async with session.post(f"{self.rag_server_url}/v1/search", json=search_payload, headers=headers_reader) as resp:
+                    result = await resp.json()
+                    if resp.status == 200:
+                        self.add_test_result(
+                            self._test_rag_search_allowed_after_privileges.test_number,
+                            self._test_rag_search_allowed_after_privileges.test_name,
+                            "POST /v1/search should succeed after granting read privileges.",
+                            ["POST /v1/search"],
+                            ["query", "collection_names"],
+                            time.time() - start,
+                            TestStatus.SUCCESS,
+                        )
+                        return True
+                    else:
+                        self.add_test_result(
+                            self._test_rag_search_allowed_after_privileges.test_number,
+                            self._test_rag_search_allowed_after_privileges.test_name,
+                            "POST /v1/search should succeed after granting read privileges.",
+                            ["POST /v1/search"],
+                            ["query", "collection_names"],
+                            time.time() - start,
+                            TestStatus.FAILURE,
+                            f"status={resp.status} body={json.dumps(result)}",
+                        )
+                        return False
+        except Exception as e:
+            self.add_test_result(
+                self._test_rag_search_allowed_after_privileges.test_number,
+                self._test_rag_search_allowed_after_privileges.test_name,
+                "POST /v1/search should succeed after granting read privileges.",
+                ["POST /v1/search"],
+                ["query", "collection_names"],
+                time.time() - start,
+                TestStatus.FAILURE,
+                str(e),
+            )
+            return False
+        finally:
+            # cleanup temp collection as admin
+            try:
+                headers_admin = {"Authorization": f"Bearer {_milvus_root_token()}"}
+                params = [("collection_names", temp_collection)]
+                async with aiohttp.ClientSession() as session:
+                    await session.delete(f"{self.ingestor_server_url}/v1/collections", params=params, headers=headers_admin)
+            except Exception:
+                pass
+
+
+
+    @test_case(85, "Cleanup auth resources (collections, users, roles)")
+    async def test_cleanup_auth_resources(self) -> bool:
+        """Cleanup resources created by this module: collections, users, roles."""
+        logger.info("\n=== Test 78: Cleanup auth resources (collections, users, roles) ===")
+        start = time.time()
+        try:
+            headers_admin = {"Authorization": f"Bearer {_milvus_root_token()}"}
+            cfg = NvidiaRAGConfig()
+            client = MilvusClient(uri=_milvus_uri(), token=_milvus_root_token())
+
+            # 1) Delete known main collection if present
+            try:
+                if getattr(self, "collection_name", None):
+                    params = [("collection_names", self.collection_name)]
+                    async with aiohttp.ClientSession() as session:
+                        await session.delete(
+                            f"{self.ingestor_server_url}/v1/collections",
+                            params=params,
+                            headers=headers_admin,
+                        )
+            except Exception:
+                pass
+
+            # 2) Sweep temporary collections created by these tests
+            #    Handle both fixed names and historical suffixed variants.
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.get(
+                        f"{self.ingestor_server_url}/v1/collections",
+                        headers=headers_admin,
+                    ) as resp:
+                        data = await resp.json()
+                        colls = [c.get("collection_name") for c in data.get("collections", [])]
+                        targets_exact = {"auth_it", "auth_rag", "auth_gen"}
+                        targets_prefix = ("auth_it_", "auth_rag_", "auth_gen_")
+                        to_delete = []
+                        for c in colls:
+                            if not isinstance(c, str):
+                                continue
+                            if c in targets_exact or c.startswith(targets_prefix):
+                                to_delete.append(c)
+                        if to_delete:
+                            # Repeat param for each collection
+                            params = [("collection_names", c) for c in to_delete]
+                            await session.delete(
+                                f"{self.ingestor_server_url}/v1/collections",
+                                params=params,
+                                headers=headers_admin,
+                            )
+            except Exception:
+                pass
+
+            # 3) Drop test users (reader, writer) if present; also attempt standard names
+            for attr_user in ("reader_user", "writer_user"):
+                try:
+                    user_val = getattr(self, attr_user, None)
+                    if user_val:
+                        client.drop_user(user_name=user_val)
+                except Exception:
+                    pass
+            for standard_user in ("reader", "writer"):
+                try:
+                    client.drop_user(user_name=standard_user)
+                except Exception:
+                    pass
+
+            # 4) Drop test roles (reader_role, writer_role) if supported; also attempt standard names
+            for attr_role in ("reader_role", "writer_role"):
+                try:
+                    role_val = getattr(self, attr_role, None)
+                    if role_val and hasattr(client, "drop_role"):
+                        client.drop_role(role_name=role_val, force_drop=True)
+                except Exception:
+                    pass
+            for standard_role in ("role_reader", "role_writer"):
+                try:
+                    if hasattr(client, "drop_role"):
+                        client.drop_role(role_name=standard_role, force_drop=True)
+                except Exception:
+                    pass
+
+            self.add_test_result(
+                self.test_cleanup_auth_resources.test_number,
+                self.test_cleanup_auth_resources.test_name,
+                "Cleanup collections, users, and roles created during auth tests.",
+                ["GET /v1/collections", "DELETE /v1/collections"],
+                [],
+                time.time() - start,
+                TestStatus.SUCCESS,
+            )
+            return True
+        except Exception as e:
+            self.add_test_result(
+                self.test_cleanup_auth_resources.test_number,
+                self.test_cleanup_auth_resources.test_name,
+                "Cleanup collections, users, and roles created during auth tests.",
+                ["GET /v1/collections", "DELETE /v1/collections"],
+                [],
+                time.time() - start,
+                TestStatus.FAILURE,
+                str(e),
+            )
+            return False

--- a/tests/integration/test_sequences.yaml
+++ b/tests/integration/test_sequences.yaml
@@ -69,3 +69,10 @@ sequences:
     test_numbers: [61, 62, 63, 64]
     pre_sequence: [65]  # Cleanup collection before VLM generation tests
     post_sequence: [65]  # Cleanup tests after sequence
+
+  milvus_vdb_auth_through_rest_api:
+    name: "Milvus VDB Auth Through REST API Tests"
+    description: "Milvus VDB Auth functionality tests through REST API"
+    test_numbers: [78, 79, 80, 81, 82, 83, 84]
+    pre_sequence: []  # Cleanup collection before Milvus VDB Auth through REST API tests
+    post_sequence: [85]  # Cleanup tests after sequence

--- a/tests/unit/test_ingestor_server/test_ingestor_server.py
+++ b/tests/unit/test_ingestor_server/test_ingestor_server.py
@@ -154,10 +154,10 @@ class MockNvidiaRAGIngestor:
             },
         }
 
-    def get_documents(self, collection_name: str, vdb_endpoint: str):
+    def get_documents(self, collection_name: str, vdb_endpoint: str, vdb_auth_token: str = ""):
         """Mock get_documents method"""
         if self._get_documents_side_effect:
-            return self._get_documents_side_effect(collection_name, vdb_endpoint)
+            return self._get_documents_side_effect(collection_name, vdb_endpoint, vdb_auth_token)
         return {
             "documents": [
                 {
@@ -172,10 +172,10 @@ class MockNvidiaRAGIngestor:
             "message": "Document listing successfully completed.",
         }
 
-    def get_collections(self, vdb_endpoint: str):
+    def get_collections(self, vdb_endpoint: str, vdb_auth_token: str = ""):
         """Mock get_collections method"""
         if self._get_collections_side_effect:
-            return self._get_collections_side_effect(vdb_endpoint)
+            return self._get_collections_side_effect(vdb_endpoint, vdb_auth_token)
         return {
             "collections": [
                 {
@@ -200,6 +200,7 @@ class MockNvidiaRAGIngestor:
         created_by: str = "",
         business_domain: str = "",
         status: str = "Active",
+        vdb_auth_token: str = "",
     ):
         """Mock create_collection method"""
         if self._create_collection_side_effect:
@@ -214,16 +215,17 @@ class MockNvidiaRAGIngestor:
                 created_by,
                 business_domain,
                 status,
+                vdb_auth_token
             )
         return {
             "message": f"Collection {collection_name} created successfully.",
             "collection_name": collection_name,
         }
 
-    def delete_collections(self, vdb_endpoint: str, collection_names: list):
+    def delete_collections(self, vdb_endpoint: str, collection_names: list, vdb_auth_token: str = ""):
         """Mock delete_collections method"""
         if self._delete_collections_side_effect:
-            return self._delete_collections_side_effect(vdb_endpoint, collection_names)
+            return self._delete_collections_side_effect(vdb_endpoint, collection_names, vdb_auth_token)
         # Filter out None values and ensure all items are strings
         valid_collections = [str(name) for name in collection_names if name is not None]
         return {
@@ -240,11 +242,12 @@ class MockNvidiaRAGIngestor:
         collection_name: str,
         vdb_endpoint: str,
         include_upload_path: bool = False,
+        vdb_auth_token: str = "",
     ):
         """Mock delete_documents method"""
         if self._delete_documents_side_effect:
             return self._delete_documents_side_effect(
-                document_names, collection_name, vdb_endpoint, include_upload_path
+                document_names, collection_name, vdb_endpoint, include_upload_path, vdb_auth_token
             )
         return {
             "message": "Files deleted successfully",
@@ -281,7 +284,7 @@ class MockNvidiaRAGIngestor:
         self._status_side_effect = not_found
 
     def return_empty_documents(self):
-        def empty(collection_name, vdb_endpoint):
+        def empty(collection_name, vdb_endpoint, vdb_auth_token=""):
             return {
                 "documents": [],
                 "total_documents": 0,
@@ -291,13 +294,13 @@ class MockNvidiaRAGIngestor:
         self._get_documents_side_effect = empty
 
     def raise_get_documents_error(self):
-        def error(collection_name, vdb_endpoint):
+        def error(collection_name, vdb_endpoint, vdb_auth_token=""):
             raise Exception("Failed to get documents")
 
         self._get_documents_side_effect = error
 
     def return_empty_collections(self):
-        def empty(vdb_endpoint):
+        def empty(vdb_endpoint, vdb_auth_token=""):
             return {
                 "collections": [],
                 "total_collections": 0,
@@ -307,25 +310,25 @@ class MockNvidiaRAGIngestor:
         self._get_collections_side_effect = empty
 
     def raise_get_collections_error(self):
-        def error(vdb_endpoint):
+        def error(vdb_endpoint, vdb_auth_token=""):
             raise Exception("Failed to get collections")
 
         self._get_collections_side_effect = error
 
     def raise_create_collection_error(self):
-        def error(collection_name, vdb_endpoint, embedding_dimension, metadata_schema):
+        def error(collection_name, vdb_endpoint, embedding_dimension, metadata_schema, vdb_auth_token=""):
             raise Exception("Failed to create collection")
 
         self._create_collection_side_effect = error
 
     def raise_delete_collections_error(self):
-        def error(vdb_endpoint, collection_names):
+        def error(vdb_endpoint, collection_names, vdb_auth_token=""):
             raise Exception("Failed to delete collections")
 
         self._delete_collections_side_effect = error
 
     def raise_delete_documents_error(self):
-        def error(document_names, collection_name, vdb_endpoint, include_upload_path):
+        def error(document_names, collection_name, vdb_endpoint, include_upload_path, vdb_auth_token=""):
             raise Exception("Failed to delete documents")
 
         self._delete_documents_side_effect = error

--- a/tests/unit/test_rag_server/test_rag_main_advanced_features.py
+++ b/tests/unit/test_rag_server/test_rag_main_advanced_features.py
@@ -1475,12 +1475,13 @@ class TestNvidiaRAGPrepareVdbOpCoverage:
                     call[1].get('model') == 'test_model' and call[1].get('url') == 'http://embedding.com'
                     for call in mock_get_embedding.call_args_list
                 )
-                # Check _get_vdb_op was called with expected parameters
-                assert mock_get_vdb_op.call_count >= 1
-                assert any(
-                    call[1].get('vdb_endpoint') == 'http://test.com' and call[1].get('embedding_model') == mock_embedding
-                    for call in mock_get_vdb_op.call_args_list
-                )
+                # Allow optional presence of vdb_auth_token in kwargs (default empty string)
+                assert mock_get_vdb_op.call_count == 1
+                _, kwargs = mock_get_vdb_op.call_args
+                assert kwargs["vdb_endpoint"] == "http://test.com"
+                assert kwargs["embedding_model"] == mock_embedding
+                if "vdb_auth_token" in kwargs:
+                    assert kwargs["vdb_auth_token"] in ("", None)
 
 
 class TestNvidiaRAGValidationCoverage:


### PR DESCRIPTION
Adds support to pass a vdb auth token to the ingestion or retrieval APIs. This then makes its way to the Milvus `token` field or Elasticsearch `bearer_auth` field as applicable.

This helps multiple users to have restricted access to their private documents/collections as users without an authorized token for a document/collection won't be able to access it.