### PR TITLE
Fix for collection data catalog: Added delete collection info entry

### DIFF
--- a/src/nvidia_rag/utils/vdb/milvus/milvus_vdb.py
+++ b/src/nvidia_rag/utils/vdb/milvus/milvus_vdb.py
@@ -966,6 +966,12 @@ class MilvusVDB(VDBRagIngest):
                 collection_name=collection_name,
                 info_value=info_value,
             )
+        
+            # Delete the existing document info from the collection
+            self._client.delete(
+                collection_name=DEFAULT_DOCUMENT_INFO_COLLECTION,
+                filter=f"info_type == '{info_type}' and collection_name == '{collection_name}' and document_name == '{document_name}'",
+            )
 
         # Add the document info to the collection
         data = {


### PR DESCRIPTION
# Fix Milvus collection document-info catalog: delete before upsert

## Summary

When `add_document_info` runs with `info_type == "collection"`, the code aggregates metadata with `_get_aggregated_document_info` and then inserts into `DEFAULT_DOCUMENT_INFO_COLLECTION`. The previous path did not remove the existing row for that `(info_type, collection_name, document_name)` tuple, which could leave stale or duplicate catalog entries and confuse consumers of the document-info catalog.

This change deletes the matching document-info row **before** inserting the updated aggregated record, so the catalog stays a single consistent row per key for collection-level info.

## Changes

- **`milvus_vdb.py` — `MilvusVDB.add_document_info`:** For `info_type == "collection"`, call `self._client.delete` on `DEFAULT_DOCUMENT_INFO_COLLECTION` with a filter matching `info_type`, `collection_name`, and `document_name`, then proceed with the existing insert.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [X] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [X] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.