### PR TITLE
Updated YAML files with page-element-v3 container image

### DIFF
--- a/deploy/compose/nims.yaml
+++ b/deploy/compose/nims.yaml
@@ -121,7 +121,7 @@ services:
     profiles: ["", "rag", "vlm-generation"]
 
   page-elements:
-    image: ${YOLOX_IMAGE:-nvcr.io/nim/nvidia/nemoretriever-page-elements-v2}:${YOLOX_TAG:-1.5.0}
+    image: ${YOLOX_IMAGE:-nvcr.io/nim/nvidia/nemoretriever-page-elements-v3}:${YOLOX_TAG:-1.7.0}
     shm_size: 16gb
     ports:
       - "8000:8000"

--- a/deploy/helm/nim-operator/rag-nimcache.yaml
+++ b/deploy/helm/nim-operator/rag-nimcache.yaml
@@ -24,7 +24,7 @@ metadata:
 spec:
   source:
     ngc:
-      modelPuller: nvcr.io/nim/nvidia/nemoretriever-page-elements-v2:1.5.0
+      modelPuller: nvcr.io/nim/nvidia/nemoretriever-page-elements-v3:1.7.0
       pullSecret: ngc-secret
       authSecret: ngc-api-secret
       model:

--- a/deploy/helm/nim-operator/rag-nimservice-dra.yaml
+++ b/deploy/helm/nim-operator/rag-nimservice-dra.yaml
@@ -69,8 +69,8 @@ metadata:
   name: nemoretriever-page-elements-v2
 spec:
   image:
-    repository: nvcr.io/nim/nvidia/nemoretriever-page-elements-v2
-    tag: 1.5.0
+    repository: nvcr.io/nim/nvidia/nemoretriever-page-elements-v3
+    tag: 1.7.0
     pullPolicy: IfNotPresent
     pullSecrets:
       - ngc-secret

--- a/deploy/helm/nim-operator/rag-nimservice.yaml
+++ b/deploy/helm/nim-operator/rag-nimservice.yaml
@@ -36,8 +36,8 @@ metadata:
   name: nemoretriever-page-elements-v2
 spec:
   image:
-    repository: nvcr.io/nim/nvidia/nemoretriever-page-elements-v2
-    tag: 1.5.0
+    repository: nvcr.io/nim/nvidia/nemoretriever-page-elements-v3
+    tag: 1.7.0
     pullPolicy: IfNotPresent
     pullSecrets:
       - ngc-secret

--- a/deploy/helm/nvidia-blueprint-rag/values.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/values.yaml
@@ -913,8 +913,8 @@ nv-ingest:
     deployed: true
     replicaCount: 1
     image:
-      repository: nvcr.io/nim/nvidia/nemoretriever-page-elements-v2
-      tag: "1.5.0"
+      repository: nvcr.io/nim/nvidia/nemoretriever-page-elements-v3
+      tag: "1.7.0"
     env:
       - name: NIM_HTTP_API_PORT
         value: "8000"

--- a/deploy/workbench/compose.yaml
+++ b/deploy/workbench/compose.yaml
@@ -86,7 +86,7 @@ services:
     profiles: ["local"]
 
   page-elements:
-    image: ${YOLOX_IMAGE:-nvcr.io/nim/nvidia/nemoretriever-page-elements-v2}:${YOLOX_TAG:-1.5.0}
+    image: ${YOLOX_IMAGE:-nvcr.io/nim/nvidia/nemoretriever-page-elements-v3}:${YOLOX_TAG:-1.7.0}
     ports:
       - "8000:8000"
       - "8001:8001"


### PR DESCRIPTION
## Upgrade NeMo Retriever Page Elements from v2 to v3

Updated page-elements container image across all deployment configurations:
- **Image**: `nemoretriever-page-elements-v2:1.5.0` → `nemoretriever-page-elements-v3:1.7.0`
- **Files updated**: Docker Compose, Helm charts, NIM Operator configs, and Workbench deployment files

### ⚠️ Notes
- Page elements v3 doesn't yet have support for API catalog
- Documentation related changes would be followed in subsequent PRs