### PR TITLE
Fix tokenizer docker pre-download and formatting

### DIFF
--- a/src/nvidia_rag/ingestor_server/Dockerfile
+++ b/src/nvidia_rag/ingestor_server/Dockerfile
@@ -48,6 +48,18 @@ COPY --from=builder /build/dist/*.whl /workspace/
 RUN WHEEL_NAME=$(ls /workspace/nvidia_rag-*.whl) && \
     uv pip install --no-deps --no-cache-dir "$WHEEL_NAME"
 
+# Pre-download default tokenizer to MODEL_PREDOWNLOAD_PATH
+ARG MODEL_PREDOWNLOAD_PATH=/workspace/models
+ENV MODEL_PREDOWNLOAD_PATH=${MODEL_PREDOWNLOAD_PATH}
+ENV HF_HOME=${MODEL_PREDOWNLOAD_PATH}
+
+# Copy post build triggers script
+COPY ./src/nvidia_rag/ingestor_server/docker/scripts/post_build_triggers.py /workspace/docker/post_build_triggers.py
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    /workspace/.venv/bin/python /workspace/docker/post_build_triggers.py || \
+    echo "Warning: Tokenizer pre-download failed, will download at runtime if internet is available"
+
 # -------- Stage 3: Minimal Runtime Stage --------
 FROM ${BASE_IMAGE_URL}:${BASE_IMAGE_TAG} AS runtime
 
@@ -78,10 +90,17 @@ ENV PATH="/workspace/.venv/bin:$PATH"
 WORKDIR /workspace
 
 # Set environment variables needed for Text splitter
-RUN mkdir /tmp-data/;
+RUN mkdir -p /tmp-data
 RUN chmod 777 -R /tmp-data
 RUN chown 1000:1000 -R /tmp-data
-ENV HF_HOME=/tmp-data
+
+# Set MODEL_PREDOWNLOAD_PATH and HF_HOME
+ARG MODEL_PREDOWNLOAD_PATH=/workspace/models
+ENV MODEL_PREDOWNLOAD_PATH=${MODEL_PREDOWNLOAD_PATH}
+ENV HF_HOME=${MODEL_PREDOWNLOAD_PATH}
+
+# Copy pre-downloaded tokenizer from python-env stage
+COPY --from=python-env ${MODEL_PREDOWNLOAD_PATH} ${MODEL_PREDOWNLOAD_PATH}
 
 WORKDIR /workspace
 

--- a/src/nvidia_rag/ingestor_server/docker/scripts/post_build_triggers.py
+++ b/src/nvidia_rag/ingestor_server/docker/scripts/post_build_triggers.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+from transformers import AutoTokenizer
+
+model_predownload_path = os.environ.get("MODEL_PREDOWNLOAD_PATH")
+if not model_predownload_path:
+    print("Warning: MODEL_PREDOWNLOAD_PATH not set, skipping tokenizer pre-download")
+    sys.exit(0)
+
+tokenizer_path = os.path.join(
+    model_predownload_path, "e5-large-unsupervised/tokenizer/"
+)
+os.makedirs(tokenizer_path, exist_ok=True)
+
+try:
+    tokenizer = AutoTokenizer.from_pretrained("intfloat/e5-large-unsupervised")
+    tokenizer.save_pretrained(tokenizer_path)
+    print(f"Successfully pre-downloaded tokenizer to {tokenizer_path}")
+except Exception as e:
+    print(f"Warning: Failed to pre-download tokenizer: {e}")
+    sys.exit(0)  # Exit with success to allow build to continue


### PR DESCRIPTION
- Add post_build_triggers.py script to pre-download tokenizer during Docker build
- Update Dockerfile to pre-download tokenizer to MODEL_PREDOWNLOAD_PATH
- Update summarization.py to use pre-downloaded tokenizer when available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build process to pre-download and cache tokenizers during image creation.

* **Performance**
  * Faster application startup with pre-cached tokenizers in container images.
  * Enhanced tokenizer loading with automatic fallback to pre-downloaded versions for improved reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->