### PR TITLE
Added support for Video as Audio Ingestion

### DIFF
--- a/docs/audio_ingestion.md
+++ b/docs/audio_ingestion.md
@@ -4,7 +4,7 @@
 -->
 # Enable Audio Ingestion Support for NVIDIA RAG Blueprint
 
-Enabling audio ingestion support allows the [NVIDIA RAG Blueprint](./readme.md) system to process and transcribe audio files (.mp3 and .wav) during document ingestion. This enables better search and retrieval capabilities for audio content in your documents.
+Enabling audio ingestion support allows the [NVIDIA RAG Blueprint](./readme.md) system to process and transcribe audio files (.mp3, .wav, .mp4, .avi, and .mov) during document ingestion. This enables better search and retrieval capabilities for audio content in your documents.
 
 After you have [deployed the blueprint](readme.md#deployment-options-for-rag-blueprint), to enable audio ingestion support, follow these steps:
 
@@ -28,7 +28,7 @@ After you have [deployed the blueprint](readme.md#deployment-options-for-rag-blu
    compose-audio-1                         Up 5 minutes (healthy)
    ```
 
-3. The ingestor-server is already configured to handle audio files. You can now ingest audio files (.mp3 or .wav) using the ingestion API as shown in the [ingestion API usage notebook](../notebooks/ingestion_api_usage.ipynb).
+3. The ingestor-server is already configured to handle audio files. You can now ingest audio files (.mp3, .wav, .mp4, .avi, or .mov) using the ingestion API as shown in the [ingestion API usage notebook](../notebooks/ingestion_api_usage.ipynb).
 
    Example usage with the ingestion API:
    ```python

--- a/frontend/src/components/drawer/UploaderSection.tsx
+++ b/frontend/src/components/drawer/UploaderSection.tsx
@@ -74,7 +74,7 @@ export const UploaderSection = () => {
       <NvidiaUpload
         onFilesChange={handleFilesChange}
         onValidationChange={handleValidationChange}
-        acceptedTypes={['.bmp', '.docx', '.html', '.jpeg', '.json', '.md', '.pdf', '.png', '.pptx', '.sh', '.tiff', '.txt', '.mp3', '.wav']}
+        acceptedTypes={['.bmp', '.docx', '.html', '.jpeg', '.json', '.md', '.pdf', '.png', '.pptx', '.sh', '.tiff', '.txt', '.mp3', '.wav', '.mp4', '.mov', '.avi']}
         maxFileSize={400}
       />
       

--- a/frontend/src/components/files/NvidiaUpload.tsx
+++ b/frontend/src/components/files/NvidiaUpload.tsx
@@ -21,7 +21,7 @@ interface NvidiaUploadProps {
 
 export default function NvidiaUpload({
   onFilesChange,
-  acceptedTypes = ['.bmp', '.docx', '.html', '.jpeg', '.json', '.md', '.pdf', '.png', '.pptx', '.sh', '.tiff', '.txt', '.mp3', '.wav'],
+  acceptedTypes = ['.bmp', '.docx', '.html', '.jpeg', '.json', '.md', '.pdf', '.png', '.pptx', '.sh', '.tiff', '.txt', '.mp3', '.wav', '.mp4', '.mov', '.avi'],
   maxFileSize = 400,
   maxFiles = 100,
   onValidationChange

--- a/frontend/src/components/files/__tests__/NvidiaUpload.test.tsx
+++ b/frontend/src/components/files/__tests__/NvidiaUpload.test.tsx
@@ -69,7 +69,7 @@ describe('NvidiaUpload', () => {
     it('passes default accepted types to FileUploadZone', () => {
       render(<NvidiaUpload />);
       
-      expect(screen.getByText(/\.bmp,.docx,.html,.jpeg,.json,.md,.pdf,.png,.pptx,.sh,.tiff,.txt,.mp3,.wav/)).toBeInTheDocument();
+      expect(screen.getByText(/\.bmp,.docx,.html,.jpeg,.json,.md,.pdf,.png,.pptx,.sh,.tiff,.txt,.mp3,.wav,.mp4,.mov,.avi/)).toBeInTheDocument();
     });
 
     it('passes default max file size to FileUploadZone', () => {

--- a/frontend/src/pages/NewCollection.tsx
+++ b/frontend/src/pages/NewCollection.tsx
@@ -279,7 +279,7 @@ export default function NewCollection() {
             <NvidiaUpload 
               onFilesChange={handleFilesChange}
               onValidationChange={handleValidationChange}
-              acceptedTypes={['.bmp', '.docx', '.html', '.jpeg', '.json', '.md', '.pdf', '.png', '.pptx', '.sh', '.tiff', '.txt', '.mp3', '.wav']}
+              acceptedTypes={['.bmp', '.docx', '.html', '.jpeg', '.json', '.md', '.pdf', '.png', '.pptx', '.sh', '.tiff', '.txt', '.mp3', '.wav', '.mp4', '.mov', '.avi']}
               maxFileSize={400}
             />
           </Stack>

--- a/src/nvidia_rag/ingestor_server/main.py
+++ b/src/nvidia_rag/ingestor_server/main.py
@@ -108,9 +108,7 @@ class Mode(str, Enum):
     SERVER = "server"
 
 
-SUPPORTED_FILE_TYPES = set(_DEFAULT_EXTRACTOR_MAP.keys()) & set(
-    EXTENSION_TO_DOCUMENT_TYPE.keys()
-)
+SUPPORTED_FILE_TYPES = set(EXTENSION_TO_DOCUMENT_TYPE.keys()) - set({"svg", "mkv"})
 
 
 class NvidiaRAGIngestor:


### PR DESCRIPTION
## Added Support for Video as Audio Ingestion

### Summary
Extended audio ingestion to support video formats (.mp4, .avi, .mov) in addition to existing audio formats (.mp3, .wav). The system can now extract and transcribe audio tracks from video files.

### Changes
- Updated `SUPPORTED_FILE_TYPES` logic in `main.py` to include video formats
- Updated documentation to reflect new supported file types
- Excluded only 'svg' and 'mkv' from supported formats

### Files Modified
- `src/nvidia_rag/ingestor_server/main.py` (4 lines changed)
- `docs/audio_ingestion.md` (4 lines changed)