### PR TITLE
Remove default NIM_MODEL_PROFILE env var, add manual configuration guide and fixed Embedding url for api endpoints

### DIFF
--- a/deploy/compose/.env
+++ b/deploy/compose/.env
@@ -39,7 +39,7 @@ export YOLOX_TABLE_STRUCTURE_INFER_PROTOCOL=grpc
 # Cloud NIM Endpoints (optional)
 # ==========================
 
-# export APP_EMBEDDINGS_SERVERURL=""
+# export APP_EMBEDDINGS_SERVERURL=https://integrate.api.nvidia.com/v1
 # export APP_LLM_SERVERURL=""
 # export APP_LLM_MODELNAME=nvidia/llama-3.3-nemotron-super-49b-v1.5
 # export APP_FILTEREXPRESSIONGENERATOR_MODELNAME=nvidia/llama-3.3-nemotron-super-49b-v1.5

--- a/deploy/compose/nims.yaml
+++ b/deploy/compose/nims.yaml
@@ -12,8 +12,6 @@ services:
     - "8000"
     environment:
       NGC_API_KEY: ${NGC_API_KEY}
-      # Automatic profile detection
-      NIM_MODEL_PROFILE: ${NIM_MODEL_PROFILE-""}
     ulimits:
       nofile:
         soft: 65536

--- a/deploy/helm/nim-operator/rag-nimservice-dra.yaml
+++ b/deploy/helm/nim-operator/rag-nimservice-dra.yaml
@@ -37,9 +37,6 @@ spec:
       name: nemotron-llama3-49b-super
       profile: ''
     sharedMemorySizeLimit: 16Gi
-  env:
-    - name: NIM_MODEL_PROFILE
-      value: "" # Provide correct profile name here
   replicas: 1
   draResources:
   - claimCreationSpec:

--- a/deploy/helm/nim-operator/rag-nimservice.yaml
+++ b/deploy/helm/nim-operator/rag-nimservice.yaml
@@ -15,9 +15,6 @@ spec:
       name: nemotron-llama3-49b-super
       profile: ''
     sharedMemorySizeLimit: 16Gi
-  env:
-    - name: NIM_MODEL_PROFILE
-      value: "" # Provide correct profile name here
   replicas: 1
   resources:
     limits:

--- a/deploy/helm/nvidia-blueprint-rag/values.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/values.yaml
@@ -635,9 +635,6 @@ nim-llm:
     requests:
       nvidia.com/gpu: 1
 
-  env:
-    - name: NIM_MODEL_PROFILE
-      value: "" # Provide correct profile name here
   model:
     ngcAPIKey: ""
     name: "nvidia/llama-3.3-nemotron-super-49b-v1.5"


### PR DESCRIPTION
## Remove default NIM_MODEL_PROFILE and update configuration docs

### Changes
- Removed default `NIM_MODEL_PROFILE` env var to use automatic profile detection
- Fixed embedding server URL in `.env` template to `https://integrate.api.nvidia.com/v1`
- Added manual profile configuration guide for Docker Compose and Helm deployments