### PR TITLE
Changed NvidiaRAGIngestor function names for intuitive tracing

### DIFF
--- a/tests/unit/test_ingestor_server/test_ingestor_library.py
+++ b/tests/unit/test_ingestor_server/test_ingestor_library.py
@@ -108,8 +108,7 @@ class TestNvidiaRAGIngestor:
 
     @pytest.fixture
     def mock_nvingest_upload_doc(self, ingestor):
-        """Mock the __nvingest_upload_doc method."""
-
+        """Mock the __run_nvingest_batched_ingestion method."""
         async def mock_nvingest(*args, **kwargs):
             # Get filepaths from kwargs
             filepaths = kwargs.get("filepaths", [])
@@ -131,9 +130,7 @@ class TestNvidiaRAGIngestor:
             return results, []
 
         with patch.object(
-            ingestor,
-            "_NvidiaRAGIngestor__nvingest_upload_doc",
-            side_effect=mock_nvingest,
+            ingestor, "_NvidiaRAGIngestor__run_nvingest_batched_ingestion", side_effect=mock_nvingest
         ):
             yield
 
@@ -647,12 +644,12 @@ class TestNvidiaRAGIngestor:
             ):
                 with patch.object(
                     ingestor,
-                    "_NvidiaRAGIngestor__nv_ingest_ingestion",
+                    "_NvidiaRAGIngestor__nv_ingest_ingestion_pipeline",
                     new_callable=AsyncMock,
                 ) as mock_ingestion:
                     mock_ingestion.return_value = ([["result"]], [])
 
