### PR TITLE
Add GCNV data ingestor Helm chart example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ This directory contains example integrations and extensions for NVIDIA RAG.
 | [rag_react_agent](./rag_react_agent/) | Integration with [NeMo Agent Toolkit (NAT)](https://github.com/NVIDIA/NeMo-Agent-Toolkit) providing RAG query and search capabilities for agent workflows | [README](./rag_react_agent/README.md) |
 | [nvidia_rag_mcp](./nvidia_rag_mcp/) | MCP (Model Context Protocol) server and client for exposing NVIDIA RAG capabilities to MCP-compatible applications | [Documentation](../docs/mcp.md) |
 | [rag_event_ingest](./rag_event_ingest/) | Automated document ingestion from object storage (MinIO) via Kafka | [Notebook](../notebooks/rag_event_ingest.ipynb) |
+| [google-cloud-netapp-volumes-data-ingestor](./google-cloud-netapp-volumes-data-ingestor/) | Helm chart for deploying the GCNV data ingestor with PVC-backed storage and configurable runtime settings | [README](./google-cloud-netapp-volumes-data-ingestor/README.md) |
 
 ## rag_react_agent
 
@@ -39,3 +40,11 @@ Components:
 - **data/** - Sample documents for testing
 
 See the [notebook](../notebooks/rag_event_ingest.ipynb) for step-by-step deployment and testing.
+
+## google-cloud-netapp-volumes-data-ingestor
+
+This example packages a GCNV data ingestor deployment as a reusable Helm chart. It is intended for Kubernetes environments where application state and source data are mounted from PVCs, including NetApp Google Cloud NetApp Volumes-backed storage.
+
+The chart supports configurable image settings, PVC creation or reuse, health probes, service exposure, and runtime environment overrides for connecting to an NVIDIA ingestor endpoint.
+
+See the [google-cloud-netapp-volumes-data-ingestor README](./google-cloud-netapp-volumes-data-ingestor/README.md) for prerequisites, installation, and configuration details.

--- a/examples/google-cloud-netapp-volumes-data-ingestor/Chart.yaml
+++ b/examples/google-cloud-netapp-volumes-data-ingestor/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: gcnv-data-ingestor
+description: Public Helm chart for the GCNV data ingestor deployment
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/examples/google-cloud-netapp-volumes-data-ingestor/README.md
+++ b/examples/google-cloud-netapp-volumes-data-ingestor/README.md
@@ -1,0 +1,178 @@
+# Google Cloud NetApp Volumes (GCNV) Data Ingestor Helm Chart
+
+This chart packages the deployment of the GCNV Data Ingestor that integrates with the NVIDIA Foundational RAG pipeline into a reusable Helm chart at `examples/google-cloud-netapp-volumes-data-ingestor`.
+
+Create or target the namespace externally with `--namespace ... --create-namespace`. Chart-managed namespace creation is intentionally not supported because Helm cannot reliably create the release namespace from within the same chart.
+
+## Prerequisites
+
+Before installing this chart, make sure the cluster can provision or expose the required PVCs from NetApp Google Cloud NetApp Volumes (GCNV).
+
+1. Install and configure NetApp Trident in the target cluster.
+2. Create or use a Trident `StorageClass` that maps to your GCNV backend.
+3. Decide how you want the chart to get storage:
+   - Let the chart create PVCs by setting `appData.storageClassName` and `sourceData.storageClassName` to Trident-backed classes.
+   - Or create the PVCs ahead of time with Trident and set `appData.create=false`, `appData.existingClaim=<claim>`, `sourceData.create=false`, and `sourceData.existingClaim=<claim>`.
+   - If you set `create=false`, the matching `existingClaim` is required.
+4. Make sure the Docker Hub image and tag you want to deploy are available.
+5. If the Docker Hub repository is private, create an image pull secret in the target namespace and set `image.pullSecrets`.
+
+## Chart Layout
+
+```text
+examples/google-cloud-netapp-volumes-data-ingestor/
+├── Chart.yaml
+├── values.yaml
+├── values.schema.json
+├── README.md
+└── templates/
+    ├── _helpers.tpl
+    ├── deployment.yaml
+    ├── pvc.yaml
+    ├── service.yaml
+    ├── validate.yaml
+    └── serviceaccount.yaml
+```
+
+## Important Values
+
+Update these values before install:
+
+- `image.repository`: set to your Docker Hub image path
+- `image.tag`: set to the image tag you want to deploy
+- `appData.storageClassName`: set to your Trident-backed app PVC class when the chart creates the PVC
+- `appData.size`: app PVC size request, defaults to `50Gi`
+- `appData.existingClaim`: use an already-created PVC instead of letting the chart create one; required when `appData.create=false`
+- `sourceData.storageClassName`: set to your Trident-backed GCNV source PVC class when the chart creates the PVC
+- `sourceData.size`: source PVC size request, defaults to `200Gi`
+- `sourceData.existingClaim`: use an already-created source PVC instead of letting the chart create one; required when `sourceData.create=false`
+- `env.nvIngestEndpoint`: set to the reachable NVIDIA ingestor-server `/v1` base URL
+
+The chart validates required values during `helm lint`, `helm template`, `helm install`, and `helm upgrade`.
+
+## Install
+
+You can either edit `values.yaml` directly or use an override file.
+
+Example override file:
+
+```yaml
+image:
+  repository: docker.io/acme/netapp_volumes_rag_ingestor
+  tag: "REPLACE_WITH_REAL_TAG"
+
+appData:
+  storageClassName: trident-app
+
+sourceData:
+  storageClassName: trident-gcnv
+
+env:
+  nvIngestEndpoint: http://YOUR_INGESTOR_SERVER:8082/v1
+```
+
+Install with:
+
+```bash
+helm install gcnv-data-ingestor ./examples/google-cloud-netapp-volumes-data-ingestor \
+  --namespace gcnv-data-ingestor \
+  --create-namespace \
+  -f my-values.yaml
+```
+
+If your Docker Hub repository is private, add an image pull secret. `image.pullSecrets` must be a YAML list of secret names:
+
+```yaml
+image:
+  pullSecrets:
+    - dockerhub-secret
+```
+
+## Common Overrides
+
+Resize the chart-managed PVCs:
+
+```yaml
+appData:
+  size: 100Gi
+  storageClassName: trident-app
+
+sourceData:
+  size: 500Gi
+  storageClassName: trident-gcnv
+```
+
+## Use Existing PVCs
+
+If Trident or another workflow already created the claims you want to mount, use overrides like this:
+
+```yaml
+appData:
+  create: false
+  existingClaim: gcnv-ingestor-config-data
+
+sourceData:
+  create: false
+  existingClaim: gcnv-data-for-rag
+```
+
+The chart will mount those existing claims into the Pod instead of creating new PVCs.
+
+If you set `create: false` and leave `existingClaim` empty, the chart now fails fast during Helm validation instead of creating a broken release.
+
+Expose the service differently:
+
+```yaml
+service:
+  type: ClusterIP
+  port: 8000
+```
+
+Tune runtime resources:
+
+```yaml
+resources:
+  requests:
+    cpu: 1
+    memory: 2Gi
+  limits:
+    cpu: 4
+    memory: 8Gi
+```
+
+Pass extra environment variables using normal Kubernetes `env` list syntax:
+
+```yaml
+env:
+  extra:
+    - name: EXTRA_FLAG
+      value: "1"
+```
+
+## Supported Values
+
+The chart supports overrides for the following areas in `values.yaml`:
+
+- Naming: `nameOverride`, `fullnameOverride`
+- Labels: `selectorLabels`, `podLabels`, `podAnnotations`
+- Deployment: `replicaCount`, `strategy`
+- Image: `image.repository`, `image.tag`, `image.pullPolicy`, `image.pullSecrets`
+- Service account: `serviceAccount.create`, `serviceAccount.name`, `serviceAccount.automount`, `serviceAccount.annotations`
+- Service: `service.type`, `service.port`, `service.annotations`
+- App PVC: `appData.create`, `appData.existingClaim`, `appData.name`, `appData.accessModes`, `appData.size`, `appData.storageClassName`, `appData.mountPath`
+- Source PVC: `sourceData.create`, `sourceData.existingClaim`, `sourceData.name`, `sourceData.accessModes`, `sourceData.size`, `sourceData.storageClassName`, `sourceData.mountPath`, `sourceData.readOnly`
+- Environment: `env.scanOutputRoot`, `env.appDbPath`, `env.defaultIncrementalSchedulerMins`, `env.nvIngestMode`, `env.nvIngestEndpoint`, `env.extra`
+- Health checks: `probes.liveness.*`, `probes.readiness.*`
+- Scheduling and placement: `nodeSelector`, `tolerations`, `affinity`
+- Resource limits: `resources`
+
+## Verify
+
+```bash
+helm template gcnv-data-ingestor ./examples/google-cloud-netapp-volumes-data-ingestor -n gcnv-data-ingestor
+kubectl get pods,svc,pvc -n gcnv-data-ingestor
+```
+
+The service defaults to `NodePort` with service port `8000`, matching the source manifest. Kubernetes assigns the external node port automatically unless you customize the Service separately.
+
+The default PVC access modes are `ReadWriteOnce`, so increasing `replicaCount` beyond `1` may require different storage semantics or pod placement constraints.

--- a/examples/google-cloud-netapp-volumes-data-ingestor/templates/_helpers.tpl
+++ b/examples/google-cloud-netapp-volumes-data-ingestor/templates/_helpers.tpl
@@ -1,0 +1,80 @@
+{{/*
+Expand the chart name.
+*/}}
+{{- define "gcnv-data-ingestor.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "gcnv-data-ingestor.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart name and version.
+*/}}
+{{- define "gcnv-data-ingestor.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "gcnv-data-ingestor.labels" -}}
+helm.sh/chart: {{ include "gcnv-data-ingestor.chart" . }}
+{{ include "gcnv-data-ingestor.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end -}}
+
+{{/*
+Selector labels copied from the source deployment.
+*/}}
+{{- define "gcnv-data-ingestor.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Values.selectorLabels.name }}
+app.kubernetes.io/instance: {{ .Values.selectorLabels.instance }}
+{{- end -}}
+
+{{/*
+Service account name.
+*/}}
+{{- define "gcnv-data-ingestor.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (printf "%s-sa" (include "gcnv-data-ingestor.fullname" .)) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+App PVC name.
+*/}}
+{{- define "gcnv-data-ingestor.appPvcName" -}}
+{{- if .Values.appData.existingClaim -}}
+{{- .Values.appData.existingClaim -}}
+{{- else -}}
+{{- .Values.appData.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Source PVC name.
+*/}}
+{{- define "gcnv-data-ingestor.sourcePvcName" -}}
+{{- if .Values.sourceData.existingClaim -}}
+{{- .Values.sourceData.existingClaim -}}
+{{- else -}}
+{{- .Values.sourceData.name -}}
+{{- end -}}
+{{- end -}}

--- a/examples/google-cloud-netapp-volumes-data-ingestor/templates/deployment.yaml
+++ b/examples/google-cloud-netapp-volumes-data-ingestor/templates/deployment.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gcnv-data-ingestor.fullname" . }}
+  labels:
+    {{- include "gcnv-data-ingestor.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.strategy.type }}
+  selector:
+    matchLabels:
+      {{- include "gcnv-data-ingestor.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gcnv-data-ingestor.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "gcnv-data-ingestor.serviceAccountName" . }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: gcnv-data-ingestor
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          env:
+            - name: MOUNT_PATH
+              value: {{ .Values.sourceData.mountPath | quote }}
+            - name: SCAN_OUTPUT_ROOT
+              value: {{ .Values.env.scanOutputRoot | quote }}
+            - name: APP_DB_PATH
+              value: {{ .Values.env.appDbPath | quote }}
+            - name: DEFAULT_INCREMENTAL_SCHEDULER_MINS
+              value: {{ .Values.env.defaultIncrementalSchedulerMins | quote }}
+            - name: NV_INGEST_MODE
+              value: {{ .Values.env.nvIngestMode | quote }}
+            - name: NV_INGEST_ENDPOINT
+              value: {{ .Values.env.nvIngestEndpoint | quote }}
+            {{- with .Values.env.extra }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: app-data
+              mountPath: {{ .Values.appData.mountPath | quote }}
+            - name: source-data
+              mountPath: {{ .Values.sourceData.mountPath | quote }}
+              readOnly: {{ .Values.sourceData.readOnly }}
+      volumes:
+        - name: app-data
+          persistentVolumeClaim:
+            claimName: {{ include "gcnv-data-ingestor.appPvcName" . }}
+        - name: source-data
+          persistentVolumeClaim:
+            claimName: {{ include "gcnv-data-ingestor.sourcePvcName" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/examples/google-cloud-netapp-volumes-data-ingestor/templates/pvc.yaml
+++ b/examples/google-cloud-netapp-volumes-data-ingestor/templates/pvc.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.appData.create (not .Values.appData.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "gcnv-data-ingestor.appPvcName" . }}
+  labels:
+    {{- include "gcnv-data-ingestor.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.appData.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.appData.size }}
+  {{- with .Values.appData.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}
+{{- if and .Values.sourceData.create (not .Values.sourceData.existingClaim) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "gcnv-data-ingestor.sourcePvcName" . }}
+  labels:
+    {{- include "gcnv-data-ingestor.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.sourceData.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.sourceData.size }}
+  {{- with .Values.sourceData.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/examples/google-cloud-netapp-volumes-data-ingestor/templates/service.yaml
+++ b/examples/google-cloud-netapp-volumes-data-ingestor/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gcnv-data-ingestor.fullname" . }}
+  labels:
+    {{- include "gcnv-data-ingestor.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "gcnv-data-ingestor.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/examples/google-cloud-netapp-volumes-data-ingestor/templates/serviceaccount.yaml
+++ b/examples/google-cloud-netapp-volumes-data-ingestor/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "gcnv-data-ingestor.serviceAccountName" . }}
+  labels:
+    {{- include "gcnv-data-ingestor.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/examples/google-cloud-netapp-volumes-data-ingestor/templates/validate.yaml
+++ b/examples/google-cloud-netapp-volumes-data-ingestor/templates/validate.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.namespace.create }}
+{{- fail "namespace.create is not supported by this chart. Create the namespace outside the chart with --create-namespace or kubectl create namespace." }}
+{{- end }}
+
+{{- if and (not .Values.appData.create) (not .Values.appData.existingClaim) }}
+{{- fail "appData.existingClaim is required when appData.create=false." }}
+{{- end }}
+
+{{- if and (not .Values.sourceData.create) (not .Values.sourceData.existingClaim) }}
+{{- fail "sourceData.existingClaim is required when sourceData.create=false." }}
+{{- end }}
+
+{{- if and (not .Values.serviceAccount.create) (not .Values.serviceAccount.name) }}
+{{- fail "serviceAccount.name is required when serviceAccount.create=false." }}
+{{- end }}

--- a/examples/google-cloud-netapp-volumes-data-ingestor/values.schema.json
+++ b/examples/google-cloud-netapp-volumes-data-ingestor/values.schema.json
@@ -1,0 +1,510 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "namespace": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        }
+      }
+    },
+    "selectorLabels": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "instance": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "name",
+        "instance"
+      ]
+    },
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "strategy": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Recreate",
+            "RollingUpdate"
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tag": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ]
+        },
+        "pullSecrets": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "required": [
+        "repository",
+        "tag",
+        "pullPolicy",
+        "pullSecrets"
+      ]
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "automount": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "create",
+        "name",
+        "automount",
+        "annotations"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "create": {
+                "const": false
+              }
+            },
+            "required": [
+              "create"
+            ]
+          },
+          "then": {
+            "properties": {
+              "name": {
+                "minLength": 1
+              }
+            }
+          }
+        }
+      ]
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "ClusterIP",
+            "NodePort",
+            "LoadBalancer"
+          ]
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "type",
+        "port",
+        "annotations"
+      ]
+    },
+    "appData": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "existingClaim": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "accessModes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadWriteOnce",
+              "ReadOnlyMany",
+              "ReadWriteMany",
+              "ReadWriteOncePod"
+            ]
+          }
+        },
+        "size": {
+          "type": "string",
+          "minLength": 1
+        },
+        "storageClassName": {
+          "type": "string"
+        },
+        "mountPath": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "create",
+        "existingClaim",
+        "name",
+        "accessModes",
+        "size",
+        "storageClassName",
+        "mountPath"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "create": {
+                "const": false
+              }
+            },
+            "required": [
+              "create"
+            ]
+          },
+          "then": {
+            "properties": {
+              "existingClaim": {
+                "minLength": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "create": {
+                "const": true
+              },
+              "existingClaim": {
+                "maxLength": 0
+              }
+            },
+            "required": [
+              "create",
+              "existingClaim"
+            ]
+          },
+          "then": {
+            "properties": {
+              "storageClassName": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "sourceData": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "existingClaim": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "accessModes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadWriteOnce",
+              "ReadOnlyMany",
+              "ReadWriteMany",
+              "ReadWriteOncePod"
+            ]
+          }
+        },
+        "size": {
+          "type": "string",
+          "minLength": 1
+        },
+        "storageClassName": {
+          "type": "string"
+        },
+        "mountPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "readOnly": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "create",
+        "existingClaim",
+        "name",
+        "accessModes",
+        "size",
+        "storageClassName",
+        "mountPath",
+        "readOnly"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "create": {
+                "const": false
+              }
+            },
+            "required": [
+              "create"
+            ]
+          },
+          "then": {
+            "properties": {
+              "existingClaim": {
+                "minLength": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "create": {
+                "const": true
+              },
+              "existingClaim": {
+                "maxLength": 0
+              }
+            },
+            "required": [
+              "create",
+              "existingClaim"
+            ]
+          },
+          "then": {
+            "properties": {
+              "storageClassName": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "env": {
+      "type": "object",
+      "properties": {
+        "scanOutputRoot": {
+          "type": "string",
+          "minLength": 1
+        },
+        "appDbPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "defaultIncrementalSchedulerMins": {
+          "type": "string",
+          "pattern": "^[0-9]+$"
+        },
+        "nvIngestMode": {
+          "type": "string",
+          "minLength": 1
+        },
+        "nvIngestEndpoint": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^https?://.+"
+        },
+        "extra": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "value": {
+                "type": "string"
+              },
+              "valueFrom": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "anyOf": [
+              {
+                "required": [
+                  "value"
+                ]
+              },
+              {
+                "required": [
+                  "valueFrom"
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "scanOutputRoot",
+        "appDbPath",
+        "defaultIncrementalSchedulerMins",
+        "nvIngestMode",
+        "nvIngestEndpoint",
+        "extra"
+      ]
+    },
+    "probes": {
+      "type": "object",
+      "properties": {
+        "liveness": {
+          "$ref": "#/definitions/httpProbe"
+        },
+        "readiness": {
+          "$ref": "#/definitions/httpProbe"
+        }
+      },
+      "required": [
+        "liveness",
+        "readiness"
+      ]
+    },
+    "resources": {
+      "type": "object"
+    },
+    "podAnnotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "podLabels": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "nodeSelector": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "tolerations": {
+      "type": "array"
+    },
+    "affinity": {
+      "type": "object"
+    }
+  },
+  "required": [
+    "image",
+    "serviceAccount",
+    "service",
+    "appData",
+    "sourceData",
+    "env",
+    "probes"
+  ],
+  "definitions": {
+    "httpProbe": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "required": [
+        "path",
+        "initialDelaySeconds",
+        "periodSeconds",
+        "timeoutSeconds",
+        "failureThreshold"
+      ]
+    }
+  }
+}

