### PR TITLE
validation error streaming fix

### DIFF
--- a/src/nvidia_rag/ingestor_server/docker/scripts/post_build_triggers.py
+++ b/src/nvidia_rag/ingestor_server/docker/scripts/post_build_triggers.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import sys
 


### PR DESCRIPTION
Fix: Make validation errors return streaming responses for consistency

- Update request_validation_exception_handler to return StreamingResponse
  instead of JSONResponse for consistency with generate endpoint
- Update CancelledError handler in generate_answer to use streaming response
- Update 5 tests to handle streaming error responses instead of JSON
- Add copyright/license header to post_build_triggers.py

All error handlers in generate endpoint now consistently return streaming
responses, matching the pattern used throughout the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated error response handling to use streaming format for improved compatibility with server-sent events.

* **Chores**
  * Added SPDX license header to project files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->