-                    await ingestor._NvidiaRAGIngestor__nvingest_upload_doc(
+                    await ingestor._NvidiaRAGIngestor__run_nvingest_batched_ingestion(
                         filepaths=filepaths,
                         collection_name="test_collection",
                         vdb_op=ingestor.vdb_op,
@@ -687,12 +684,12 @@ class TestNvidiaRAGIngestor:
             ):
                 with patch.object(
                     ingestor,
-                    "_NvidiaRAGIngestor__nv_ingest_ingestion",
+                    "_NvidiaRAGIngestor__nv_ingest_ingestion_pipeline",
                     new_callable=AsyncMock,
                 ) as mock_ingestion:
                     mock_ingestion.return_value = ([["result"]], [])
 
-                    await ingestor._NvidiaRAGIngestor__nvingest_upload_doc(
+                    await ingestor._NvidiaRAGIngestor__run_nvingest_batched_ingestion(
                         filepaths=filepaths,
                         collection_name="test_collection",
                         vdb_op=ingestor.vdb_op,
@@ -714,12 +711,12 @@ class TestNvidiaRAGIngestor:
             with patch.dict(os.environ, {"ENABLE_NV_INGEST_BATCH_MODE": "false"}):
                 with patch.object(
                     ingestor,
-                    "_NvidiaRAGIngestor__nv_ingest_ingestion",
+                    "_NvidiaRAGIngestor__nv_ingest_ingestion_pipeline",
                     new_callable=AsyncMock,
                 ) as mock_ingestion:
                     mock_ingestion.return_value = ([["result"]], [])
 
-                    await ingestor._NvidiaRAGIngestor__nvingest_upload_doc(
+                    await ingestor._NvidiaRAGIngestor__run_nvingest_batched_ingestion(
                         filepaths=filepaths,
                         collection_name="test_collection",
                         vdb_op=ingestor.vdb_op,
@@ -747,12 +744,12 @@ class TestNvidiaRAGIngestor:
             ):
                 with patch.object(
                     ingestor,
-                    "_NvidiaRAGIngestor__nv_ingest_ingestion",
+                    "_NvidiaRAGIngestor__nv_ingest_ingestion_pipeline",
                     new_callable=AsyncMock,
                 ) as mock_ingestion:
                     mock_ingestion.return_value = ([["result"]], [])
 
-                    await ingestor._NvidiaRAGIngestor__nvingest_upload_doc(
+                    await ingestor._NvidiaRAGIngestor__run_nvingest_batched_ingestion(
                         filepaths=filepaths,
                         collection_name="test_collection",
                         vdb_op=ingestor.vdb_op,
@@ -782,13 +779,13 @@ class TestNvidiaRAGIngestor:
             ):
                 with patch.object(
                     ingestor,
-                    "_NvidiaRAGIngestor__nv_ingest_ingestion",
+                    "_NvidiaRAGIngestor__nv_ingest_ingestion_pipeline",
                     new_callable=AsyncMock,
                 ) as mock_ingestion:
                     mock_ingestion.return_value = ([["result"]], [])
 
                     with pytest.raises(FileNotFoundError, match="File not found"):
-                        await ingestor._NvidiaRAGIngestor__nvingest_upload_doc(
+                        await ingestor._NvidiaRAGIngestor__run_nvingest_batched_ingestion(
                             filepaths=filepaths,
                             collection_name="test_collection",
                             vdb_op=ingestor.vdb_op,

--- a/tests/unit/test_ingestor_server/test_ingestor_main_document_operations.py
+++ b/tests/unit/test_ingestor_server/test_ingestor_main_document_operations.py
@@ -57,7 +57,7 @@ class TestNvidiaRAGIngestorCoverageImprovement:
         ingestor = NvidiaRAGIngestor(mode=Mode.LIBRARY)
 
         with patch.object(ingestor, '_NvidiaRAGIngestor__prepare_vdb_op_and_collection_name', return_value=(mock_vdb_op, "test_collection")):
-            with patch.object(ingestor, '_NvidiaRAGIngestor__ingest_docs', side_effect=Exception("Test exception")):
+            with patch.object(ingestor, '_NvidiaRAGIngestor__run_background_ingest_task', side_effect=Exception("Test exception")):
                 result = await ingestor.upload_documents(
                     filepaths=["test.txt"],
                     collection_name="test_collection",
@@ -93,7 +93,7 @@ class TestNvidiaRAGIngestorCoverageImprovement:
         }]]
         
         with patch.object(ingestor, '_NvidiaRAGIngestor__prepare_vdb_op_and_collection_name') as mock_prepare:
-            with patch.object(ingestor, '_NvidiaRAGIngestor__nvingest_upload_doc', return_value=(mock_results, [])):
+            with patch.object(ingestor, '_NvidiaRAGIngestor__run_nvingest_batched_ingestion', return_value=(mock_results, [])):
                 with patch('os.path.exists', return_value=True):
                     with patch('os.path.isfile', return_value=True):
                         with patch.object(ingestor, 'validate_directory_traversal_attack'):
@@ -422,7 +422,7 @@ class TestNvidiaRAGIngestorCoverageImprovement:
             
             with patch.object(ingestor, '_NvidiaRAGIngestor__prepare_vdb_op_and_collection_name', return_value=(mock_vdb_op, "test_collection")):
                 with patch.object(ingestor, '_validate_custom_metadata', return_value=(True, [])):
-                    with patch.object(ingestor, '_NvidiaRAGIngestor__nvingest_upload_doc', return_value=(mock_results, [])):
+                    with patch.object(ingestor, '_NvidiaRAGIngestor__run_nvingest_batched_ingestion', return_value=(mock_results, [])):
                         # Mock get_documents to return empty list initially (no existing documents)
                         # and then return the uploaded documents after ingestion
                         with patch.object(ingestor, 'get_documents', side_effect=[


### PR DESCRIPTION
### 1. Function Renaming (Main Focus)

Renamed private methods in `NvidiaRAGIngestor` class for better clarity and traceability:

| Old Name | New Name | Purpose |
|----------|----------|---------|
| `__ingest_docs` | `__run_background_ingest_task` | More clearly indicates this method runs background ingestion tasks |
| `__nvingest_upload_doc` | `__run_nvingest_batched_ingestion` | Better describes the batched ingestion process using NV-Ingest |
| `__nv_ingest_ingestion` | `__nv_ingest_ingestion_pipeline` | Clarifies this is the complete NV-Ingest pipeline execution |
| `_perform_file_ext_based_ingestion` | `_perform_file_ext_based_nv_ingest_ingestion` | More explicit about using NV-Ingest for file extension-based processing |
