### PR TITLE
docs: Update Release Notes for 2.4.0 (develop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ This modular design ensures efficient query processing, accurate retrieval of in
     - [Llama 3.1 NemoGuard 8B Topic Control NIM](https://build.nvidia.com/nvidia/llama-3_1-nemoguard-8b-topic-control)
     - [Llama-3.1 Nemotron-nano-12b-v2-vl NIM](https://build.nvidia.com/nvidia/nemotron-nano-12b-v2-vl)
     - [NeMo Retriever Parse NIM](https://build.nvidia.com/nvidia/nemoretriever-parse)
-    - [NeMo Retriever OCR NIM](https://build.nvidia.com/nvidia/nemoretriever-ocr) (Early Access)
+    - [NeMo Retriever OCR NIM](https://build.nvidia.com/nvidia/nemoretriever-ocr)
     - [llama-3.2-nemoretriever-1b-vlm-embed-v1](https://build.nvidia.com/nvidia/llama-3_2-nemoretriever-1b-vlm-embed-v1) (Early Access)
 
 

--- a/docs/deploy-docker-self-hosted.md
+++ b/docs/deploy-docker-self-hosted.md
@@ -297,7 +297,7 @@ After the first time you deploy the RAG Blueprint successfully, you can consider
 
 - For improved accuracy, consider enabling reasoning mode. For details, refer to [Enable thinking](./enable-nemotron-thinking.md).
 
-- To use NeMo Retriever OCR (Early Access) instead of Paddle OCR, refer to [NeMo Retriever OCR](nemoretriever-ocr.md).
+- To use NeMo Retriever OCR instead of Paddle OCR, refer to [NeMo Retriever OCR](nemoretriever-ocr.md).
 
 - For advanced users who need direct filesystem access to extraction results, refer to [Ingestor Server Volume Mounting](mount-ingestor-volume.md).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,7 +66,7 @@ After you deploy the RAG blueprint, you can customize it for your use cases.
     - [Custom Metadata Support](custom-metadata.md)
     - [File System Access to Extraction Results](mount-ingestor-volume.md)
     - [Multimodal Embedding Support (Early Access)](vlm-embed.md)
-    - [NeMo Retriever OCR for Enhanced Text Extraction (Early Access)](nemoretriever-ocr.md)
+    - [NeMo Retriever OCR for Enhanced Text Extraction](nemoretriever-ocr.md)
     - [PDF Extraction with Nemotron Parse](nemoretriever-parse-extraction.md)
     - [Text-Only Ingestion](text_only_ingest.md)
 
@@ -193,7 +193,7 @@ After you deploy the RAG blueprint, you can customize it for your use cases.
    Enhanced PDF Extraction <nemoretriever-parse-extraction.md>
    File System Access to Results <mount-ingestor-volume.md>
    Multimodal Embedding Support (Early Access) <vlm-embed.md>
-   NeMo Retriever OCR (Early Access) <nemoretriever-ocr.md>
+   NeMo Retriever OCR <nemoretriever-ocr.md>
    Standalone NV-Ingest <nv-ingest-standalone.md>
    Text-Only Ingestion <text_only_ingest.md>
 ```

--- a/docs/nemoretriever-ocr.md
+++ b/docs/nemoretriever-ocr.md
@@ -2,15 +2,12 @@
   SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
   SPDX-License-Identifier: Apache-2.0
 -->
-# NeMo Retriever OCR Configuration Guide for NVIDIA RAG Blueprint (Early Access)
+# NeMo Retriever OCR Configuration Guide for NVIDIA RAG Blueprint
 
 You can enable NeMO Retriever OCR for your [NVIDIA RAG Blueprint](readme.md). NeMo Retriever OCR is an advanced optical character recognition service that provides enhanced text extraction capabilities for document processing workflows. It serves as a high-performance alternative to the default Paddle OCR service, offering significant improvements in speed and resource efficiency.
 
-For more information about NeMo Retriever OCR, refer to [NeMo Retriever OCR v1 Container](https://build.nvidia.com/nvidia/nemoretriever-ocr-v1).
+For more information about NeMo Retriever OCR, refer to [nemoretriever-ocr-v1](https://build.nvidia.com/nvidia/nemoretriever-ocr-v1/modelcard).
 
-:::{note}
-**Early Access**: Currently, the NeMo Retriever OCR v1 container is in early access preview.
-:::
 
 
 ## Key Benefits of NeMo Retriever OCR
@@ -22,7 +19,7 @@ For more information about NeMo Retriever OCR, refer to [NeMo Retriever OCR v1 C
 - **GPU Requirements**: Check the [NeMo Retriever OCR Support Matrix](https://docs.nvidia.com/nim/ingestion/image-ocr/latest/support-matrix.html) for detailed hardware requirements and supported GPUs
   - **GPU Memory**: Requires approximately **~4.1GB of GPU memory** [Triton server (~2.3GB) + Python backend processes(~1.8GB)] - ensure sufficient GPU memory is available
 - **Quality Variance**: Extraction quality may vary based on image quality and text complexity
-- **Early Access**: Currently in preview - monitor for updates and stability improvements
+
 
 
 ## How to Enable NeMo Retriever OCR

--- a/docs/nvidia-rag-mcp.md
+++ b/docs/nvidia-rag-mcp.md
@@ -455,3 +455,9 @@ python nvidia_rag_mcp/mcp_client.py call \
 - 406 on `/mcp`: For streamable_http, a 406 on GET can still indicate the server is up; use the client list/call commands above.
 - Port conflicts: Free port 8000 before launching (e.g., `fuser -k 8000/tcp` on Linux).
 - Ensure the RAG and Ingestor services are running and reachable at the configured URLs.
+
+
+
+## Related Topics
+
+- [MCP server usage notebook](../notebooks/mcp_server_usage.ipynb)

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -67,7 +67,7 @@ After you deploy the RAG blueprint, you can customize it for your use cases.
     - [Custom Metadata Support](custom-metadata.md)
     - [File System Access to Extraction Results](mount-ingestor-volume.md)
     - [Multimodal Embedding Support (Early Access)](vlm-embed.md)
-    - [NeMo Retriever OCR for Enhanced Text Extraction (Early Access)](nemoretriever-ocr.md)
+    - [NeMo Retriever OCR for Enhanced Text Extraction](nemoretriever-ocr.md)
     - [PDF Extraction with Nemotron Parse](nemoretriever-parse-extraction.md)
     - [Text-Only Ingestion](text_only_ingest.md)
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,254 +8,51 @@ This documentation contains the release notes for [NVIDIA RAG Blueprint](readme.
 
 
 
-<!-- Beginning with version 2.4.0 -->
-<!-- Delete all previous versions from this page -->
-<!-- And populate the Previous Versions section at the end of this page with version 2.3.0 -->
+## Release 2.4.0 (26-02-TBD)
 
-## Release 2.4.0 (TBD)
-This release adds new features to the RAG pipeline for supporting features/functionalities for agents workflows and enhances generations with vlms augmenting multimodal input.
+This release adds new features to the RAG pipeline for supporting agent workflows and enhances generations with VLMs augmenting multimodal input.
 
-### Highlights
+
+### Highlights 
 
 This release contains the following key changes:
-- Summarization enhancements. [Dedicated notebook](../notebooks/summarization.ipynb) available showcasing new features.
+
+- Added support for non-NIM models including OpenAI, models hosted on AWS and Azure, OSS models, and others. Supported through service-specific API keys. For details, refer to [Get an API Key](api-key.md).
+- The RAG Blueprint now uses [nemoretriever-ocr-v1](https://build.nvidia.com/nvidia/nemoretriever-ocr-v1/modelcard) as the default OCR model. For details, refer to [NeMo Retriever OCR Configuration Guide](nemoretriever-ocr.md).
+- The Vision-Language Model (VLM) inference feature now uses the model [nemotron-nano-12b-v2-vl](https://build.nvidia.com/nvidia/nemotron-nano-12b-v2-vl/modelcard). For details, refer to [VLM for Generation](vlm.md).
+- User interface improvements including catalog display, image and text query, and others. For details, refer to [User Interface](user-interface.md).
+- Added ingestion metrics endpoint support with OpenTelemetry (OTEL) for monitoring document uploads, elements ingested, and pages processed. For details, refer to [Observability](observability.md).
+- Support image and text as input query. For details, refer to [Multimodal Query Support](multimodal-query.md).
+- Now support using thinking budget control to keep balance between accuracy and performance. For details, refer to [Enable Reasoning](enable-nemotron-thinking.md).
+- Vector Database enhancements including secure database access. For details, refer to [Milvus Configuration](milvus-configuration.md) and [Elasticsearch Configuration](change-vectordb.md).
+- You can now access RAG functionality from a Model Context Protocol (MCP) server for tool integration. For details, refer to [MCP Server and Client Usage](nvidia-rag-mcp.md).
+- Added OpenAI-compatible search endpoint for integration with OpenAI tools. For details, refer to [API - RAG Server Schema](api-rag.md).
+- Added support for collection-level data catalog, descriptions, and metadata. For details, refer to [Data Catalog](data-catalog.md).
+- Enhanced `/status` endpoint publishing ingestion metrics and status information. For details, refer to the [ingestion notebook](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/notebooks/ingestion_api_usage.ipynb).
+- Multi-turn conversation support is no longer the default for either retrieval or generation stage in the pipeline. Refer to [Multi-Turn Conversation Support](./multiturn.md) for details.
+- Improved document processing and element extraction.
+- Enhancements to RAG library mode including the following. For details, refer to [Use the NVIDIA RAG Blueprint Python Package](python-client.md).
+  - Independent multi-instance support for the RAG Server and the ingestion server
+  - Configuration support through function arguments
+  - Async interface for RAG methods
+  - Compatibility with the [NVIDIA NeMo Agent Toolkit (NAT)](https://github.com/NVIDIA/NeMo-Agent-Toolkit)
+- Summarization enhancements including the following. For details, refer to [Documentation Summarization Customization Guide](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/notebooks/summarization.ipynb).
   - Shallow summarization support
   - Easy model switches and dedicated configurations
   - Ease of prompt changes
-- [Dedicated service specific API keys](./api-key.md#service-specific-api-keys)
-  - Facilitates Non-NIM model support - Support hosted endpoints by openAI, NIM hosted on AWS/AZure, OSS models (e.g. Qwen)
-- Updated VLM model to nemotron-nano-12b-v2-vl for inference
-- Support passing image+text as input query. For details, refer to [Multimodal Query Support](multimodal-query.md).
-  - Added [a new notebook](../notebooks/image_input.ipynb) showcasing this feature.
-- LLM NIM Thinking budget - support using thinking budget control to keep balance between accuracy & performance. For details, refer to [Enable Reasoning](enable-nemotron-thinking.md).
-- Migrated page element NIM to V3 for improved document processing and element extraction
-- Updated NemoRetriever OCR (GA) - Switched to NemoRetriever OCR as the default OCR engine. For details, refer to [NeMo Retriever OCR Configuration Guide](nemoretriever-ocr.md).
-- Vector Database enhancements. For details, refer to [Milvus Configuration](milvus-configuration.md) and [Elasticsearch Configuration](change-vectordb.md).
-  - Milvus authorization support for secure database access
-  - Elasticsearch authorization support for secure database access
-  - Vector DB authentication token support through REST API
-- Interface enhancements
-  - RAG functionality exposed as MCP (Model Context Protocol) server for tool integration. For details, refer to [MCP Server and Client Usage](nvidia-rag-mcp.md) and the [MCP server usage notebook](../notebooks/mcp_server_usage.ipynb).
-  - OpenAI compatible search endpoint for seamless integration with OpenAI tools. For details, refer to [API - RAG Server Schema](api-rag.md).
-  - Collection-level data catalog with support for collection descriptions and metadata. For details, refer to [Data Catalog](data-catalog.md).
-- Observability improvements. For details, refer to [Observability Setup](observability.md).
-  - Ingestion metrics endpoint support with OTEL (OpenTelemetry) for monitoring document uploads, elements ingested, and pages processed
-- Enhanced /status endpoint publishing ingestion metrics and status information in a more granular way. Refer to the [ingestion notebook](../notebooks/ingestion_api_usage.ipynb).
-- RAG library mode enhancements. For details, refer to [Use the NVIDIA RAG Blueprint Python Package](python-client.md) and the [RAG library usage notebook](../notebooks/rag_library_usage.ipynb).
-  - Independent multi-instance support for RAG Server and Ingestor Server
-  - Configuration support through function arguments
-  - Async interface for RAG methods
-  - Dependency compatibility with [NVIDIA NeMo Agent Toolkit (NAT)](https://github.com/NVIDIA/NeMo-Agent-Toolkit)
-- Multiturn at both retrieval and generated stage disabled as default in the pipeline. Refer to [Multiturn Usage](./multiturn.md) for details.
-- UI improvements. For details, refer to [User Interface](user-interface.md).
-  - Collection metadata and information exposed in the UI
-  - Support for collection catalog display
-  - Enhanced support for images+text as part of query input
-  - File level summarization support
-- Technical improvements and migrations
-  - Replaced third party containers with stable releases and versions
-  - Migrated development to GitHub
-  - Migrated to latest NIMs and NvIngest packages
-  - Migrated from bitnami legacy hosted containers
-  - Added comprehensive unit and integration tests to the repository. For details refer [here](./../tests/).
 
-### Fixed Known Issues
-
-The following are the known issues that are fixed in this version:
-
-- Fixed issue in NIM LLM for automatic profile selection.
-
-For the full list of known issues, see [Known Issues](#all-known-issues).
-
-
-## Release 2.3.0 (2025-10-14)
-
-This release adds RTX6000 platform support, adds deployment by using NIM operator, improves vector database pluggability with the blueprint, and other changes.
-
-### Highlights 
-
-This release contains the following key changes:
-
-- You can now deploy the RAG Blueprint on [RTX Pro 6000 Blackwell Server Edition](https://www.nvidia.com/en-us/data-center/rtx-pro-6000-blackwell-server-edition/).
-- Migrated to [`llama-3.3-nemotron-super-49b-v1.5`](https://build.nvidia.com/nvidia/llama-3_3-nemotron-super-49b-v1_5) as the default LLM model.
-- Added support to deploy the helm chart by using NVIDIA NIM operator.
-- Updated all NIMs, NVIDIA Ingest and third party dependencies to latest versions.
-- Refactored to support custom 3rd-party vector database integration in a streamlined manner. For details, refer to [Building Custom Vector Database Operators](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/notebooks/building_rag_vdb_operator.ipynb).
-- Added support for [elasticsearch vector DB as an alternate to milvus](change-vectordb.md).
-- Added opt-in [query decomposition support](query_decomposition.md).
-- Added opt-in [nemoretriever-ocr support](nemoretriever-ocr.md).
-- Added opt-in [VLM embedding support](vlm-embed.md)
-- Custom metadata enhancements including the following. For details, refer to [Advanced Metadata Filtering](custom-metadata.md).
-  - Added support for more data types.
-  - Added opt-in support to generate filters using LLM yielding better accuracy.
-  - Added an interactive notebook that showcases the new features. For details, refer to [Notebooks](notebooks.md).
-- Added dependency check support for ingestor server /health API.
-- Added support for configurable confidence threshold for retrieval from API layer.
-- Added support to store NV-Ingest extraction results [directly from the filesystem](mount-ingestor-volume.md).
-- Logging enhancements
-- Added better latency data reporting for RAG server
-  - API level enhancements for component level latency
-  - Added dedicated Prometheus metric endpoint
-- Added independent script to [showcase batch ingestion](https://github.com/NVIDIA-AI-Blueprints/rag/blob/release-v2.3.0/scripts/README.md)
-- Enabled support for [GPU indexing with CPU search](milvus-configuration.md#gpu-indexing-with-cpu-search)
-  - Exposed `APP_VECTORSTORE_EF` as a configurable parameter
-- Added environment variables to control llm parameters LLM_MAX_TOKENS, LLM_TEMPERATURE and LLM_TOP_P
-- Added notebooks for showcasing RAG evaluation using common metrics. For details, refer to [Notebooks](notebooks.md).
-- Added unit tests and pre-commit hooks for maintaining code quality.
-- Optimized container sizes by removing unnecessary packages and improving security.
-- Refactored the rag-playground code including the following changes. For details, refer to [User Interface](user-interface.md).
-  - Use React end to end. Next.js dependencies were deprecated.
-  - More developer friendly and intuitive look and feel.
-  - The `rag-playground` service is renamed to `rag-frontend`.
-- Refactored helm chart support including the following changes. For details, refer to [Deploy with Helm](deploy-helm.md).
-  - Expanded and reorganized Helm chart configuration, enabling granular control over service components, resource settings, and observability (tracing, metrics).
-  - Introduced ConfigMap and service definitions to facilitate improved application deployment flexibility.
-  - Implemented refined service account and secret management in Helm templates.
-  - Added a new Helm values file for nim-operator to configure LLM model environment and component toggles.
-
-
-### Removed
-- Removed consistency level configuration support for Milvus.
-- Removed `EMBEDDING_NIM_ENDPOINT` and `EMBEDDING_NIM_MODEL_NAME` environment variables for nv-ingest.
-- Removed `ENABLE_MULTITURN` environment variable from rag-server.
-- Removed `ENABLE_NEMOTRON_THINKING` environment variable from rag-server.
 
 
 ### Fixed Known Issues
 
 The following are the known issues that are fixed in this version:
 
-- Fixed support for long audio file ingestion.
-- Fixed support to ingest images without charts/tables.
-- Fixed requirement of rebuilding rag frontend container when LLM model name was changed.
+- Fixed issue in NIM LLM for automatic profile selection. For details, refer to [Model Profiles](model-profiles.md).
 
-For the full list of known issues, see [Known Issues](#all-known-issues).
+For the full list of known issues, refer to [Known Issues](#all-known-issues).
 
 
 
-## Release 2.2.1 (2025-07-22)
-
-This is a minor patch release. 
-This release updates to the latest `nv-ingest-client` version 25.6.3 to fix breaking changes introduced by [pypdfium2](https://github.com/pypdfium2-team/pypdfium2). 
-For details, refer to [NVIDIA NV Ingest 25.6.3](https://github.com/NVIDIA/nv-ingest/releases/tag/25.6.3).
-
-
-
-## Release 2.2.0 (2025-07-08)
-
-This release adds B200 platform support, a native Python API, and major enhancements for multimodal and metadata features. It also improves deployment flexibility and customization across the RAG blueprint.
-
-### Highlights 
-
-This release contains the following key changes:
-
-- You can now deploy the RAG Blueprint on [DGX B200](https://www.nvidia.com/en-us/data-center/dgx-b200/).
-- You can use Multi Instance GPUs to reduce the GPU requirements to 3xH100. For details, refer to [Deploy on Kubernetes with Helm and MIG Support](mig-deployment.md).
-- The RAG Blueprint project now uses `uv` as the package manager.
-- Added support for [NVIDIA AI Workbench](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/deploy/workbench/README.md).
-- Added support for native python API. For details, refer to [Python Client Package](python-client.md).
-- Added support for custom metadata for files and metadata-based filtering. For details, refer to [Advanced Metadata Filtering](custom-metadata.md).
-- Added support for multi collection based retrieval. For details, refer to [Multi-Collection Retrieval](multi-collection-retrieval.md).
-- Added support for .mp3 and .wav files. For details, refer to [Audio Ingestion](audio_ingestion.md).
-- Added support for vision language model-based inferencing for charts and images. For details, refer to [Vision Language Model for Generation](vlm.md).
-- Added support for generating summaries of uploaded files. For details, refer to [Document Summarization](summarization.md).
-- Added support for configurable vector store consistency levels (Bounded/Strong/Session) to optimize retrieval performance and accuracy trade-offs.
-- Added support for non-blocking file upload to the user interface. For details, refer to [User Interface](user-interface.md).
-- Added more efficient error reporting to the user interface for ingestion failures. For details, refer to [User Interface](user-interface.md).
-- Added support for customizing prompts without rebuilding images. For details, refer to [Customize Prompts](prompt-customization.md).
-- Added support to enable infographics, which improves accuracy for documents containing text in image format. For details, refer to [Ingestion and Chunking](accuracy_perf.md#ingestion-and-chunking).
-- Optimized batch mode ingestion support to improve performance for multi-user concurrent file upload. For details, refer to [Advanced Ingestion Batch Mode Optimization](accuracy_perf.md#advanced-ingestion-batch-mode-optimization).
-- Added support for enhanced pdf extraction. For details, refer to [Nemoretriever Parse](nemoretriever-parse-extraction.md).
-- Added support for running CPU-based Milvus. For details, refer to [Milvus Configuration](milvus-configuration.md).
-- Added support for running NV-Ingest as a standalone service for the RAG Blueprint. For more information, refer to [Deploy NV-Ingest Standalone](nv-ingest-standalone.md).
-- Updated the API, including the following changes. For details, refer to [Migration Guide](migration_guide.md).
-  - POST /collections is replaced by POST /collection for `ingestor-server`.
-  - New endpoint GET /summary added for rag-server.
-  - Metadata information available as part of GET /collections and GET /documents API.
-
-
-
-## Release 2.1.0 (2025-05-13)
-
-This release reduces the overall GPU requirement for the deployment of the RAG Blueprint. 
-This release also improves the performance and stability for both Docker- and Helm-based deployments.
-
-### Highlights 
-
-This release contains the following key changes:
-
-- The overall GPU requirement is now reduced to 2xH100 / 3xA100. For details, refer to [Support Matrix](support-matrix.md).
-  - Changed the default LLM model to [llama-3_3-nemotron-super-49b-v1](https://build.nvidia.com/nvidia/llama-3_3-nemotron-super-49b-v1). This reduces overall GPU needed to deploy LLM model to 1xH100 / 2xA100.
-  - Changed the default GPU needed for all other NIMs (ingestion and reranker) to 1xH100 / 1xA100.
-- The Helm chart is now published on the NGC Public registry. For details, refer to [NVIDIA NGC Catalog](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/blueprint/helm-charts/nvidia-blueprint-rag).
-- Helm chart customization is now available for many optional features. For details, refer to [Deploy with Helm](deploy-helm.md).
-- Changed the default chunk size to 512 to reduce LLM context size and in turn reduce RAG server response latency.
-- Exposed config to split PDFs after chunking. You can control this by using the `APP_NVINGEST_ENABLEPDFSPLITTER` environment variable. For details, refer to [Best Practices](accuracy_perf.md).
-- Added batch-based ingestion which can help manage memory usage of `ingestor-server` more effectively. You can control this by using the `ENABLE_NV_INGEST_BATCH_MODE` and `NV_INGEST_FILES_PER_BATCH` variables. For details, refer to [Best Practices](accuracy_perf.md).
-- Removed `extract_options` from API level of `ingestor-server`.
-- Made security and stability improvements.
-- Added non-blocking async support to upload documents API. For details, refer to [Migration Guide](migration_guide.md).
-  - Added a new field `blocking: bool` to control this behavior from the client side. The default is set to `true`. 
-  - Added a new API `/status` to monitor state or completion status of uploaded docs.
-
-
-### Fixed Known Issues
-
-The following are the known issues that are fixed in this version:
-
-- Issues processing very large files have been fixed.
-- Resolved an issue during bulk ingestion where the ingestion job failed if ingestion of a single file failed.
-
-For the full list of known issues, see [Known Issues](#all-known-issues).
-
-
-
-## Release 2.0.0 (2025-03-18)
-
-This release adds support for multimodal documents including the ability to parse PDF, Word, and PowerPoint documents. 
-This release also significantly improves accuracy and performance considerations by refactoring the APIs and architecture. 
-There is also a new developer-friendly user interface.
-
-### Highlights 
-
-This release contains the following key changes:
-
-- The RAG Blueprint now uses two separate microservices to manage ingestion and retrieval/generation.
-- The RAG Blueprint now uses [Retriever Extraction](https://github.com/NVIDIA/nv-ingest) instead of unstructured.io for the ingestion pipeline.
-- Default settings are now configured to achieve a balance between accuracy and perf. For details, refer to [Best Practices](accuracy_perf.md).
-- Added support for observability and telemetry. For details, refer to [Observability](observability.md).
-- Added new react and nodeJS-based user interface to showcase runtime configurations. For details, refer to [User Interface](user-interface.md).
-- Query rewriting now uses a smaller llama3.1-8b-instruct model and is turned off by default. For details, refer to [Multi-Turn Conversation Support](multiturn.md).
-- Added support for the following optional features to improve accuracy and reliability of the pipeline. These are turned off by default. For details, refer to [Best Practices](accuracy_perf.md).
-  - [Self Reflection](self-reflection.md)
-  - [NeMo Guardrails](nemo-guardrails.md)
-  - [Hybrid Search](hybrid_search.md)
-- Support to use conversation history during retrieval for low-latency  multiturn support.
-- Added a deployment-ready notebook intended to run in a [Brev environment](https://console.brev.dev/environment/new). For details, refer to [Notebooks](notebooks.md).
-- Helm charts are now modularized, with separate helm charts provided for each distinct microservice. For details, refer to [Deploy with Helm](deploy-helm.md).
-- The default docker deployment flow now uses on-premises models. Alternatively, you can deploy with Docker and using NVIDIA-Hosted Models. For details, refer to the following:
-  - [Get Started With the NVIDIA RAG Blueprint](deploy-docker-self-hosted.md)
-  - [Deploy with Docker (NVIDIA-Hosted Models)](deploy-docker-nvidia-hosted.md)
-- Made security and stability improvements.
-- Updated the API, including the following changes. For details, refer to [Migration Guide](migration_guide.md).
-  - Support runtime configuration of all common parameters. 
-  - Multimodal citation support.
-  - New dedicated endpoints for deleting collection, creating collections and re-ingestion of documents.
-
-
-
-## Release 1.0.0 (2025-01-15)
-
-This is the initial release of the NVIDIA RAG Blueprint.
-
-
-
-
-
-
-
-<!-- REQUIRED: Add any new know issues in this release -->
-<!-- REQUIRED: Remove any know issues fixed in this release -->
 ## All Known Issues
 
 The following are the known issues for the NVIDIA RAG Blueprint:
@@ -279,10 +76,9 @@ The following are the known issues for the NVIDIA RAG Blueprint:
 
 
 
-<!-- ADD THIS SECTION Starting with version 2.4.0 -->
-<!-- ## Release Notes for Previous Versions -->
-<!--                                        -->
-<!-- | link | link | link | -->
+## Release Notes for Previous Versions
+
+| [2.3.0](https://docs.nvidia.com/rag/2.3.0/release-notes.html) | [2.2.1](https://docs.nvidia.com/rag/2.3.0/release-notes.html#release-2-2-1-2025-07-22) | [2.2.0](https://docs.nvidia.com/rag/2.3.0/release-notes.html#release-2-2-0-2025-07-08) | [2.1.0](https://docs.nvidia.com/rag/2.3.0/release-notes.html#release-2-1-0-2025-05-13) | [2.0.0](https://docs.nvidia.com/rag/2.3.0/release-notes.html#release-2-0-0-2025-03-18) | [1.0.0](https://docs.nvidia.com/rag/2.3.0/release-notes.html#release-1-0-0-2025-01-15) |
 
 
 


### PR DESCRIPTION
Update Release Notes for 2.4.0, removed "Early Access" markers from nemoretriever OCR, et. al.