### PR TITLE
Fix functionality of ENABLE_REDIS_BACKEND in Helm

### DIFF
--- a/deploy/compose/docker-compose-ingestor-server.yaml
+++ b/deploy/compose/docker-compose-ingestor-server.yaml
@@ -127,6 +127,7 @@ services:
       REDIS_HOST: ${REDIS_HOST:-redis}
       REDIS_PORT: ${REDIS_PORT:-6379}
       REDIS_DB: ${REDIS_DB:-0}
+      ENABLE_REDIS_BACKEND: ${ENABLE_REDIS_BACKEND:-False}
 
       # Bulk upload to MinIO
       ENABLE_MINIO_BULK_UPLOAD: ${ENABLE_MINIO_BULK_UPLOAD:-True}

--- a/deploy/helm/nvidia-blueprint-rag/values.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/values.yaml
@@ -388,6 +388,7 @@ ingestor-server:
     REDIS_HOST: "rag-redis-master"
     REDIS_PORT: "6379"
     REDIS_DB: "0"
+    ENABLE_REDIS_BACKEND: "False"
 
     # === Bulk upload to MinIO ===
     ENABLE_MINIO_BULK_UPLOAD: "True"

--- a/deploy/workbench/compose.yaml
+++ b/deploy/workbench/compose.yaml
@@ -307,6 +307,7 @@ services:
       REDIS_HOST: ${REDIS_HOST:-redis}
       REDIS_PORT: ${REDIS_PORT:-6379}
       REDIS_DB: ${REDIS_DB:-0}
+      ENABLE_REDIS_BACKEND: ${ENABLE_REDIS_BACKEND:-False}
 
       # Bulk upload to MinIO
       ENABLE_MINIO_BULK_UPLOAD: ${ENABLE_MINIO_BULK_UPLOAD:-True}

--- a/docs/deploy-docker-nvidia-hosted.md
+++ b/docs/deploy-docker-nvidia-hosted.md
@@ -216,6 +216,8 @@ After the first time you deploy the RAG Blueprint successfully, you can consider
 
 - For information about advanced settings, see [Best Practices for Common Settings](accuracy_perf.md).
 
+- For Redis backend configuration, refer to [(Optional) Redis Backend Configuration](deploy-docker-self-hosted.md#optional-redis-backend-configuration).
+
 - To turn on recommended configurations for accuracy optimization, run the following code:
 
    ```bash

--- a/docs/deploy-docker-self-hosted.md
+++ b/docs/deploy-docker-self-hosted.md
@@ -265,6 +265,16 @@ After the first time you deploy the RAG Blueprint successfully, you can consider
 
 - For information about advanced settings, see [Best Practices for Common Settings](accuracy_perf.md).
 
+### (Optional) Redis Backend Configuration
+
+The ingestor server uses Redis for task status tracking. The `ENABLE_REDIS_BACKEND` environment variable controls whether Redis is used (default: `False`). When disabled, task state is stored in-memory.
+
+To enable Redis backend for multi-instance deployments:
+```bash
+export ENABLE_REDIS_BACKEND=True
+docker compose -f deploy/compose/docker-compose-ingestor-server.yaml up -d
+```
+
 - To turn on recommended configurations for accuracy optimized profile set additional configs by running the following code:
 
    ```bash

--- a/docs/deploy-helm-from-repo.md
+++ b/docs/deploy-helm-from-repo.md
@@ -79,6 +79,7 @@ If you are working directly with the source Helm chart, and you want to customiz
     - [Experiment with the Web User Interface](deploy-helm.md#experiment-with-the-web-user-interface)
     - [Change a deployment](deploy-helm.md#change-a-deployment)
     - [Uninstall a deployment](deploy-helm.md#uninstall-a-deployment)
+    - [(Optional) Configure Redis Backend](deploy-helm.md#optional-configure-redis-backend)
     - [(Optional) Enable Persistence](deploy-helm.md#optional-enable-persistence)
     - [Troubleshooting Helm Issues](deploy-helm.md#troubleshooting-helm-issues)
 

--- a/docs/deploy-helm.md
+++ b/docs/deploy-helm.md
@@ -204,6 +204,20 @@ kubectl delete nimcache --all -n rag
 kubectl delete pvc --all -n rag
 ```
 
+## (Optional) Configure Redis Backend
+
+The ingestor server uses Redis for task status tracking. The `ENABLE_REDIS_BACKEND` environment variable controls whether Redis is used (default: `False`). **Redis backend is required when running multiple replicas of the ingestor-server.**
+
+To enable Redis backend in the `values.yaml` file:
+```yaml
+ingestor-server:
+  envVars:
+    ENABLE_REDIS_BACKEND: "True"
+```
+
+Then apply the changes using the [Change a Deployment](#change-a-deployment) procedure.
+
+
 ## (Optional) Enable Persistence
 
 1. Update the ***values.yaml*** file for the persistence that you want. Use the following instructions.


### PR DESCRIPTION
## Description
Fixes the ENABLE_REDIS_BACKEND environment variable functionality in Helm and Docker Compose deployments, and migrates Redis operations from RedisJSON module to standard Redis commands with JSON serialization.

## Changes
Added ENABLE_REDIS_BACKEND env var to Helm values and Docker Compose config (default: False)
Replaced redis.json() commands with standard redis.set()/redis.get() + Python json module
Added null safety checks for Redis operations in task_handler.py

## Checklist
- [X] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [X] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [X] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [X] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Redis backend configuration for task status tracking, controlled by ENABLE_REDIS_BACKEND environment variable (disabled by default).

* **Documentation**
  * Added Redis backend configuration guides for Docker and Helm deployments, with instructions for enabling Redis in multi-instance setups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->