### PR TITLE
Documentation for default Elasticsearch VDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ This modular design ensures efficient query processing, accurate retrieval of in
 
 - **RAG Orchestrator Server** – Coordinates interactions between the user, retrievers, vector database, and inference models, ensuring multi-turn and context-aware query handling. This is [LangChain](https://www.langchain.com/)-based.
 
-- **Vector Database (accelerated with NVIDIA cuVS)** – Stores and searches embeddings at scale with GPU-accelerated indexing and retrieval for low-latency performance. **Default: [Elasticsearch](https://www.elastic.co/elasticsearch/vector-database).** **Alternative:** [Milvus](https://milvus.io/) (GPU-accelerated).
+- **Vector Database (accelerated with NVIDIA cuVS)** – Stores and searches embeddings at scale with GPU-accelerated indexing and retrieval for low-latency performance. The default is [Elasticsearch](https://www.elastic.co/elasticsearch/vector-database). Another alternative is [Milvus](https://milvus.io/) (GPU-accelerated).
 
 - **NeMo Retriever Extraction** – A high-performance ingestion microservice for parsing multimodal content. For more information about the ingestion pipeline, see [NeMo Retriever Extraction Overview](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/)
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ This modular design ensures efficient query processing, accurate retrieval of in
 
 - **RAG Orchestrator Server** – Coordinates interactions between the user, retrievers, vector database, and inference models, ensuring multi-turn and context-aware query handling. This is [LangChain](https://www.langchain.com/)-based.
 
-- **Vector Database (accelerated with NVIDIA cuVS)** – Stores and searches embeddings at scale with GPU-accelerated indexing and retrieval for low-latency performance. You can use [Milvus Vector Database](https://milvus.io/) or [Elasticsearch](https://www.elastic.co/elasticsearch/vector-database).
+- **Vector Database (accelerated with NVIDIA cuVS)** – Stores and searches embeddings at scale with GPU-accelerated indexing and retrieval for low-latency performance. **Default: [Elasticsearch](https://www.elastic.co/elasticsearch/vector-database).** **Alternative:** [Milvus](https://milvus.io/) (GPU-accelerated).
 
 - **NeMo Retriever Extraction** – A high-performance ingestion microservice for parsing multimodal content. For more information about the ingestion pipeline, see [NeMo Retriever Extraction Overview](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/)
 

--- a/deploy/helm/nvidia-blueprint-rag/endpoints.md
+++ b/deploy/helm/nvidia-blueprint-rag/endpoints.md
@@ -5,8 +5,8 @@ This document describes the configurable endpoints used by the RAG server and it
 ## Core Service Endpoints
 
 ### Vector Store
-- **APP_VECTORSTORE_URL**: URL for the vector store service (default: "http://milvus:19530")
-- **APP_VECTORSTORE_NAME**: Type of vector store (default: "milvus")
+- **APP_VECTORSTORE_URL**: URL for the vector store service (default: "http://rag-eck-elasticsearch-es-http:9200")
+- **APP_VECTORSTORE_NAME**: Type of vector store (default: "elasticsearch")
 - **APP_VECTORSTORE_SEARCHTYPE**: Type of vector store search (default: "dense")
 
 ### Object Storage

--- a/docs/change-vectordb.md
+++ b/docs/change-vectordb.md
@@ -4,11 +4,11 @@
 -->
 # Vector Database Configuration for NVIDIA RAG Blueprint
 
-The [NVIDIA RAG Blueprint](readme.md) supports multiple vector database backends, including [Elasticsearch](https://www.elastic.co/elasticsearch/vector-database) and [Milvus](https://milvus.io/docs). **Elasticsearch is the default vector database.** Standard deployments use Elasticsearch out of the box—no separate “switch” is required. The RAG and Ingestor servers default to `APP_VECTORSTORE_NAME=elasticsearch` and `APP_VECTORSTORE_URL=http://elasticsearch:9200` in Docker Compose, or to the bundled ECK Elasticsearch HTTP service in Helm.
+[NVIDIA RAG Blueprint](readme.md) is compatible with several vector database backends, including [Elasticsearch](https://www.elastic.co/elasticsearch/vector-database) and [Milvus](https://milvus.io/docs). Elasticsearch is the default option. Standard deployments automatically use Elasticsearch—no manual configuration is required. In both the RAG and Ingestor servers, the defaults are set to `APP_VECTORSTORE_NAME=elasticsearch` and `APP_VECTORSTORE_URL=http://elasticsearch:9200` in Docker Compose, or to the bundled ECK Elasticsearch HTTP service when using Helm.
 
-Milvus is available as an optional secondary backend when you want that stack instead.
+Milvus is available as an optional secondary backend if you prefer to use that stack.
 
-After you have [deployed the blueprint](readme.md#deployment-options-for-rag-blueprint), use this page to configure Elasticsearch (authentication, index settings), use the default Elasticsearch path, switch to Milvus, or integrate a custom vector database.
+After you’ve [deployed the blueprint](readme.md#deployment-options-for-rag-blueprint), use this page to configure Elasticsearch settings (including authentication and index options), work with the default Elasticsearch setup, switch to Milvus, or connect a custom vector database.
 
 :::{tip}
 To navigate this page more easily, click the outline button at the top of the page. ![outline-button](assets/outline-button.png)
@@ -18,11 +18,11 @@ To navigate this page more easily, click the outline button at the top of the pa
 
 Use this section as a map to the topics below.
 
-- **Elasticsearch client (library installs)** – For local development without the pre-built Docker images, install Elasticsearch support with `pip install nvidia_rag[elasticsearch]` or `uv sync --extra elasticsearch`. The Docker images include this dependency by default.
+**Elasticsearch client (library installs)** – For local development without the pre-built Docker images, enable Elasticsearch support by installing nvidia_rag[elasticsearch] using `pip install nvidia_rag[elasticsearch]` or `uv sync --extra elasticsearch`. The Docker images already include this dependency.
 
 - **Changing the backend** – If you switch between vector databases (for example Elasticsearch and Milvus), you must re-upload your documents; data is not migrated automatically.
 
-- **Port** – Elasticsearch listens on port **9200** by default. Ensure it is available or adjust your configuration.
+- **Port** – Elasticsearch listens on port 9200 by default. Ensure it is available or adjust your configuration.
 
 - **Folder permissions (Docker Compose)** – Elasticsearch data is stored under `volumes/elasticsearch`. Create the directory and set ownership if required:
 
@@ -35,7 +35,7 @@ Use this section as a map to the topics below.
    If the Elasticsearch container fails to start due to permission issues, you may optionally use `sudo chmod -R 777 deploy/compose/volumes/elasticsearch/` for broader access.
    :::
 
-- **Authentication** – See [Elasticsearch Authentication](#elasticsearch-authentication) for xpack, API keys, and Helm (ECK) credentials.
+- **Authentication** – Refer to [Elasticsearch Authentication](#elasticsearch-authentication) for xpack, API keys, and Helm (ECK) credentials.
 
 - **Index and search tuning** – Adjust index type, dense or hybrid search, and related behavior with `APP_VECTORSTORE_*` in the RAG and Ingestor compose files or Helm `envVars` (for example `APP_VECTORSTORE_SEARCHTYPE`, `APP_VECTORSTORE_INDEXTYPE`).
 
@@ -132,7 +132,7 @@ If you're using Helm for deployment, Elasticsearch (ECK) is enabled by default. 
         APP_VECTORSTORE_PASSWORD: ""
    ```
 
-2. Ensure Elasticsearch (ECK) is enabled in [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml). This is the default; the following block is the reference configuration:
+Ensure that Elasticsearch (ECK) is enabled in [values.yaml](../deploy/helm/nvidia-blueprint-rag/values.yaml). This is the default setting; use the following block as the reference configuration:
 
    ```yaml
    eck-elasticsearch:
@@ -222,7 +222,7 @@ You should see a response that indicates the cluster status is green or yellow, 
 
 ## Switching to Milvus
 
-Use Milvus when you want the optional Milvus stack instead of Elasticsearch. **You must re-upload your documents** after switching; embeddings stored in Elasticsearch are not migrated to Milvus automatically.
+Use Milvus when you want the optional Milvus stack instead of Elasticsearch. You must re-upload your documents after switching; embeddings stored in Elasticsearch are not migrated to Milvus automatically.
 
 ### Docker Compose
 
@@ -1070,7 +1070,7 @@ Update your [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml) fil
 
 ### Disable Default Vector Database and Add Custom Helm Chart
 
-1. **Disable the chart-managed vector databases you are replacing** in [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml). The defaults deploy Elasticsearch (ECK) and keep Milvus optional via nv-ingest; for a custom Helm chart backend, turn off the bundled backends you no longer need—for example:
+**Disable the chart-managed vector databases you are replacing** in [values.yaml](../deploy/helm/nvidia-blueprint-rag/values.yaml). The default configuration deploys Elasticsearch (ECK) and keeps Milvus optional through nv-ingest; for a custom Helm chart backend, disable any bundled backends you no longer need—for example:
 
    ```yaml
    eck-elasticsearch:

--- a/docs/change-vectordb.md
+++ b/docs/change-vectordb.md
@@ -2,37 +2,29 @@
   SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
   SPDX-License-Identifier: Apache-2.0
 -->
-# Configure Elasticsearch as Your Vector Database for NVIDIA RAG Blueprint
+# Vector Database Configuration for NVIDIA RAG Blueprint
 
-The [NVIDIA RAG Blueprint](readme.md) supports multiple vector database backends including [Milvus](https://milvus.io/docs) and [Elasticsearch](https://www.elastic.co/elasticsearch/vector-database).
-Elasticsearch provides robust search capabilities and can be used as an alternative to Milvus for storing and retrieving document embeddings.
+The [NVIDIA RAG Blueprint](readme.md) supports multiple vector database backends, including [Elasticsearch](https://www.elastic.co/elasticsearch/vector-database) and [Milvus](https://milvus.io/docs). **Elasticsearch is the default vector database.** Standard deployments use Elasticsearch out of the box—no separate “switch” is required. The RAG and Ingestor servers default to `APP_VECTORSTORE_NAME=elasticsearch` and `APP_VECTORSTORE_URL=http://elasticsearch:9200` in Docker Compose, or to the bundled ECK Elasticsearch HTTP service in Helm.
 
-After you have [deployed the blueprint](readme.md#deployment-options-for-rag-blueprint),
-use this documentation to configure Elasticsearch as your vector database.
+Milvus is available as an optional secondary backend when you want that stack instead.
+
+After you have [deployed the blueprint](readme.md#deployment-options-for-rag-blueprint), use this page to configure Elasticsearch (authentication, index settings), use the default Elasticsearch path, switch to Milvus, or integrate a custom vector database.
 
 :::{tip}
 To navigate this page more easily, click the outline button at the top of the page. ![outline-button](assets/outline-button.png)
+:::
 
+## Configuring Elasticsearch
 
-## Prerequisites and Important Considerations Before You Start
+Use this section as a map to the topics below.
 
-The following are some important notes to keep in mind before you switch from Milvus to Elasticsearch.
+- **Elasticsearch client (library installs)** – For local development without the pre-built Docker images, install Elasticsearch support with `pip install nvidia_rag[elasticsearch]` or `uv sync --extra elasticsearch`. The Docker images include this dependency by default.
 
-- **Elasticsearch Dependency** – Elasticsearch support is provided as an optional dependency. For local development, install it with:
-    ```bash
-    pip install nvidia_rag[elasticsearch]
-    ```
-    Or when using uv:
-    ```bash
-    uv sync --extra elasticsearch
-    ```
-    The Docker images already include this dependency by default.
+- **Changing the backend** – If you switch between vector databases (for example Elasticsearch and Milvus), you must re-upload your documents; data is not migrated automatically.
 
-- **Fresh Setup Required** – When you switch from Milvus to Elasticsearch, you need to re-upload your documents. The data stored in Milvus isn't automatically migrated to Elasticsearch.
+- **Port** – Elasticsearch listens on port **9200** by default. Ensure it is available or adjust your configuration.
 
-- **Port Availability** – Elasticsearch runs on port 9200 by default. Ensure this port is available and not in conflict with other services.
-
-- **Folder Permissions** – Elasticsearch data is persisted in the `volumes/elasticsearch` directory. Make sure you create the directory and have appropriate permissions set.
+- **Folder permissions (Docker Compose)** – Elasticsearch data is stored under `volumes/elasticsearch`. Create the directory and set ownership if required:
 
     ```bash
     sudo mkdir -p deploy/compose/volumes/elasticsearch/
@@ -40,21 +32,26 @@ The following are some important notes to keep in mind before you switch from Mi
     ```
 
    :::{note}
-   If the Elasticsearch container fails to start due to permission issues, you may optionally use `sudo chmod -R 777 deploy/compose/volumes/elasticsearch/` for broader access
+   If the Elasticsearch container fails to start due to permission issues, you may optionally use `sudo chmod -R 777 deploy/compose/volumes/elasticsearch/` for broader access.
    :::
 
+- **Authentication** – See [Elasticsearch Authentication](#elasticsearch-authentication) for xpack, API keys, and Helm (ECK) credentials.
 
-## Docker Compose Configuration for Elasticsearch Vector Database
+- **Index and search tuning** – Adjust index type, dense or hybrid search, and related behavior with `APP_VECTORSTORE_*` in the RAG and Ingestor compose files or Helm `envVars` (for example `APP_VECTORSTORE_SEARCHTYPE`, `APP_VECTORSTORE_INDEXTYPE`).
 
-Use the following steps to configure Elasticsearch as your vector database in Docker.
+## Using Elasticsearch (Default)
 
-1. Start the Elasticsearch container.
+The following steps describe the default Elasticsearch deployment for Docker Compose and Helm.
+
+### Docker Compose
+
+1. Start the vector database stack. Elasticsearch is included in the default profile for `vectordb.yaml` (you may pass `--profile elasticsearch` explicitly if you prefer).
 
    ```bash
-   docker compose -f deploy/compose/vectordb.yaml --profile elasticsearch up -d
+   docker compose -f deploy/compose/vectordb.yaml up -d
    ```
 
-2. Set the vector database configuration.
+2. Confirm vector database settings. The compose files for the RAG and Ingestor servers already default to Elasticsearch; set or export these if you need to be explicit:
 
    ```bash
    export APP_VECTORSTORE_URL="http://elasticsearch:9200"
@@ -72,15 +69,15 @@ Use the following steps to configure Elasticsearch as your vector database in Do
 
    Access the RAG UI at `http://<host-ip>:8090`. In the UI, navigate to: Settings > Endpoint Configuration > Vector Database Endpoint → set to `http://elasticsearch:9200`.
 
-## Helm Deployment to Configure Elasticsearch as Vector Database
+### Helm
 
-If you're using Helm for deployment, use the following steps to configure Elasticsearch as your vector database.
+If you're using Helm for deployment, Elasticsearch (ECK) is enabled by default. Use the following steps to align the release with the default vector database.
 
 :::{note}
 **Performance Consideration**: Slow VDB upload is observed in Helm deployments for Elasticsearch (ES). For more details, refer to the [troubleshooting documentation](./troubleshooting.md).
 :::
 
-### Prerequisites
+#### Prerequisites
 
 1. Install the ECK (Elastic Cloud on Kubernetes) operator:
 
@@ -112,11 +109,11 @@ If you're using Helm for deployment, use the following steps to configure Elasti
    kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=elastic-operator -n elastic-system --timeout=300s
    ```
 
-### Configuration Steps
+#### Configuration Steps
 
-1. Configure Elasticsearch as the vector database in [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml).
+1. Confirm Elasticsearch settings in [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml).
 
-   Update both the RAG server and ingestor-server sections:
+   The chart defaults to Elasticsearch; ensure both the RAG server and ingestor-server sections match your ECK service URL and credentials:
 
     ```yaml
     # RAG Server configuration
@@ -135,7 +132,7 @@ If you're using Helm for deployment, use the following steps to configure Elasti
         APP_VECTORSTORE_PASSWORD: ""
    ```
 
-2. Enable Elasticsearch deployment in [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml).
+2. Ensure Elasticsearch (ECK) is enabled in [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml). This is the default; the following block is the reference configuration:
 
    ```yaml
    eck-elasticsearch:
@@ -198,17 +195,16 @@ If you're using Helm for deployment, use the following steps to configure Elasti
 
 7. Access the UI at `http://<host-ip>:3000` and set Settings > Endpoint Configuration > Vector Database Endpoint to `http://rag-eck-elasticsearch-es-http:9200`.
 
-
-## Verify Your Elasticsearch Vector Database Setup
+### Verify Your Elasticsearch Vector Database Setup
 
 After you complete the setup, verify that Elasticsearch is running correctly:
 
-### For Docker Deployment:
+#### For Docker Deployment:
 ```bash
 curl -X GET "localhost:9200/_cluster/health?pretty"
 ```
 
-### For Helm deployments:
+#### For Helm deployments:
 ```bash
 # 1. Get the name of your Elasticsearch pod:
 kubectl get pods -n rag | grep elasticsearch
@@ -223,6 +219,79 @@ curl -X GET "localhost:9200/_cluster/health?pretty"
 ```
 
 You should see a response that indicates the cluster status is green or yellow, confirming that Elasticsearch is operational and ready to store embeddings.
+
+## Switching to Milvus
+
+Use Milvus when you want the optional Milvus stack instead of Elasticsearch. **You must re-upload your documents** after switching; embeddings stored in Elasticsearch are not migrated to Milvus automatically.
+
+### Docker Compose
+
+1. Start the Milvus profile (Milvus, etcd, MinIO, and related services).
+
+   ```bash
+   docker compose -f deploy/compose/vectordb.yaml --profile milvus up -d
+   ```
+
+2. Point the application at Milvus.
+
+   ```bash
+   export APP_VECTORSTORE_NAME="milvus"
+   export APP_VECTORSTORE_URL="http://milvus:19530"
+   ```
+
+3. Relaunch the RAG and ingestion services.
+
+   ```bash
+   docker compose -f deploy/compose/docker-compose-ingestor-server.yaml up -d
+   docker compose -f deploy/compose/docker-compose-rag-server.yaml up -d
+   ```
+
+4. Update the RAG UI configuration.
+
+   Settings > Endpoint Configuration > Vector Database Endpoint → `http://milvus:19530`.
+
+### Helm
+
+Configure [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml) so Milvus is deployed, ECK Elasticsearch is disabled, and both servers use the Milvus endpoint.
+
+1. Set the vector database environment variables on the RAG server and ingestor server:
+
+    ```yaml
+    # RAG Server configuration
+    envVars:
+      APP_VECTORSTORE_URL: "http://milvus:19530"
+      APP_VECTORSTORE_NAME: "milvus"
+      APP_VECTORSTORE_USERNAME: ""
+      APP_VECTORSTORE_PASSWORD: ""
+
+    # Ingestor Server configuration
+    ingestor-server:
+      envVars:
+        APP_VECTORSTORE_URL: "http://milvus:19530"
+        APP_VECTORSTORE_NAME: "milvus"
+        APP_VECTORSTORE_USERNAME: ""
+        APP_VECTORSTORE_PASSWORD: ""
+    ```
+
+2. Disable ECK Elasticsearch and deploy Milvus via nv-ingest:
+
+   ```yaml
+   eck-elasticsearch:
+     enabled: false
+
+   nv-ingest:
+     milvusDeployed: true
+   ```
+
+   Adjust additional `nv-ingest.milvus` settings in [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml) as needed (resources, images, authentication, and so on).
+
+3. Deploy or upgrade the Helm release as described in [Change a Deployment](deploy-helm.md#change-a-deployment).
+
+4. Verify Milvus pods and services, then set the RAG UI vector endpoint to match your Milvus HTTP/gRPC service (commonly `http://milvus:19530` from application pods when using the default `fullnameOverride`).
+
+:::{note}
+Kubernetes DNS names may include your Helm release prefix. Use `kubectl get svc -n rag` to confirm the Milvus service hostname if connections fail.
+:::
 
 ## Elasticsearch Authentication
 
@@ -891,7 +960,7 @@ Follow these steps to add your custom vector database to the NVIDIA RAG servers 
     Or, you may edit the files locally to show your custom value. Search for `APP_VECTORSTORE_NAME` and adjust defaults if desired:
     ```yaml
     # Type of vectordb used to store embedding (supports "milvus", "elasticsearch", or a custom value like "your_custom_vdb")
-    APP_VECTORSTORE_NAME: ${APP_VECTORSTORE_NAME:-"milvus"}
+    APP_VECTORSTORE_NAME: ${APP_VECTORSTORE_NAME:-"elasticsearch"}
     # URL on which vectorstore is hosted
     APP_VECTORSTORE_URL: ${APP_VECTORSTORE_URL:-http://your-custom-vdb:1234}
     ```
@@ -1001,11 +1070,14 @@ Update your [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml) fil
 
 ### Disable Default Vector Database and Add Custom Helm Chart
 
-1. **Disable Milvus in the NeMo Retriever Library configuration:**
+1. **Disable the chart-managed vector databases you are replacing** in [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml). The defaults deploy Elasticsearch (ECK) and keep Milvus optional via nv-ingest; for a custom Helm chart backend, turn off the bundled backends you no longer need—for example:
+
    ```yaml
+   eck-elasticsearch:
+     enabled: false
+
    nv-ingest:
      enabled: true
-     # Disable Milvus deployment
      milvusDeployed: false
      milvus:
        enabled: false

--- a/docs/deploy-docker-nvidia-hosted.md
+++ b/docs/deploy-docker-nvidia-hosted.md
@@ -236,7 +236,7 @@ After the first time you deploy the RAG Blueprint successfully, you can consider
    source deploy/compose/perf_profile.env
    ```
 
-- If you prefer **Milvus** over the default **Elasticsearch** vector database, or need CPU-only Milvus tuning, see [Milvus configuration](milvus-configuration.md) and [Vector database configuration](change-vectordb.md) (section **Switching to Milvus**).
+- If you prefer Milvus over the default Elasticsearch vector database, or need CPU-only Milvus tuning, refer to [Milvus configuration](milvus-configuration.md) and [Vector database configuration](change-vectordb.md#switching-to-milvus) the Switching to Milvus section.
 
 - If you have a requirement to build the NeMo Retriever Library runtime container from source, you can do it by following instructions [here](https://github.com/NVIDIA/NeMo-Retriever).
 

--- a/docs/deploy-docker-nvidia-hosted.md
+++ b/docs/deploy-docker-nvidia-hosted.md
@@ -236,7 +236,7 @@ After the first time you deploy the RAG Blueprint successfully, you can consider
    source deploy/compose/perf_profile.env
    ```
 
-- If you don't have a GPU available, you can switch to CPU-only Milvus by following the instructions in [milvus-configuration.md](./milvus-configuration.md).
+- If you prefer **Milvus** over the default **Elasticsearch** vector database, or need CPU-only Milvus tuning, see [Milvus configuration](milvus-configuration.md) and [Vector database configuration](change-vectordb.md) (section **Switching to Milvus**).
 
 - If you have a requirement to build the NeMo Retriever Library runtime container from source, you can do it by following instructions [here](https://github.com/NVIDIA/NeMo-Retriever).
 

--- a/docs/deploy-docker-self-hosted.md
+++ b/docs/deploy-docker-self-hosted.md
@@ -324,7 +324,7 @@ After the first time you deploy the RAG Blueprint successfully, you can consider
    docker compose -f deploy/compose/docker-compose-*-server.yaml up -d --build
    ```
 
-- By default, **Elasticsearch** is deployed as the vector database (`vectordb.yaml` with the default profile). **Milvus is optional**: start it with `docker compose -f deploy/compose/vectordb.yaml --profile milvus up -d` and set `APP_VECTORSTORE_NAME` / `APP_VECTORSTORE_URL` for Milvus (see [Vector database configuration](change-vectordb.md)). When you use the Milvus profile, Milvus can run GPU-accelerated; choose the GPU ID with the variable below. For all service port mappings and GPU assignments, see [Service Port and GPU Reference](service-port-gpu-reference.md).
+By default, Elasticsearch is deployed as the vector database (`vectordb.yaml` with the default profile). Milvus is optional. You can start Milvus with `docker compose -f deploy/compose/vectordb.yaml --profile milvus up -d` and set `APP_VECTORSTORE_NAME` / `APP_VECTORSTORE_URL` for Milvus (see [Vector database configuration](change-vectordb.md)). When you use the Milvus profile, Milvus can run as GPU-accelerated. Choose the GPU ID using the following variables. For all service port mappings and GPU assignments, refer to [Service Port and GPU Reference](service-port-gpu-reference.md).
 
    ```bash
    VECTORSTORE_GPU_DEVICE_ID=0

--- a/docs/deploy-docker-self-hosted.md
+++ b/docs/deploy-docker-self-hosted.md
@@ -324,7 +324,7 @@ After the first time you deploy the RAG Blueprint successfully, you can consider
    docker compose -f deploy/compose/docker-compose-*-server.yaml up -d --build
    ```
 
-- By default, GPU accelerated Milvus DB is deployed. You can choose the GPU ID to allocate by using the below env variable. For all service port mappings and GPU assignments, see [Service Port and GPU Reference](service-port-gpu-reference.md).
+- By default, **Elasticsearch** is deployed as the vector database (`vectordb.yaml` with the default profile). **Milvus is optional**: start it with `docker compose -f deploy/compose/vectordb.yaml --profile milvus up -d` and set `APP_VECTORSTORE_NAME` / `APP_VECTORSTORE_URL` for Milvus (see [Vector database configuration](change-vectordb.md)). When you use the Milvus profile, Milvus can run GPU-accelerated; choose the GPU ID with the variable below. For all service port mappings and GPU assignments, see [Service Port and GPU Reference](service-port-gpu-reference.md).
 
    ```bash
    VECTORSTORE_GPU_DEVICE_ID=0

--- a/docs/deploy-helm-from-repo.md
+++ b/docs/deploy-helm-from-repo.md
@@ -119,7 +119,7 @@ If you are working directly with the source Helm chart, and you want to customiz
    :::
 
 
-6. Follow the remaining instructions in [Deploy on Kubernetes with Helm](./deploy-helm.md) (including verification examples that reflect the default **Elasticsearch** vector database; optional **Milvus** adds different pods and services—see [Vector database configuration](change-vectordb.md)):
+6. Follow the remaining instructions in [Deploy on Kubernetes with Helm](../deploy-helm.md) (including verification examples that reflect the default Elasticsearch vector database; optional Milvus adds different pods and services—refer to [Vector database configuration](change-vectordb.md)) for more information.
 
     - [Verify a Deployment](deploy-helm.md#verify-a-deployment)
     - [Port-Forwarding to Access Web User Interface](deploy-helm.md#port-forwarding-to-access-web-user-interface)

--- a/docs/deploy-helm-from-repo.md
+++ b/docs/deploy-helm-from-repo.md
@@ -119,7 +119,7 @@ If you are working directly with the source Helm chart, and you want to customiz
    :::
 
 
-6. Follow the remaining instructions in [Deploy on Kubernetes with Helm](../deploy-helm.md) (including verification examples that reflect the default Elasticsearch vector database; optional Milvus adds different pods and services—refer to [Vector database configuration](change-vectordb.md)) for more information.
+6. Follow the remaining instructions in [Deploy on Kubernetes with Helm](./deploy-helm.md) (including verification examples that reflect the default Elasticsearch vector database; optional Milvus adds different pods and services—refer to [Vector database configuration](change-vectordb.md)) for more information.
 
     - [Verify a Deployment](deploy-helm.md#verify-a-deployment)
     - [Port-Forwarding to Access Web User Interface](deploy-helm.md#port-forwarding-to-access-web-user-interface)

--- a/docs/deploy-helm-from-repo.md
+++ b/docs/deploy-helm-from-repo.md
@@ -119,7 +119,7 @@ If you are working directly with the source Helm chart, and you want to customiz
    :::
 
 
-6. Follow the remaining instructions in [Deploy on Kubernetes with Helm](./deploy-helm.md):
+6. Follow the remaining instructions in [Deploy on Kubernetes with Helm](./deploy-helm.md) (including verification examples that reflect the default **Elasticsearch** vector database; optional **Milvus** adds different pods and services—see [Vector database configuration](change-vectordb.md)):
 
     - [Verify a Deployment](deploy-helm.md#verify-a-deployment)
     - [Port-Forwarding to Access Web User Interface](deploy-helm.md#port-forwarding-to-access-web-user-interface)

--- a/docs/deploy-helm.md
+++ b/docs/deploy-helm.md
@@ -138,7 +138,7 @@ To verify a deployment, use the following procedure.
     kubectl get pods -n rag
     ```
 
-    You should see output similar to the following. With the default **Elasticsearch** vector database (ECK), expect pods such as `rag-eck-elasticsearch-es-default-0`. If you enable **Milvus** in [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml), you will also see Milvus and etcd pods—see [Vector database configuration](change-vectordb.md).
+You should see output similar to the following. With the default Elasticsearch vector database (ECK), expect pods such as `rag-eck-elasticsearch-es-default-0`. If you enable Milvus in [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml), you will also see Milvus and etcd pods—refer to [Vector database configuration](change-vectordb.md).
 
    :::{note}
    If some pods remain in `Pending` state after deployment, refer to [PVCs in Pending state (StorageClass issues)](troubleshooting.md#pvcs-in-pending-state-storageclass-issues) in the troubleshooting guide.
@@ -204,7 +204,7 @@ To verify a deployment, use the following procedure.
     kubectl get svc -n rag
     ```
 
-    You should see output similar to the following. The default stack exposes **Elasticsearch** HTTP on a service such as `rag-eck-elasticsearch-es-http` (port 9200). Enabling **Milvus** adds separate services—see [Vector database configuration](change-vectordb.md).
+    You should see output similar to the following. The default stack exposes Elasticsearch HTTP on a service such as `rag-eck-elasticsearch-es-http` (port 9200). Enabling Milvus adds separate services—refer to [Vector database configuration](change-vectordb.md).
 
     ```sh
     NAME                                TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)              AGE

--- a/docs/deploy-helm.md
+++ b/docs/deploy-helm.md
@@ -138,7 +138,7 @@ To verify a deployment, use the following procedure.
     kubectl get pods -n rag
     ```
 
-    You should see output similar to the following.
+    You should see output similar to the following. With the default **Elasticsearch** vector database (ECK), expect pods such as `rag-eck-elasticsearch-es-default-0`. If you enable **Milvus** in [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml), you will also see Milvus and etcd pods—see [Vector database configuration](change-vectordb.md).
 
    :::{note}
    If some pods remain in `Pending` state after deployment, refer to [PVCs in Pending state (StorageClass issues)](troubleshooting.md#pvcs-in-pending-state-storageclass-issues) in the troubleshooting guide.
@@ -147,7 +147,7 @@ To verify a deployment, use the following procedure.
     ```sh
     NAME                                                 READY   STATUS      RESTARTS   AGE
     ingestor-server-6cc886bcdf-6rfwm                     1/1     Running     0          54m
-    milvus-standalone-7dd5db4755-ctqzg                   1/1     Running     0          54m
+    rag-eck-elasticsearch-es-default-0                   1/1     Running     0          54m
     nemotron-embedding-ms-86f75c8f65-dfhd2          1/1     Running     0          39m
     nemotron-graphic-elements-v1-67d9d65bdc-ftbkw   1/1     Running     0          33m
     nemotron-ocr-v1-78f56cddb9-f4852                1/1     Running     0          40m
@@ -156,7 +156,6 @@ To verify a deployment, use the following procedure.
     nemotron-table-structure-v1-696c9f5665-l9sxn    1/1     Running     0          37m
     nim-llm-7cb9bdcc89-hwpkq                             1/1     Running     0          11m
     nim-llm-cache-job-77hpc                              0/1     Completed   0          94s
-    rag-etcd-0                                           1/1     Running     0          54m
     rag-frontend-5db7874b77-49q8f                        1/1     Running     0          54m
     rag-minio-649f6476c-n29b8                            1/1     Running     0          54m
     rag-nv-ingest-6bf4d98866-kbgg7                       1/1     Running     0          54m
@@ -205,12 +204,12 @@ To verify a deployment, use the following procedure.
     kubectl get svc -n rag
     ```
 
-    You should see output similar to the following.
+    You should see output similar to the following. The default stack exposes **Elasticsearch** HTTP on a service such as `rag-eck-elasticsearch-es-http` (port 9200). Enabling **Milvus** adds separate services—see [Vector database configuration](change-vectordb.md).
 
     ```sh
     NAME                                TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)              AGE
     ingestor-server                     ClusterIP   10.107.12.217    <none>        8082/TCP             54m
-    milvus                              ClusterIP   10.99.110.203    <none>        19530/TCP,9091/TCP   54m
+    rag-eck-elasticsearch-es-http       ClusterIP   10.99.110.203    <none>        9200/TCP             54m
     nemotron-embedding-ms          ClusterIP   10.104.99.15     <none>        8000/TCP,8001/TCP    54m
     nemotron-graphic-elements-v1   ClusterIP   10.96.115.45     <none>        8000/TCP,8001/TCP    54m
     nemotron-ocr-v1                ClusterIP   10.100.107.215   <none>        8000/TCP,8001/TCP    54m
@@ -218,8 +217,6 @@ To verify a deployment, use the following procedure.
     nemotron-ranking-ms            ClusterIP   10.96.114.244    <none>        8000/TCP,8001/TCP    54m
     nemotron-table-structure-v1    ClusterIP   10.107.227.139   <none>        8000/TCP,8001/TCP    54m
     nim-llm                             ClusterIP   10.104.60.155    <none>        8000/TCP,8001/TCP    54m
-    rag-etcd                            ClusterIP   10.104.74.116    <none>        2379/TCP,2380/TCP    54m
-    rag-etcd-headless                   ClusterIP   None             <none>        2379/TCP,2380/TCP    54m
     rag-frontend                        NodePort    10.100.190.142   <none>        3000:31473/TCP       54m
     rag-minio                           ClusterIP   10.101.18.143    <none>        9000/TCP             54m
     rag-nv-ingest                       ClusterIP   10.107.186.4     <none>        7670/TCP             54m

--- a/docs/milvus-configuration.md
+++ b/docs/milvus-configuration.md
@@ -5,7 +5,7 @@
 # Milvus Configuration for NVIDIA RAG Blueprint
 
 :::{note}
-Milvus is an optional vector database for the NVIDIA RAG Blueprint. The default VDB is Elasticsearch. Use this guide if you want to switch to Milvus, or if you already use Milvus and need to tune GPU/CPU behavior, endpoints, authentication, or runtime API tokens. For enabling Milvus and wiring `APP_VECTORSTORE_*`, start with [Vector database configuration](change-vectordb#switching-to-milvus.md) the Switching to Milvus section.
+Milvus is an optional vector database for the NVIDIA RAG Blueprint. The default VDB is Elasticsearch. Use this guide if you want to switch to Milvus, or if you already use Milvus and need to tune GPU/CPU behavior, endpoints, authentication, or runtime API tokens. For enabling Milvus and wiring `APP_VECTORSTORE_*`, start with the **Switching to Milvus** section in [Vector database configuration](change-vectordb.md#switching-to-milvus).
 :::
 
 This document describes **optional Milvus-specific** settings. It does not replace the default Elasticsearch path—see [Vector database configuration](change-vectordb.md) for the standard vector database and for switching between backends.

--- a/docs/milvus-configuration.md
+++ b/docs/milvus-configuration.md
@@ -4,16 +4,22 @@
 -->
 # Milvus Configuration for NVIDIA RAG Blueprint
 
-You can configure how Milvus works with your [NVIDIA RAG Blueprint](readme.md).
+:::{note}
+Milvus is an optional vector database for the NVIDIA RAG Blueprint. The default VDB is Elasticsearch. Use this guide if you want to switch to Milvus, or if you already use Milvus and need to tune GPU/CPU behavior, endpoints, authentication, or runtime API tokens. For enabling Milvus and wiring `APP_VECTORSTORE_*`, start with [Vector database configuration](change-vectordb.md) (section **Switching to Milvus**).
+:::
+
+This document describes **optional Milvus-specific** settings. It does not replace the default Elasticsearch path—see [Vector database configuration](change-vectordb.md) for the standard vector database and for switching between backends.
 
 
 ## GPU to CPU Mode Switch
 
-Milvus uses GPU acceleration by default for vector operations. Switch to CPU mode if you encounter:
+When Milvus is running, it uses GPU acceleration by default for vector operations. Switch to CPU mode if you encounter:
 - GPU memory constraints
 - Development without GPU support
 
 ## Docker compose
+
+The commands below use the **`milvus` Compose profile** so the Milvus, etcd, and MinIO services start. Ensure `APP_VECTORSTORE_NAME` and `APP_VECTORSTORE_URL` target Milvus if you have not already switched from Elasticsearch ([Vector database configuration](change-vectordb.md)).
 
 ### Configuration Steps
 
@@ -58,11 +64,11 @@ export APP_VECTORSTORE_ENABLEGPUINDEX=False
 After making the configuration changes and setting environment variables, restart the services:
 
 ```bash
-# 1. Stop existing services
-docker compose -f deploy/compose/vectordb.yaml down
+# 1. Stop existing services (Milvus profile)
+docker compose -f deploy/compose/vectordb.yaml --profile milvus down
 
 # 2. Start Milvus and dependencies
-docker compose -f deploy/compose/vectordb.yaml up -d
+docker compose -f deploy/compose/vectordb.yaml --profile milvus up -d
 
 # 3. Now start the ingestor server
 docker compose -f deploy/compose/docker-compose-ingestor-server.yaml up -d
@@ -78,9 +84,10 @@ To configure Milvus to run in CPU mode when deploying with Helm:
 
         ```yaml
         envVars:
-        APP_VECTORSTORE_ENABLEGPUSEARCH: "False"
+          APP_VECTORSTORE_ENABLEGPUSEARCH: "False"
+
         ingestor-server:
-        envVars:
+          envVars:
             APP_VECTORSTORE_ENABLEGPUSEARCH: "False"
             APP_VECTORSTORE_ENABLEGPUINDEX: "False"
         ```
@@ -136,7 +143,7 @@ Example sequence:
 
 ```bash
 # Start/ensure Milvus is up (GPU image if you want GPU indexing)
-docker compose -f deploy/compose/vectordb.yaml up -d
+docker compose -f deploy/compose/vectordb.yaml --profile milvus up -d
 
 # Set env vars and start the ingestor (GPU indexing + CPU search)
 export APP_VECTORSTORE_ENABLEGPUSEARCH=False
@@ -181,19 +188,19 @@ When `adapt_for_cpu` is in effect, your search requests must supply an `ef` para
 
 ## (Optional) Customize the Milvus Endpoint
 
-To use a custom Milvus endpoint, use the following procedure.
+Use this procedure when the RAG stack should talk to a **Milvus instance you operate separately** (outside the chart’s Milvus subchart), for example a shared cluster or a different namespace.
 
 1. Update the `APP_VECTORSTORE_URL` and `MINIO_ENDPOINT` variables in both the RAG server and the ingestor server sections in [values.yaml](../deploy/helm/nvidia-blueprint-rag/values.yaml). Your changes should look similar to the following.
 
    ```yaml
-   env:
+   envVars:
      # ... existing code ...
      APP_VECTORSTORE_URL: "http://your-custom-milvus-endpoint:19530"
      MINIO_ENDPOINT: "http://your-custom-minio-endpoint:9000"
      # ... existing code ...
 
    ingestor-server:
-     env:
+     envVars:
        # ... existing code ...
        APP_VECTORSTORE_URL: "http://your-custom-milvus-endpoint:19530"
        MINIO_ENDPOINT: "http://your-custom-minio-endpoint:9000"
@@ -206,7 +213,7 @@ To use a custom Milvus endpoint, use the following procedure.
        # ... existing code ...
    ```
 
-2. Disable the Milvus deployment. Set `milvusDeployed: false` in the `nv-ingest.milvusDeployed` section to prevent deploying the default Milvus instance. Your changes should look like the following.
+2. Turn off the **in-chart** Milvus deployment so Helm does not create a second Milvus alongside your external endpoint. Set `nv-ingest.milvusDeployed` to `false`:
 
    ```yaml
     nv-ingest:
@@ -220,13 +227,13 @@ To use a custom Milvus endpoint, use the following procedure.
 
 ## Milvus Authentication
 
-Enable authentication for Milvus to secure your vector database.
+Enable authentication for Milvus to secure the Milvus deployment you use with the blueprint (only applicable when Milvus is your configured vector database).
 
 ### Docker Compose
 
 #### 1. Configure Milvus Authentication
 
-Download the default Milvus configuration file (matching the version used in `deploy/compose/vectordb.yaml`):
+Download the Milvus configuration file from the upstream release (matching the version used in `deploy/compose/vectordb.yaml`):
 ```bash
 wget https://raw.githubusercontent.com/milvus-io/milvus/v2.6.5/configs/milvus.yaml -O deploy/compose/milvus.yaml
 ```
@@ -252,7 +259,7 @@ volumes:
 
 Start Milvus with authentication:
 ```bash
-docker compose -f deploy/compose/vectordb.yaml up -d
+docker compose -f deploy/compose/vectordb.yaml --profile milvus up -d
 ```
 
 Set authentication credentials and start RAG services:
@@ -268,9 +275,9 @@ docker compose -f deploy/compose/docker-compose-rag-server.yaml up -d
 **Set the password before deployment** as it persists in the etcd volume. To change the password after deployment, stop the containers, remove the volumes, and restart:
 
 ```bash
-docker compose -f deploy/compose/vectordb.yaml down
+docker compose -f deploy/compose/vectordb.yaml --profile milvus down
 rm -rf deploy/compose/volumes/milvus deploy/compose/volumes/minio deploy/compose/volumes/etcd
-docker compose -f deploy/compose/vectordb.yaml up -d
+docker compose -f deploy/compose/vectordb.yaml --profile milvus up -d
 ```
 :::
 
@@ -299,7 +306,7 @@ nv-ingest:
 (Optional) For more details on configuring Milvus with Helm, refer to the [Milvus Helm configuration](https://milvus.io/docs/configure-helm.md).
 
 :::{important}
-**Change the password before starting the Helm deployment.** Once the deployment is started, the default password becomes persistent in the etcd volume. To change the password after deployment:
+**Change the password before starting the Helm deployment.** Once the deployment is started, the root password you set becomes persistent in the etcd volume. To change the password after deployment:
 
 1. Uninstall the deployment:
    ```bash
@@ -344,7 +351,9 @@ For detailed HELM deployment instructions, see [Helm Deployment Guide](deploy-he
 
 ## Using VDB Auth Token at Runtime via APIs
 
-NVIDIA RAG Blueprint servers accept a Vector DB (VDB) authentication token via the HTTP `Authorization` header at runtime. This header is forwarded to Milvus for auth-protected operations. This feature assumes you have prior knowledge of creating Milvus users, creating/granting roles, and granting appropriate privileges. Once you have configured users, roles, and privileges in Milvus, you can use these auth tokens in the `Authorization` header to enforce access control.
+When **Milvus** is the active vector database (`APP_VECTORSTORE_NAME=milvus`), NVIDIA RAG Blueprint servers accept a Vector DB (VDB) authentication token via the HTTP `Authorization` header at runtime. This header is forwarded to Milvus for auth-protected operations. If you use **Elasticsearch** as the default VDB, runtime bearer tokens are handled differently—see **Using VDB Auth Token at Runtime via APIs** in [Vector database configuration](change-vectordb.md).
+
+This Milvus flow assumes you already know how to create Milvus users, roles, and privileges. After you configure those in Milvus, you can pass auth tokens in the `Authorization` header to enforce access control.
 
 Access permissions are enforced based on the privileges assigned to each user:
 - **Read operations**: Users without privileges such as `Load`, `Search`, and `Query` will not be able to read data from collections.
@@ -458,7 +467,7 @@ If you encounter GPU_CAGRA errors that cannot be resolved by when switching to C
 
 1. Stop all running services:
    ```bash
-   docker compose -f deploy/compose/vectordb.yaml down
+   docker compose -f deploy/compose/vectordb.yaml --profile milvus down
    docker compose -f deploy/compose/docker-compose-ingestor-server.yaml down
    ```
 
@@ -469,7 +478,7 @@ If you encounter GPU_CAGRA errors that cannot be resolved by when switching to C
 
 3. Restart the services:
    ```bash
-   docker compose -f deploy/compose/vectordb.yaml up -d
+   docker compose -f deploy/compose/vectordb.yaml --profile milvus up -d
    docker compose -f deploy/compose/docker-compose-ingestor-server.yaml up -d
    ```
 
@@ -480,6 +489,7 @@ This will delete all existing vector data, so ensure you have backups if needed.
 
 ## Related Topics
 
+- [Vector database configuration](change-vectordb.md) (Elasticsearch default, switching to Milvus)
 - [NVIDIA RAG Blueprint Documentation](readme.md)
 - [Best Practices for Common Settings](accuracy_perf.md).
 - [RAG Pipeline Debugging Guide](debugging.md)

--- a/docs/milvus-configuration.md
+++ b/docs/milvus-configuration.md
@@ -5,7 +5,7 @@
 # Milvus Configuration for NVIDIA RAG Blueprint
 
 :::{note}
-Milvus is an optional vector database for the NVIDIA RAG Blueprint. The default VDB is Elasticsearch. Use this guide if you want to switch to Milvus, or if you already use Milvus and need to tune GPU/CPU behavior, endpoints, authentication, or runtime API tokens. For enabling Milvus and wiring `APP_VECTORSTORE_*`, start with [Vector database configuration](change-vectordb.md) (section **Switching to Milvus**).
+Milvus is an optional vector database for the NVIDIA RAG Blueprint. The default VDB is Elasticsearch. Use this guide if you want to switch to Milvus, or if you already use Milvus and need to tune GPU/CPU behavior, endpoints, authentication, or runtime API tokens. For enabling Milvus and wiring `APP_VECTORSTORE_*`, start with [Vector database configuration](change-vectordb#switching-to-milvus.md) the Switching to Milvus section.
 :::
 
 This document describes **optional Milvus-specific** settings. It does not replace the default Elasticsearch path—see [Vector database configuration](change-vectordb.md) for the standard vector database and for switching between backends.
@@ -19,7 +19,7 @@ When Milvus is running, it uses GPU acceleration by default for vector operation
 
 ## Docker compose
 
-The commands below use the **`milvus` Compose profile** so the Milvus, etcd, and MinIO services start. Ensure `APP_VECTORSTORE_NAME` and `APP_VECTORSTORE_URL` target Milvus if you have not already switched from Elasticsearch ([Vector database configuration](change-vectordb.md)).
+The commands below use the `milvus` Compose profile so the Milvus, etcd, and MinIO services start. Ensure `APP_VECTORSTORE_NAME` and `APP_VECTORSTORE_URL` target Milvus if you have not already switched from Elasticsearch ([Vector database configuration](change-vectordb.md)).
 
 ### Configuration Steps
 
@@ -188,7 +188,7 @@ When `adapt_for_cpu` is in effect, your search requests must supply an `ef` para
 
 ## (Optional) Customize the Milvus Endpoint
 
-Use this procedure when the RAG stack should talk to a **Milvus instance you operate separately** (outside the chart’s Milvus subchart), for example a shared cluster or a different namespace.
+Use this procedure when the RAG stack should talk to a Milvus instance you operate separately (outside the chart’s Milvus subchart), for example a shared cluster or a different namespace.
 
 1. Update the `APP_VECTORSTORE_URL` and `MINIO_ENDPOINT` variables in both the RAG server and the ingestor server sections in [values.yaml](../deploy/helm/nvidia-blueprint-rag/values.yaml). Your changes should look similar to the following.
 
@@ -213,7 +213,7 @@ Use this procedure when the RAG stack should talk to a **Milvus instance you ope
        # ... existing code ...
    ```
 
-2. Turn off the **in-chart** Milvus deployment so Helm does not create a second Milvus alongside your external endpoint. Set `nv-ingest.milvusDeployed` to `false`:
+2. Turn off the in-chart Milvus deployment so Helm does not create a second Milvus alongside your external endpoint. Set `nv-ingest.milvusDeployed` to `false`:
 
    ```yaml
     nv-ingest:
@@ -306,7 +306,7 @@ nv-ingest:
 (Optional) For more details on configuring Milvus with Helm, refer to the [Milvus Helm configuration](https://milvus.io/docs/configure-helm.md).
 
 :::{important}
-**Change the password before starting the Helm deployment.** Once the deployment is started, the root password you set becomes persistent in the etcd volume. To change the password after deployment:
+Change the password before starting the Helm deployment. Once the deployment is started, the root password you set becomes persistent in the etcd volume. To change the password after deployment:
 
 1. Uninstall the deployment:
    ```bash
@@ -351,7 +351,7 @@ For detailed HELM deployment instructions, see [Helm Deployment Guide](deploy-he
 
 ## Using VDB Auth Token at Runtime via APIs
 
-When **Milvus** is the active vector database (`APP_VECTORSTORE_NAME=milvus`), NVIDIA RAG Blueprint servers accept a Vector DB (VDB) authentication token via the HTTP `Authorization` header at runtime. This header is forwarded to Milvus for auth-protected operations. If you use **Elasticsearch** as the default VDB, runtime bearer tokens are handled differently—see **Using VDB Auth Token at Runtime via APIs** in [Vector database configuration](change-vectordb.md).
+When Milvus is the active vector database (`APP_VECTORSTORE_NAME=milvus`), NVIDIA RAG Blueprint servers accept a Vector DB (VDB) authentication token via the HTTP `Authorization` header at runtime. This header is forwarded to Milvus for auth-protected operations. If you use Elasticsearch as the default VDB, runtime bearer tokens are handled differently—refer to Using VDB Auth Token at Runtime via APIs in [Vector database configuration](change-vectordb.md).
 
 This Milvus flow assumes you already know how to create Milvus users, roles, and privileges. After you configure those in Milvus, you can pass auth tokens in the `Authorization` header to enforce access control.
 

--- a/docs/python-client.md
+++ b/docs/python-client.md
@@ -94,9 +94,11 @@ Launch dependent services and NIMs. For more information, refer to [Docker prere
 
 3. Login to `nvcr.io` to pull dependency containers: `echo "${NGC_API_KEY}" | docker login nvcr.io -u '$oauthtoken' --password-stdin`
 
-### Setup Milvus Vector Database Services
+### Setup Milvus Vector Database Services (optional)
 
-Milvus uses GPU indexing by default. Set the correct GPU ID. For CPU-only mode, refer to [milvus-configuration.md](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/milvus-configuration.md).
+Use this section **only if you opt into Milvus** as the vector database. The default Docker deployment uses **Elasticsearch**; see [Vector database configuration](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/change-vectordb.md). For Milvus-specific tuning (GPU/CPU, auth), see [Milvus configuration](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/milvus-configuration.md).
+
+When Milvus is enabled, it uses GPU indexing by default. Set the correct GPU ID. For CPU-only mode, refer to [milvus-configuration.md](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/milvus-configuration.md).
 
 1. Set the GPU device ID:
 
@@ -104,10 +106,10 @@ Milvus uses GPU indexing by default. Set the correct GPU ID. For CPU-only mode, 
 os.environ["VECTORSTORE_GPU_DEVICE_ID"] = "0"
 ```
 
-2. Start the Milvus vector database:
+2. Start the Milvus vector database (Compose `milvus` profile):
 
 ```bash
-docker compose -f ../deploy/compose/vectordb.yaml up -d
+docker compose -f ../deploy/compose/vectordb.yaml --profile milvus up -d
 ```
 
 ### Setup NIMs
@@ -252,6 +254,10 @@ else:
 ingestor = NvidiaRAGIngestor(config=config_ingestor)
 ```
 
+:::{note}
+The API examples below use **`vdb_endpoint="http://localhost:9200"`**, matching the default **Elasticsearch** vector database. If you use **Milvus** instead, use `http://localhost:19530` (or your Milvus service URL) for every `vdb_endpoint` argument and ensure `APP_VECTORSTORE_*` targets Milvus.
+:::
+
 ### Create a New Collection
 
 ```python
@@ -273,7 +279,7 @@ print(response)
 ### List All Collections
 
 ```python
-response = ingestor.get_collections(vdb_endpoint="http://localhost:19530")
+response = ingestor.get_collections(vdb_endpoint="http://localhost:9200")
 print(response)  
 ```
 
@@ -284,7 +290,7 @@ Upload documents to a collection. To update existing documents, use `update_docu
 ```python
 response = await ingestor.upload_documents(
     collection_name="test_library",
-    vdb_endpoint="http://localhost:19530",
+    vdb_endpoint="http://localhost:9200",
     blocking=False,
     split_options={"chunk_size": 512, "chunk_overlap": 150},
     filepaths=[
@@ -322,7 +328,7 @@ print(response)
 ```python
 response = await ingestor.update_documents(
     collection_name="test_library",
-    vdb_endpoint="http://localhost:19530",
+    vdb_endpoint="http://localhost:9200",
     blocking=False,
     filepaths=["../data/multimodal/woods_frost.docx"],
     generate_summary=False
@@ -336,7 +342,7 @@ print(response)
 ```python
 response = ingestor.get_documents(
     collection_name="test_library",
-    vdb_endpoint="http://localhost:19530",
+    vdb_endpoint="http://localhost:9200",
 )
 print(response)  
 ```
@@ -598,7 +604,7 @@ rag_custom = NvidiaRAG(config=config_rag, prompts="custom_prompts.yaml")
 response = ingestor.delete_documents(
     collection_name="test_library",
     document_names=["../data/multimodal/multimodal_test.pdf"],
-    vdb_endpoint="http://localhost:19530"
+    vdb_endpoint="http://localhost:9200"
 )
 print(response)  
 ```
@@ -606,7 +612,7 @@ print(response)
 ## Delete Collections
 
 ```python
-response = ingestor.delete_collections(vdb_endpoint="http://localhost:19530", collection_names=["test_library"])
+response = ingestor.delete_collections(vdb_endpoint="http://localhost:9200", collection_names=["test_library"])
 print(response)  
 ```
 For more information, refer to [Prompt Customization](prompt-customization.md#prompt-customization-in-python-library-mode).

--- a/docs/python-client.md
+++ b/docs/python-client.md
@@ -96,7 +96,7 @@ Launch dependent services and NIMs. For more information, refer to [Docker prere
 
 ### Setup Milvus Vector Database Services (optional)
 
-Use this section **only if you opt into Milvus** as the vector database. The default Docker deployment uses **Elasticsearch**; see [Vector database configuration](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/change-vectordb.md). For Milvus-specific tuning (GPU/CPU, auth), see [Milvus configuration](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/milvus-configuration.md).
+Use this section only if you opt into Milvus as the vector database. The default Docker deployment uses Elasticsearch. Refer to [Vector database configuration](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/change-vectordb.md) for more information. For Milvus-specific tuning (GPU/CPU, auth), refer to [Milvus configuration](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/milvus-configuration.md).
 
 When Milvus is enabled, it uses GPU indexing by default. Set the correct GPU ID. For CPU-only mode, refer to [milvus-configuration.md](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/milvus-configuration.md).
 
@@ -255,7 +255,7 @@ ingestor = NvidiaRAGIngestor(config=config_ingestor)
 ```
 
 :::{note}
-The API examples below use **`vdb_endpoint="http://localhost:9200"`**, matching the default **Elasticsearch** vector database. If you use **Milvus** instead, use `http://localhost:19530` (or your Milvus service URL) for every `vdb_endpoint` argument and ensure `APP_VECTORSTORE_*` targets Milvus.
+The API examples below use `vdb_endpoint="http://localhost:9200"`, matching the default Elasticsearch vector database. If you use Milvus instead, use the `http://localhost:19530` URL value (or your Milvus service URL) for every `vdb_endpoint` argument and confirm that the `APP_VECTORSTORE_*` value targets Milvus.
 :::
 
 ### Create a New Collection

--- a/docs/service-port-gpu-reference.md
+++ b/docs/service-port-gpu-reference.md
@@ -35,11 +35,11 @@ The following table provides a comprehensive reference of all services, their po
 
 | Service | Container Name | Host Port(s) | Container Port(s) | Default GPU ID | Environment Variable | Notes |
 |---------|---------------|--------------|-------------------|----------------|---------------------|-------|
-| Milvus | `milvus-standalone` | 19530, 9091 | 19530, 9091 | 0 | `VECTORSTORE_GPU_DEVICE_ID` | Vector database |
-| Milvus MinIO | `milvus-minio` | 9010, 9011 | 9010, 9011 | N/A (CPU) | N/A | Object storage |
-| Milvus etcd | `milvus-etcd` | N/A | 2379 | N/A (CPU) | N/A | Metadata storage |
+| Elasticsearch | `elasticsearch` | 9200 | 9200 | N/A (CPU) | N/A | Default |
 | Redis | `compose-redis-1` | 6379 | 6379 | N/A (CPU) | N/A | Task queue |
-| Elasticsearch | `elasticsearch` | 9200 | 9200 | N/A (CPU) | N/A | Profile: elasticsearch |
+| Milvus | `milvus-standalone` | 19530, 9091 | 19530, 9091 | 0 | `VECTORSTORE_GPU_DEVICE_ID` | Vector database (Profile: milvus) |
+| Milvus MinIO | `milvus-minio` | 9010, 9011 | 9010, 9011 | N/A (CPU) | N/A | Object storage (Profile: milvus) |
+| Milvus etcd | `milvus-etcd` | N/A | 2379 | N/A (CPU) | N/A | Metadata storage (Profile: milvus) |
 
 :::{note}
 **Opt-in NIM Services:**

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -72,7 +72,7 @@ To install the RAG Blueprint on Kubernetes, you need one of the following:
 
 The following are requirements and recommendations for the individual components of the RAG Blueprint:
 
-- **Pipeline operation** – 1x L40 GPU or similar recommended. Required if you use Milvus (optional) as the vector database with GPU acceleration. The default Elasticsearch VDB does not require a GPU. If you change the vector backend or enable optional GPU acceleration for vector search, confirm GPU requirements for that configuration.
+- **Pipeline operation** – 1x L40 GPU or similar recommended. This is required if you use Milvus (optional) as the vector database with GPU acceleration. The default Elasticsearch VDB does not require a GPU. If you change the vector backend or enable optional GPU acceleration for vector search, confirm GPU requirements for that configuration.
 - **LLM NIM (nemotron-3-super-120b-a12b)** – Refer to the [Support Matrix](https://docs.nvidia.com/nim/large-language-models/latest/supported-models.html).
 - **Embedding NIM (Llama-3.2-NV-EmbedQA-1B-v2 )** – Refer to the [Support Matrix](https://docs.nvidia.com/nim/nemo-retriever/text-embedding/latest/support-matrix.html#llama-3-2-nv-embedqa-1b-v2).
 - **Reranking NIM (llama-3_2-nv-rerankqa-1b-v2 )**: Refer to the [Support Matrix](https://docs.nvidia.com/nim/nemo-retriever/text-reranking/latest/support-matrix.html#llama-3-2-nv-rerankqa-1b-v2).

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -72,7 +72,7 @@ To install the RAG Blueprint on Kubernetes, you need one of the following:
 
 The following are requirements and recommendations for the individual components of the RAG Blueprint:
 
-- **Pipeline operation** – 1x L40 GPU or similar recommended. This is needed for the Milvus vector database, as GPU acceleration is enabled by default.
+- **Pipeline operation** – 1x L40 GPU or similar recommended. Required if you use Milvus (optional) as the vector database with GPU acceleration. The default Elasticsearch VDB does not require a GPU. If you change the vector backend or enable optional GPU acceleration for vector search, confirm GPU requirements for that configuration.
 - **LLM NIM (nemotron-3-super-120b-a12b)** – Refer to the [Support Matrix](https://docs.nvidia.com/nim/large-language-models/latest/supported-models.html).
 - **Embedding NIM (Llama-3.2-NV-EmbedQA-1B-v2 )** – Refer to the [Support Matrix](https://docs.nvidia.com/nim/nemo-retriever/text-embedding/latest/support-matrix.html#llama-3-2-nv-embedqa-1b-v2).
 - **Reranking NIM (llama-3_2-nv-rerankqa-1b-v2 )**: Refer to the [Support Matrix](https://docs.nvidia.com/nim/nemo-retriever/text-reranking/latest/support-matrix.html#llama-3-2-nv-rerankqa-1b-v2).


### PR DESCRIPTION
# Docs: Elasticsearch as default vector database

## Dependency

This PR is **dependent on** [#468 - Make Elasticsearch as default VDB](https://github.com/NVIDIA-AI-Blueprints/rag/pull/468), which introduces the Elasticsearch-first defaults in code, Compose, Helm, CI, and tests.

## Summary

Updates user-facing documentation so it reflects **Elasticsearch as the default** vector database in the NVIDIA RAG Blueprint. The README now states Elasticsearch as the default and Milvus as an alternative. Helm `endpoints.md` reflects the default `APP_VECTORSTORE_URL` and `APP_VECTORSTORE_NAME` for Elasticsearch (including the ECK service URL where applicable).

`docs/change-vectordb.md` is reframed as general vector DB configuration: Elasticsearch is the standard path, Milvus remains documented as an optional backend, with clearer guidance on client installs, switching backends (re-ingest), ports, volumes, and authentication pointers. Related pages (`deploy-docker-*`, `deploy-helm*.md`, `milvus-configuration.md`, `python-client.md`, `service-port-gpu-reference.md`, `support-matrix.md`) are adjusted for consistent defaults and terminology.

## Changes

- **README.md** — Default VDB called out as Elasticsearch; Milvus as alternative.
- **`deploy/helm/nvidia-blueprint-rag/endpoints.md`** — Default `APP_VECTORSTORE_URL` / `APP_VECTORSTORE_NAME` for Elasticsearch.
- **`docs/change-vectordb.md`** — Title and structure updated for ES-default narrative; Milvus as optional path.
- **Deploy and reference docs** — Aligned with Elasticsearch defaults across Docker and Helm guides, Milvus configuration page, Python client, ports/GPU reference, and support matrix.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [X] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [X] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.