### PR TITLE
Bug fix to handle incase result element is empty

### DIFF
--- a/src/nvidia_rag/ingestor_server/main.py
+++ b/src/nvidia_rag/ingestor_server/main.py
@@ -685,19 +685,18 @@ class NvidiaRAGIngestor:
             custom_metadata_item.get("filename"): custom_metadata_item.get("metadata")
             for custom_metadata_item in (state_manager.custom_metadata or [])
         }
-        filename_to_result_map = {
-            os.path.basename(
-                result[0].get("metadata").get("source_metadata").get("source_id")
-            ): result
-            for result in results
-        }
+        filename_to_result_map = {}
+        for result in results:
+            if len(result) > 0:
+                filename_to_result_map[os.path.basename(result[0].get("metadata").get("source_metadata").get("source_id"))] = result
+
         # Generate response dictionary
         uploaded_documents = []
         for filepath in filepaths:
             if os.path.basename(filepath) not in failures_filepaths:
                 doc_type_counts, _, total_elements, raw_text_elements_size = (
                     self._get_document_type_counts(
-                        [filename_to_result_map.get(os.path.basename(filepath))]
+                        [filename_to_result_map.get(os.path.basename(filepath), [])]
                     )
                 )
 


### PR DESCRIPTION
## Fix: Handle empty result elements in ingestion response

Prevents `IndexError` when processing documents that produce empty results by adding length check before accessing `result[0]` in filename-to-result mapping.

**Changed:** 
- Added `len(result) > 0` check
- Changed default from `None` to `[]` in `.get()`