### PR TITLE
docs: Add blog examples (release-v2.3.0)

### DIFF
--- a/docs/enable-nemotron-thinking.md
+++ b/docs/enable-nemotron-thinking.md
@@ -54,8 +54,16 @@ export LLM_TOP_P=0.95
 Accuracy improvements from enabling reasoning across datasets average approximately 5%, 
 with several cases demonstrating dramatic corrections.
 
-For example, in FinanceBench, the baseline model incorrectly computed Adobe's FY2017 operating cash flow ratio as 2.91. 
+For example, using the [ADOBE_2017_10Kpdf](https://github.com/patronus-ai/financebench/blob/main/pdfs/ADOBE_2017_10K.pdf) from [FinanceBench](https://github.com/patronus-ai/financebench/), 
+and the following question: 
+
+```text
+What is the FY2017 operating cash flow ratio for Adobe? Operating cash flow ratio is defined as: cash from operations / total current liabilities. Round your answer to two decimal places. Please utilize information provided primarily within the balance sheet and the cash flow statement. 
+```
+
+Before enabling reasoning, the baseline model incorrectly computed Adobe's FY2017 operating cash flow ratio as 2.91. 
 After enabling reasoning, the model produced the correct answer (0.83), demonstrating precise contextual understanding. 
+The answer is found on 2 separate pages of the PDF; page 57 and page 61.
 
 The following table shows some approximate accuracy improvements from enabling reasoning across datasets.
 

--- a/docs/query_decomposition.md
+++ b/docs/query_decomposition.md
@@ -26,7 +26,7 @@ Each subquery is processed independently to gather comprehensive context, which 
 
 ## Accuracy Improvement Example
 
-The following example that uses the HotpotQA dataset demonstrates the accuracy improvement from enabling query decomposition.
+The following example that uses the [HotpotQA](https://hotpotqa.github.io/) dataset demonstrates the accuracy improvement from enabling query decomposition.
 
 ```text
 Query: I am thinking of a Ancient Roman City. The city was destroyed by volcanic eruption. The eruption occurred in the year 79 AD. The volcano was a stratovolcano. Where was the session held where it was decided that the city would be named a UNESCO world heritage site?

--- a/docs/vlm.md
+++ b/docs/vlm.md
@@ -91,6 +91,19 @@ Users interact with the system normally - they ask questions and receive respons
 
 The following example that uses the Ragbattle dataset demonstrates the accuracy improvement from enabling VLM.
 
+Using the [Deloitte's Tax transformation trends survey from May 2021](https://www.deloitte.com/content/dam/assets-shared/en_gb/legacy/docs/research/2022/Deloitte-tax-operations-transformation-trends-survey-2021.pdf) 
+and the following question:
+
+```text
+What is the percentage of companies with NextGen ERP systems/Advanced that said the tax team was highly effective in advising the business on emerging compliance issues?
+```
+
+Before enabling VLM, the system answers 38% with an accuracy score of 0.0. 
+After enabling VLM, the system answers 64% with an accuracy score of 1.0. 
+The answer is found on page 21 of the PDF (page 20 of the document).
+
+The following table shows some approximate accuracy improvements from enabling VLM.
+
 | Query                                                                                    | Correct Answer      | Answer Without VLM (Score) | Answer With VLM (Score)   | Reason for Improvement |
 |------------------------------------------------------------------------------------------|---------------------|----------------------------|---------------------------|------------------------|
 | Percentage for "…NextGen ERP system/Advanced" on "Effectiveness of the tax team…" graph. | "64%"               | "38%" (0.0)                | "64%" (1.0)               | Precise reading of a charted percentage. |


### PR DESCRIPTION
Add blog examples to documentation as new sections titled "Accuracy Improvement Example"

- Reasoning
- Query Decomposition
- VLM

Other branches:

- main: #109 
- develop: #110