### PR TITLE
Embed health url fix, Upgrade tp NV Ingest 26.1.0 RC3, Fix ES errors

### DIFF
--- a/deploy/compose/docker-compose-ingestor-server.yaml
+++ b/deploy/compose/docker-compose-ingestor-server.yaml
@@ -156,7 +156,7 @@ services:
       - "6379:6379"
 
   nv-ingest-ms-runtime:
-    image: nvcr.io/0648981100760671/nv-ingest:26.1.0-RC2
+    image: nvcr.io/0648981100760671/nv-ingest:26.1.0-RC3
     # cpuset: "0-15" # Uncomment to restrict this container to CPU cores 0–15
     volumes:
       - ${DATASET_ROOT:-./data}:/workspace/data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,8 @@ rag = [
 ]
 ingest = [
     # nv-ingest dependencies (required for ingestion operations)
-    "nv-ingest-api==26.1.0rc2",
-    "nv-ingest-client==26.1.0rc2",
+    "nv-ingest-api==26.1.0rc3",
+    "nv-ingest-client==26.1.0rc3",
     "tritonclient==2.57.0",
     # Other ingest dependencies
     "langchain-openai>=0.2,<1.0",
@@ -81,8 +81,8 @@ ingest = [
 ]
 all = [
     # nv-ingest dependencies (required for ingestion operations)
-    "nv-ingest-api==26.1.0rc2",
-    "nv-ingest-client==26.1.0rc2",
+    "nv-ingest-api==26.1.0rc3",
+    "nv-ingest-client==26.1.0rc3",
     "tritonclient==2.57.0",
     # RAG + Ingest dependencies
     "langchain-openai>=0.2,<1.0",

--- a/src/nvidia_rag/ingestor_server/health.py
+++ b/src/nvidia_rag/ingestor_server/health.py
@@ -25,6 +25,7 @@
 import asyncio
 import logging
 import os
+import re
 import time
 from typing import Any, Optional
 from urllib.parse import urlparse
@@ -421,9 +422,17 @@ async def check_all_services_health(
     ):
         embed_url = config.embeddings.server_url
         if not embed_url.startswith(("http://", "https://")):
-            embed_url = f"http://{embed_url}/v1/health/ready"
+            embed_url = f"http://{embed_url}"
+        
+        # Check if version suffix (v1, v2, vN) is already present in the URL
+        has_version = re.search(r'/v\d+(?:/|$)', embed_url)
+        
+        if has_version:
+            # Version already present, just add /health/ready
+            embed_url = f"{embed_url.rstrip('/')}/health/ready"
         else:
-            embed_url = f"{embed_url}/v1/health/ready"
+            # No version present, add /v1/health/ready
+            embed_url = f"{embed_url.rstrip('/')}/v1/health/ready"
 
         # For local services, check health and add model info
         embed_result = await check_service_health(

--- a/src/nvidia_rag/rag_server/health.py
+++ b/src/nvidia_rag/rag_server/health.py
@@ -23,6 +23,7 @@
 import asyncio
 import logging
 import os
+import re
 import time
 from typing import Any
 from urllib.parse import urlparse
@@ -316,9 +317,17 @@ async def check_all_services_health(
     ):
         embed_url = config.embeddings.server_url
         if not embed_url.startswith(("http://", "https://")):
-            embed_url = f"http://{embed_url}/v1/health/ready"
+            embed_url = f"http://{embed_url}"
+        
+        # Check if version suffix (v1, v2, vN) is already present in the URL
+        has_version = re.search(r'/v\d+(?:/|$)', embed_url)
+        
+        if has_version:
+            # Version already present, just add /health/ready
+            embed_url = f"{embed_url.rstrip('/')}/health/ready"
         else:
-            embed_url = f"{embed_url}/v1/health/ready"
+            # No version present, add /v1/health/ready
+            embed_url = f"{embed_url.rstrip('/')}/v1/health/ready"
 
         # For local services, check health and add model info
         embed_result = await check_service_health(

--- a/tests/integration/test_cases/rag_search.py
+++ b/tests/integration/test_cases/rag_search.py
@@ -100,7 +100,7 @@ class RAGSearchModule(BaseTestModule):
     async def test_search_with_citations(self) -> bool:
         """Test /search endpoint and verify citations are returned"""
         payload = {
-            "query": "Tell me about the content of these documents",
+            "query": "Tell me something interesting",
             "reranker_top_k": 2,
             "vdb_top_k": 10,
             "collection_names": [self.collections["with_metadata"]],

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1723,7 +1723,7 @@ wheels = [
 
 [[package]]
 name = "nv-ingest-api"
-version = "26.1.0rc2"
+version = "26.1.0rc3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
@@ -1737,14 +1737,14 @@ dependencies = [
     { name = "tritonclient" },
     { name = "universal-pathlib" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/94/c9/affc0c6727ee9cc6f6b027a596d211ca13417e67dd5d046c675cf273bdf2/nv_ingest_api-26.1.0rc2.tar.gz", hash = "sha256:d6c0d5fd0e6aaf0bc4d492ec5ff3df946bcc801cdd4d042c1ce215142db84933", size = 258541, upload-time = "2025-12-12T01:06:01.336Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/f8/eb37dbf22235c392505598d99ff858bb067b2e1531020df29b7c2de721f2/nv_ingest_api-26.1.0rc3.tar.gz", hash = "sha256:09858be8856350976ac43ce71af1ce8ba2bcb9ec8202711dd4c3ca720d76dff7", size = 259270, upload-time = "2025-12-19T15:10:05.77Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/34/7719f3eee5d3b8221895e349786e8853e358c2220000f79c3580384ffb13/nv_ingest_api-26.1.0rc2-py3-none-any.whl", hash = "sha256:5c83f0f260bd5ad66e25020bb3a8a3b67982ea1a2124b7d782037a889350ad69", size = 356350, upload-time = "2025-12-12T01:05:57.072Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/98/d630522672360d33b0fa057fc289f74a1d4f48f897c5487bea2aeb28f508/nv_ingest_api-26.1.0rc3-py3-none-any.whl", hash = "sha256:ba5d1ca240fecd97c2fe1ffd098787b61763b1be34bb8c90c00c25991cbd45b3", size = 357095, upload-time = "2025-12-19T15:10:03.366Z" },
 ]
 
 [[package]]
 name = "nv-ingest-client"
-version = "26.1.0rc2"
+version = "26.1.0rc3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build" },
@@ -1759,9 +1759,9 @@ dependencies = [
     { name = "setuptools" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/ca/e9c000a1261d802b722a448b9f7999055afab458a5abcdf2ea900a47a917/nv_ingest_client-26.1.0rc2.tar.gz", hash = "sha256:38d0c763cebdb78c11b14979a6c1f0e37fe6c0f7bd9e22da6a03e96a83f2cac9", size = 126406, upload-time = "2025-12-12T01:06:07.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/07/15f864fb408b1b642c9dbedb596f7a100be1227cb97928baa7379d95fb41/nv_ingest_client-26.1.0rc3.tar.gz", hash = "sha256:7753c48e9cc0390166f71745262eb395b323ce69e75fdb32aa2a9274fcf1178e", size = 126548, upload-time = "2025-12-19T15:10:10.611Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/89/6ae1d52440a54fb882834c22ea482abf3bf1bf6e1d9eeee5e4c7cd44dabd/nv_ingest_client-26.1.0rc2-py3-none-any.whl", hash = "sha256:1bf1b6ef7492f9d2c5a79e6af99599f6cc7d9ec836176a642524cef18e5447cd", size = 146803, upload-time = "2025-12-12T01:06:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/57/3169f88c550fa4e74a563d84c34d91032de362a27710cb7ac717d9437ff7/nv_ingest_client-26.1.0rc3-py3-none-any.whl", hash = "sha256:1cff01810db3812f772e498037c1dbb60c8c81a77ac4cf0d9f187e0837cc8bfc", size = 146879, upload-time = "2025-12-19T15:10:07.484Z" },
 ]
 
 [[package]]
@@ -1889,10 +1889,10 @@ requires-dist = [
     { name = "lark", specifier = ">=1.2.2" },
     { name = "mcp", specifier = ">=1.23.1" },
     { name = "minio", specifier = ">=7.2,<8.0" },
-    { name = "nv-ingest-api", marker = "extra == 'all'", specifier = "==26.1.0rc2" },
-    { name = "nv-ingest-api", marker = "extra == 'ingest'", specifier = "==26.1.0rc2" },
-    { name = "nv-ingest-client", marker = "extra == 'all'", specifier = "==26.1.0rc2" },
-    { name = "nv-ingest-client", marker = "extra == 'ingest'", specifier = "==26.1.0rc2" },
+    { name = "nv-ingest-api", marker = "extra == 'all'", specifier = "==26.1.0rc3" },
+    { name = "nv-ingest-api", marker = "extra == 'ingest'", specifier = "==26.1.0rc3" },
+    { name = "nv-ingest-client", marker = "extra == 'all'", specifier = "==26.1.0rc3" },
+    { name = "nv-ingest-client", marker = "extra == 'ingest'", specifier = "==26.1.0rc3" },
     { name = "opentelemetry-api", marker = "extra == 'all'", specifier = ">=1.29,<2.0" },
     { name = "opentelemetry-api", marker = "extra == 'ingest'", specifier = ">=1.29,<2.0" },
     { name = "opentelemetry-api", marker = "extra == 'rag'", specifier = ">=1.29,<2.0" },


### PR DESCRIPTION
## Upgrade to NV Ingest 26.1.0-RC3 & Bug Fixes

### Changes
- **Upgrade**: NV Ingest `26.1.0-RC2` → `26.1.0-RC3`
  - Updated Docker image and Python dependencies

- **Fix**: Embed health URL construction
  - Prevents duplicate version paths in health check URLs (e.g., `/v1/v1/health/ready`)
  - Added regex check to detect existing version suffix

- **Fix**: Elasticsearch VDB error handling
  - Added `ConflictError` exception handling for document info deletion
  - Removed duplicate `super().__init__()` call
  - Improved logging for missing document info

### Impact
Improves stability for embedding service health checks and Elasticsearch operations.