--- a/examples/google-cloud-netapp-volumes-data-ingestor/values.yaml
+++ b/examples/google-cloud-netapp-volumes-data-ingestor/values.yaml
@@ -1,0 +1,90 @@
+nameOverride: ""
+fullnameOverride: gcnv-data-ingestor
+
+namespace:
+  # Helm charts cannot reliably create their own target namespace during install.
+  # Use `helm install --create-namespace` instead.
+  create: false
+
+selectorLabels:
+  name: nvidia-gcnv-rag-manager
+  instance: netapp-volumes-rag-ingestor
+
+replicaCount: 1
+
+strategy:
+  type: Recreate
+
+image:
+  repository: ""
+  tag: ""
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+serviceAccount:
+  create: true
+  name: gcnv-data-ingestor-sa
+  automount: true
+  annotations: {}
+
+service:
+  type: NodePort
+  port: 8000
+  annotations: {}
+
+appData:
+  create: true
+  existingClaim: ""
+  name: gcnv-ingestor-config-data
+  accessModes:
+    - ReadWriteOnce
+  size: 50Gi
+  storageClassName: ""
+  mountPath: /data
+
+sourceData:
+  create: true
+  existingClaim: ""
+  name: gcnv-data-for-rag
+  accessModes:
+    - ReadWriteOnce
+  size: 200Gi
+  storageClassName: ""
+  mountPath: /source
+  readOnly: true
+
+env:
+  scanOutputRoot: /data/scans
+  appDbPath: /data/state/app.db
+  defaultIncrementalSchedulerMins: "0"
+  nvIngestMode: ingestor
+  nvIngestEndpoint: ""
+  extra: []
+
+probes:
+  liveness:
+    path: /healthz
+    initialDelaySeconds: 20
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    path: /healthz
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 1Gi
+  limits:
+    cpu: "2"
+    memory: 4Gi
+
+podAnnotations: {}
+podLabels: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
Package the GCNV data ingestor deployment into a reusable Helm chart with PVC, service, and namespace templates plus installation guidance for Trident-backed storage.


## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.