### PR TITLE
Fix for ES Helm instability

### DIFF
--- a/deploy/helm/nvidia-blueprint-rag/values.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/values.yaml
@@ -515,9 +515,24 @@ eck-elasticsearch:
             storage: 50Gi
     podTemplate:
       spec:
+        # JVM heap (-Xmx) must be ≤ 50% of pod memory limit; limit ≥ 2× -Xmx (here 2g heap → 4Gi limit).
+        initContainers:
+        - name: elastic-internal-init-filesystem
+          env:
+          - name: ES_JAVA_OPTS
+            value: "-Xms2g -Xmx2g"
         containers:
         - name: elasticsearch
-          # Override readiness probe to not require authentication
+          env:
+          - name: ES_JAVA_OPTS
+            value: "-Xms2g -Xmx2g"
+          resources:
+            requests:
+              memory: "4Gi"
+              cpu: "500m"
+            limits:
+              memory: "4Gi"
+          # Override readiness probe to not require authentication; tolerant under ingest load
           readinessProbe:
             exec:
               command:
@@ -525,10 +540,10 @@ eck-elasticsearch:
               - -c
               - |
                 curl -s http://localhost:9200/_cluster/health | grep -q '"status":"green"\|"status":"yellow"'
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
-            failureThreshold: 3
+            failureThreshold: 10
 
 # -- Observability
 # subsection: serviceMonitor

--- a/src/nvidia_rag/utils/vdb/elasticsearch/elastic_vdb.py
+++ b/src/nvidia_rag/utils/vdb/elasticsearch/elastic_vdb.py
@@ -204,6 +204,8 @@ class ElasticVDB(VDBRagIngest):
             hybrid=self.hybrid,
         )
 
+        self._repair_stale_ingest_refresh_settings()
+
     @property
     def collection_name(self) -> str:
         """Get the collection name."""
@@ -237,6 +239,42 @@ class ElasticVDB(VDBRagIngest):
         Check if the index exists in Elasticsearch.
         """
         return self._es_connection.indices.exists(index=index_name)
+
+    def _repair_stale_ingest_refresh_settings(self) -> None:
+        """
+        If a prior bulk ingest exited before restoring settings, refresh_interval may
+        remain -1. Reset to 1s so search visibility and cluster behavior are normal.
+        """
+        if not self.index_name or not self._check_index_exists(self.index_name):
+            return
+        try:
+            resp = self._es_connection.indices.get_settings(index=self.index_name)
+        except (ESConnectionError, ConnectionError, OSError) as e:
+            logger.warning(
+                "Could not read settings for Elasticsearch index %s: %s",
+                self.index_name,
+                e,
+            )
+            return
+        index_block = resp.get(self.index_name)
+        if index_block is None and resp:
+            index_block = next(iter(resp.values()))
+        if not index_block:
+            return
+        settings = index_block.get("settings", {})
+        index_settings = settings.get("index", {})
+        refresh = index_settings.get("refresh_interval")
+        if refresh in ("-1", "-1s"):
+            logger.warning(
+                "Index %s has refresh_interval=%s (stale after interrupted ingest); "
+                "resetting to 1s",
+                self.index_name,
+                refresh,
+            )
+            self._es_connection.indices.put_settings(
+                index=self.index_name,
+                body={"index": {"refresh_interval": "1s"}},
+            )
 
     def create_index(self):
         """
@@ -293,35 +331,45 @@ class ElasticVDB(VDBRagIngest):
             f"Commencing Elasticsearch ingestion process for {total_records} records..."
         )
 
-        # Process records in batches of batch_size
-        for i in range(0, total_records, batch_size):
-            end_idx = min(i + batch_size, total_records)
-            batch_texts = texts[i:end_idx]
-            batch_embeddings = embeddings[i:end_idx]
-            batch_metadatas = metadatas[i:end_idx]
+        self._es_connection.indices.put_settings(
+            index=self.index_name,
+            body={"index": {"refresh_interval": "-1"}},
+        )
+        try:
+            # Process records in batches of batch_size
+            for i in range(0, total_records, batch_size):
+                end_idx = min(i + batch_size, total_records)
+                batch_texts = texts[i:end_idx]
+                batch_embeddings = embeddings[i:end_idx]
+                batch_metadatas = metadatas[i:end_idx]
 
-            # Upload current batch to Elasticsearch
-            self.es_store.add_texts(
-                texts=batch_texts,
-                vectors=batch_embeddings,
-                metadatas=batch_metadatas,
-            )
-
-            uploaded_count += len(batch_texts)
-
-            # Log progress every 5 batches (5000 records)
-            if (
-                uploaded_count % (5 * batch_size) == 0
-                or uploaded_count == total_records
-            ):
-                logger.info(
-                    f"Successfully ingested {uploaded_count} records into Elasticsearch index {self.index_name}"
+                # Upload current batch to Elasticsearch
+                self.es_store.add_texts(
+                    texts=batch_texts,
+                    vectors=batch_embeddings,
+                    metadatas=batch_metadatas,
                 )
+
+                uploaded_count += len(batch_texts)
+
+                # Log progress every 5 batches (5000 records)
+                if (
+                    uploaded_count % (5 * batch_size) == 0
+                    or uploaded_count == total_records
+                ):
+                    logger.info(
+                        f"Successfully ingested {uploaded_count} records into Elasticsearch index {self.index_name}"
+                    )
+        finally:
+            self._es_connection.indices.put_settings(
+                index=self.index_name,
+                body={"index": {"refresh_interval": "1s"}},
+            )
+            self._es_connection.indices.refresh(index=self.index_name)
 
         logger.info(
             f"Elasticsearch ingestion completed. Total records processed: {uploaded_count}"
         )
-        self._es_connection.indices.refresh(index=self.index_name)
 
     def retrieval(self, queries: list, **kwargs) -> list[dict[str, Any]]:
         """
@@ -787,7 +835,7 @@ class ElasticVDB(VDBRagIngest):
             "info_value": info_value,
         }
         self._es_connection.index(index=DEFAULT_DOCUMENT_INFO_COLLECTION, body=data)
-        logger.info(
+        logger.debug(
             f"Document info added to the ES index {DEFAULT_DOCUMENT_INFO_COLLECTION}. \
             Document info: {info_type}, {document_name}, {info_value}."
         )

--- a/src/nvidia_rag/utils/vdb/elasticsearch/es_queries.py
+++ b/src/nvidia_rag/utils/vdb/elasticsearch/es_queries.py
@@ -34,7 +34,7 @@ def get_unique_sources_query():
         "aggs": {
             "unique_sources": {
                 "composite": {
-                    "size": 1000,  # Adjust size depending on number of unique values
+                    "size": 65536,  # Adjust size depending on number of unique values
                     "sources": [
                         {
                             "source_name": {
@@ -102,7 +102,7 @@ def get_chunks_by_source_and_pages_query(
                 ]
             }
         },
-        "size": 1000,
+        "size": 65536,
         "_source": ["text", "metadata"],
     }
 

--- a/tests/unit/test_utils/test_vdb/test_elastic_vdb.py
+++ b/tests/unit/test_utils/test_vdb/test_elastic_vdb.py
@@ -1572,7 +1572,7 @@ class TestEsQueries(unittest.TestCase):
 
         # Verify composite aggregation
         composite = unique_sources["composite"]
-        self.assertEqual(composite["size"], 1000)
+        self.assertEqual(composite["size"], 65536)
         self.assertIn("sources", composite)
 
         # Verify source field configuration

--- a/tests/unit/test_utils/test_vdb/test_elasticsearch/test_es_queries.py
+++ b/tests/unit/test_utils/test_vdb/test_elasticsearch/test_es_queries.py
@@ -30,7 +30,7 @@ class TestGetUniqueSourcesQuery:
         assert query["size"] == 0
         assert "aggs" in query
         assert "unique_sources" in query["aggs"]
-        assert query["aggs"]["unique_sources"]["composite"]["size"] == 1000
+        assert query["aggs"]["unique_sources"]["composite"]["size"] == 65536
         assert "top_hit" in query["aggs"]["unique_sources"]["aggs"]
         assert (
             query["aggs"]["unique_sources"]["composite"]["sources"][0]["source_name"][


### PR DESCRIPTION
# Elasticsearch Helm stability (OOM + ingest load)

## Summary

In Helm, the Elasticsearch pod had no JVM/memory alignment with Kubernetes limits, so the heap could grow during large ingestions and the pod could be OOMKilled. Docker Compose already pinned the heap via `ES_JAVA_OPTS`. This change aligns Helm with bounded heap and memory, reduces background work during bulk ingest, and hardens recovery if ingest is interrupted.

## Changes

- **Helm** (`deploy/helm/nvidia-blueprint-rag/values.yaml`): Set **4Gi** memory requests/limits on the ES container, **`ES_JAVA_OPTS=-Xms2g -Xmx2g`** on the Elasticsearch container and the ECK init container (heap stays within ~50% of the limit), and relax the readiness probe slightly under ingest load (longer initial delay, higher failure threshold).
- **Ingestion** (`elastic_vdb.py`): Set **`refresh_interval: -1`** for the index during bulk ingest and restore **`1s`** in a **`finally`** block (plus explicit refresh), cutting refresh pressure while loading data. On connect, **`_repair_stale_ingest_refresh_settings`** resets a stuck `-1` if a prior run exited before the `finally` ran.

## Notes

ECK expects the JVM heap to remain at or below half of the pod memory limit; the 4Gi limit pairs with the 2g heap setting above.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [X] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [X] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.