### PR TITLE
NRL: nightly bump, embed-before-store, filetype filter, HTML/audio pipelines, disable split config

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -83,15 +83,24 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          apt-get update && apt-get install -y gcc && rm -rf /var/lib/apt/lists/*
+          apt-get update && apt-get install -y gcc curl && rm -rf /var/lib/apt/lists/*
 
       - name: Install package with dependencies
         run: |
-          pip install -e .[all]
-          pip install --no-cache-dir -r tests/unit/requirements-test.txt
+          # Install uv (Python package and environment manager)
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          export PATH="$HOME/.local/bin:$PATH"
+
+          # Create a fresh virtual environment using uv
+          rm -rf venv-unit || echo "No existing venv-unit to clean up"
+          uv venv venv-unit
+          . venv-unit/bin/activate
+          uv pip install -e .[all]
+          uv pip install --no-cache -r tests/unit/requirements-test.txt
 
       - name: Run unit tests with coverage
         run: |
+          . venv-unit/bin/activate
           python -m pytest -v -s --cov=src --cov-report=term-missing tests/unit
 
   frontend-unit-tests:

--- a/deploy/compose/docker-compose-ingestor-server.yaml
+++ b/deploy/compose/docker-compose-ingestor-server.yaml
@@ -104,6 +104,7 @@ services:
       APP_NVINGEST_TEXTDEPTH: ${APP_NVINGEST_TEXTDEPTH:-page} # extract by "page" or "document"
 
       ##===NV-Ingest Splitting Configurations========
+      APP_NVINGEST_ENABLESPLIT: ${APP_NVINGEST_ENABLESPLIT:-False} # Master toggle: enable text splitting/chunking stage (disabled by default)
       APP_NVINGEST_CHUNKSIZE: ${APP_NVINGEST_CHUNKSIZE:-512}
       APP_NVINGEST_CHUNKOVERLAP: ${APP_NVINGEST_CHUNKOVERLAP:-150}
       APP_NVINGEST_ENABLEPDFSPLITTER: ${APP_NVINGEST_ENABLEPDFSPLITTER:-True}

--- a/deploy/helm/nvidia-blueprint-rag/values.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/values.yaml
@@ -413,6 +413,7 @@ ingestor-server:
     LOGLEVEL: "INFO"
 
     # === NV-Ingest splitting configurations ===
+    APP_NVINGEST_ENABLESPLIT: "False"  # Master toggle: enable text splitting/chunking stage (disabled by default)
     APP_NVINGEST_CHUNKSIZE: "512"  # Size of chunks for splitting
     APP_NVINGEST_CHUNKOVERLAP: "150"  # Overlap size for chunks
     APP_NVINGEST_ENABLEPDFSPLITTER: "True"  # Enable PDF splitter

--- a/notebooks/rag_library_lite_usage.ipynb
+++ b/notebooks/rag_library_lite_usage.ipynb
@@ -34,9 +34,9 @@
         "uv pip install nvidia-rag[all]\n",
         "```\n",
         "\n",
-        "Install nv-ingest library using below command - **OR** - Run the cell below if Jupyter notebook is started in the same environment:\n",
+        "Install nv-ingest-related libraries using below command - **OR** - Run the cell below if Jupyter notebook is started in the same environment (versions match `pyproject.toml` `[all]` / `ingest` extras):\n",
         "```bash\n",
-        "uv pip install nv-ingest==26.3.0\n",
+        "uv pip install \"nv-ingest==2026.4.21.dev20260421\" \"nv-ingest-api==2026.4.21.dev20260421\" \"nv-ingest-client==2026.4.21.dev20260421\" \"nemo-retriever==2026.4.21.dev68\"\n",
         "```"
       ]
     },
@@ -70,8 +70,8 @@
         "# !cd .. && uv build\n",
         "# !uv pip install ../dist/nvidia_rag-*-py3-none-any.whl[all]\n",
         "\n",
-        "# Install NV-Ingest library in the same environment to run NV-Ingest pipeline\n",
-        "!uv pip install nv-ingest==26.3.0"
+        "# Install NV-Ingest / NeMo Retriever libraries (pins match pyproject.toml ingest/all extras)\n",
+        "!uv pip install \"nv-ingest==2026.4.21.dev20260421\" \"nv-ingest-api==2026.4.21.dev20260421\" \"nv-ingest-client==2026.4.21.dev20260421\" \"nemo-retriever==2026.4.21.dev68\""
       ]
     },
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ nvidia-rag = { workspace = true }
 
 [tool.uv]
 # Pillow 12.x required for containers; moviepy pins pillow<12 so override needed for resolution
-override-dependencies = ["pillow>=12.1.0"]
+override-dependencies = ["pillow>=12.1.0", "lance-namespace>=0.4.5,<0.7"]
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,10 +61,10 @@ rag = [
 ingest = [
     # nv-ingest dependencies (required for ingestion operations)
     # nv-ingest dependencies (required for ingestion operations)
-    "nv-ingest==2026.4.15.dev20260415",
-    "nv-ingest-api==2026.4.15.dev20260415",
-    "nv-ingest-client==2026.4.15.dev20260415",
-    "nemo-retriever==2026.4.15.dev62",
+    "nv-ingest==2026.4.21.dev20260421",
+    "nv-ingest-api==2026.4.21.dev20260421",
+    "nv-ingest-client==2026.4.21.dev20260421",
+    "nemo-retriever==2026.4.21.dev68",
     "tritonclient==2.57.0",
     # Other ingest dependencies
     "langchain-openai>=0.2,<1.1.9",
@@ -86,10 +86,10 @@ ingest = [
 all = [
     # nv-ingest dependencies (required for ingestion operations)
     # nv-ingest dependencies (required for ingestion operations)
-    "nv-ingest==2026.4.15.dev20260415",
-    "nv-ingest-api==2026.4.15.dev20260415",
-    "nv-ingest-client==2026.4.15.dev20260415",
-    "nemo-retriever==2026.4.15.dev62",
+    "nv-ingest==2026.4.21.dev20260421",
+    "nv-ingest-api==2026.4.21.dev20260421",
+    "nv-ingest-client==2026.4.21.dev20260421",
+    "nemo-retriever==2026.4.21.dev68",
     "tritonclient==2.57.0",
     # RAG + Ingest dependencies
     "langchain-openai>=0.2,<1.1.9",

--- a/src/nvidia_rag/ingestor_server/main.py
+++ b/src/nvidia_rag/ingestor_server/main.py
@@ -358,7 +358,7 @@ class NvidiaRAGIngestor:
         vdb_op.create_document_info_collection()
 
         # Set default values for mutable arguments
-        if split_options is None:
+        if split_options is None and self.config.nv_ingest.enable_split:
             split_options = {
                 "chunk_size": self.config.nv_ingest.chunk_size,
                 "chunk_overlap": self.config.nv_ingest.chunk_overlap,
@@ -965,7 +965,7 @@ class NvidiaRAGIngestor:
             vdb_endpoint = self.config.vector_store.url
 
         # Set default values for mutable arguments
-        if split_options is None:
+        if split_options is None and self.config.nv_ingest.enable_split:
             split_options = {
                 "chunk_size": self.config.nv_ingest.chunk_size,
                 "chunk_overlap": self.config.nv_ingest.chunk_overlap,
@@ -2284,6 +2284,25 @@ class NvidiaRAGIngestor:
             shallow_summary = summary_options.get("shallow_summary", False)
 
         # ------------------------------------------------------------------
+        # Pre-filter: identify files whose extensions are not supported by NRL.
+        # Mirrors __remove_unsupported_files / __get_non_supported_files from the
+        # NV-Ingest path so unsupported files are reported with a clear
+        # "Unsupported file type" error rather than silently producing zero chunks.
+        # Logic lives in nemo_retriever/filters.py, not here.
+        # ------------------------------------------------------------------
+        from nvidia_rag.ingestor_server.nemo_retriever.filters import filter_unsupported
+
+        filepaths, unsupported_failures = filter_unsupported(filepaths)
+
+        if not filepaths:
+            logger.warning(
+                "NRL: no supported files remain after pre-filter; "
+                "returning %d unsupported failure(s) immediately",
+                len(unsupported_failures),
+            )
+            return [], unsupported_failures
+
+        # ------------------------------------------------------------------
         # Set PENDING status for all files when summary generation is requested.
         # Mirrors the identical block at the top of __run_nvingest_batched_ingestion
         # so that callers polling GET /summary see a consistent initial state.
@@ -2389,7 +2408,8 @@ class NvidiaRAGIngestor:
 
         # failures shape: list[tuple[path, error]] — consumed by __get_failed_documents
         # which accesses failure[0] (path) and failure[1] (error message).
-        failures: list[tuple[str, Any]] = [
+        # unsupported_failures are prepended so they appear first in the response.
+        failures: list[tuple[str, Any]] = unsupported_failures + [
             (path, "NRL ingest produced no embedded chunks for this document")
             for path in schema_mgr.failed_sources()
         ]
@@ -2646,7 +2666,7 @@ class NvidiaRAGIngestor:
             - summary_options: SummaryOptions - Advanced options for summary (page_filter, shallow_summary, summarization_strategy)
             - state_manager: IngestionStateManager - State manager for the ingestion process
         """
-        if split_options is None:
+        if split_options is None and self.config.nv_ingest.enable_split:
             split_options = {
                 "chunk_size": self.config.nv_ingest.chunk_size,
                 "chunk_overlap": self.config.nv_ingest.chunk_overlap,

--- a/src/nvidia_rag/ingestor_server/nemo_retriever/__init__.py
+++ b/src/nvidia_rag/ingestor_server/nemo_retriever/__init__.py
@@ -20,8 +20,11 @@ Public surface (imported by ``ingestor_server/main.py`` when
 
 * :class:`NemoRetrieverHandler` — async façade over ``GraphIngestor``.
 * :class:`IngestSchemaManager` — stable accessor API over the NRL DataFrame.
+* :func:`filter_unsupported` — split filepaths into supported / unsupported
+  before invoking ``NemoRetrieverHandler.ingest()``.
 """
 
+from nvidia_rag.ingestor_server.nemo_retriever.filters import filter_unsupported
 from nvidia_rag.ingestor_server.nemo_retriever.handler import NemoRetrieverHandler
 from nvidia_rag.ingestor_server.nemo_retriever.ingest_schema_manager import (
     IngestSchemaManager,
@@ -30,4 +33,5 @@ from nvidia_rag.ingestor_server.nemo_retriever.ingest_schema_manager import (
 __all__ = [
     "NemoRetrieverHandler",
     "IngestSchemaManager",
+    "filter_unsupported",
 ]

--- a/src/nvidia_rag/ingestor_server/nemo_retriever/filters.py
+++ b/src/nvidia_rag/ingestor_server/nemo_retriever/filters.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""File-type filtering utilities for the NRL ingestion pipeline.
+
+``filter_unsupported`` is the NRL-backend equivalent of
+``__remove_unsupported_files`` / ``__get_non_supported_files`` from the
+NV-Ingest path in ``ingestor_server/main.py``.  Keeping it here rather than
+inline in ``main.py`` gives it a single home and keeps ``main.py`` slim.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from nvidia_rag.ingestor_server.nemo_retriever.handler import NRL_SUPPORTED_EXTENSIONS
+
+logger = logging.getLogger(__name__)
+
+# Human-readable extension list built once at import time — used in error messages.
+_SUPPORTED_EXTS_DISPLAY: str = ", ".join(
+    sorted(ext.lstrip(".") for ext in NRL_SUPPORTED_EXTENSIONS)
+)
+_UNSUPPORTED_ERROR: str = (
+    f"Unsupported file type, supported file types are: {_SUPPORTED_EXTS_DISPLAY}"
+)
+
+
+def filter_unsupported(
+    filepaths: list[str],
+) -> tuple[list[str], list[tuple[str, str]]]:
+    """Split *filepaths* into NRL-supported and unsupported groups.
+
+    Unsupported files are never sent to ``NemoRetrieverHandler.ingest()``;
+    instead they are returned as pre-built failure tuples so the caller can
+    surface a clear ``"Unsupported file type"`` error to the end user.
+
+    Parameters
+    ----------
+    filepaths:
+        Absolute paths of documents intended for NRL ingestion.
+
+    Returns
+    -------
+    tuple[list[str], list[tuple[str, str]]]
+        ``(supported_filepaths, unsupported_failures)``
+
+        *supported_filepaths*
+            Files whose extensions are in ``NRL_SUPPORTED_EXTENSIONS``;
+            safe to pass directly to ``NemoRetrieverHandler.ingest()``.
+
+        *unsupported_failures*
+            ``(filepath, error_message)`` pairs for files whose extensions
+            are not recognised by NRL.  The error message begins with
+            ``"Unsupported file type"`` so existing test assertions and
+            response validators continue to match.
+    """
+    supported: list[str] = []
+    unsupported_failures: list[tuple[str, str]] = []
+
+    for fp in filepaths:
+        ext = Path(fp).suffix.lower()
+        if ext in NRL_SUPPORTED_EXTENSIONS:
+            supported.append(fp)
+        else:
+            logger.warning(
+                "NRL: unsupported file extension %r for %r — "
+                "will be reported as 'Unsupported file type'",
+                ext,
+                Path(fp).name,
+            )
+            unsupported_failures.append((fp, _UNSUPPORTED_ERROR))
+
+    if unsupported_failures:
+        logger.info(
+            "NRL file-type filter: %d supported file(s), %d unsupported file(s)",
+            len(supported),
+            len(unsupported_failures),
+        )
+
+    return supported, unsupported_failures

--- a/src/nvidia_rag/ingestor_server/nemo_retriever/handler.py
+++ b/src/nvidia_rag/ingestor_server/nemo_retriever/handler.py
@@ -25,20 +25,57 @@ Threading model::
     FastAPI request
         └── INGESTION_TASK_HANDLER.submit_task(_task)
                 └── asyncio background task
-                        └── loop.run_in_executor(
-                                NemoRetrieverHandler._executor,
-                                handler._run_sync,
-                                ingestor
-                            )
-                                └── GraphIngestor.ingest()  [blocking, in thread]
+                        └── for each type group (sequential):
+                                loop.run_in_executor(
+                                    NemoRetrieverHandler._executor,
+                                    handler._run_sync,
+                                    ingestor,
+                                    type_label,
+                                )
+                                    └── GraphIngestor.ingest()  [blocking, in thread]
+
+Supported file types and pipelines
+-----------------------------------
+Each extension is classified into one of five type groups.  A separate
+``GraphIngestor`` is built per non-empty group and executed **sequentially**
+(each group completes before the next starts).  The NRL reference example
+(``graph_pipeline.py``) also runs one ingestor per file type — parallelising
+across types is not safe because Ray manages its own internal concurrency.
+
+    pdf_doc     — .pdf / .docx / .pptx
+                  → extract → split → [caption] → [embed] → [store]
+
+    image       — .jpg / .jpeg / .png / .tiff / .tif / .bmp
+                  → extract_image_files → [caption] → [embed] → [store]
+
+    text        — .txt
+                  → extract_txt  (chunking built-in via TextChunkParams)
+                  → [embed]
+
+    html        — .html / .htm
+                  → extract_html  (chunking built-in via HtmlChunkParams)
+                  → [embed]
+
+    audio_video — .mp3 / .wav / .mp4
+                  → extract_audio  (chunking built-in via AudioChunkParams
+                                    + ASR via ASRParams)
+                  → [embed]
+
+Files with unrecognised extensions are logged as warnings and routed to the
+``pdf_doc`` pipeline (backward-compatible fallback).
+
+Results from all type groups are ``pd.concat``-ed into a single DataFrame
+before being wrapped in ``IngestSchemaManager``.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import pandas as pd
@@ -48,9 +85,12 @@ from nvidia_rag.ingestor_server.nemo_retriever.ingest_schema_manager import (
     IngestSchemaManager,
 )
 from nvidia_rag.ingestor_server.nemo_retriever.params import (
+    make_asr_params,
+    make_audio_chunk_params,
     make_caption_params,
     make_embed_params,
     make_extract_params,
+    make_html_chunk_params,
     make_split_params,
     make_store_params,
 )
@@ -60,6 +100,33 @@ if TYPE_CHECKING:
     from nvidia_rag.utils.vdb.vdb_base import VDBRag
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# File-type extension sets and lookup table
+# ---------------------------------------------------------------------------
+
+_PDF_DOC_EXTS: frozenset[str] = frozenset({".pdf", ".docx", ".pptx"})
+_IMAGE_EXTS: frozenset[str] = frozenset({".jpg", ".jpeg", ".png", ".tiff", ".tif", ".bmp"})
+_TEXT_EXTS: frozenset[str] = frozenset({".txt"})
+_HTML_EXTS: frozenset[str] = frozenset({".html", ".htm"})
+_AUDIO_VIDEO_EXTS: frozenset[str] = frozenset({".mp3", ".wav", ".mp4"})
+
+# Flat extension → type-key lookup built once at import time.
+_EXT_TO_TYPE: dict[str, str] = {
+    **dict.fromkeys(_PDF_DOC_EXTS, "pdf_doc"),
+    **dict.fromkeys(_IMAGE_EXTS, "image"),
+    **dict.fromkeys(_TEXT_EXTS, "text"),
+    **dict.fromkeys(_HTML_EXTS, "html"),
+    **dict.fromkeys(_AUDIO_VIDEO_EXTS, "audio_video"),
+}
+
+# Processing order: deterministic for concat ordering and log output.
+_TYPE_ORDER: tuple[str, ...] = ("pdf_doc", "image", "text", "html", "audio_video")
+
+# Public constant: all extensions recognised by the NRL pipeline.
+# Exposed so callers (e.g. main.py) can pre-filter unsupported files before
+# calling ingest(), mirroring SUPPORTED_FILE_TYPES in the NV-Ingest path.
+NRL_SUPPORTED_EXTENSIONS: frozenset[str] = frozenset(_EXT_TO_TYPE)
 
 
 class NemoRetrieverHandler:
@@ -73,11 +140,7 @@ class NemoRetrieverHandler:
 
     def __init__(self, config: NvidiaRAGConfig) -> None:
         self._config = config
-        # Read run_mode added to NvIngestConfig (see NRL_INTEGRATION_PLAN.md §9).
-        # Fall back to "inprocess" until configuration.py is updated.
-        self._run_mode: str = getattr(
-            config.nv_ingest, "nrl_run_mode", "batch"
-        )
+        self._run_mode: str = getattr(config.nv_ingest, "nrl_run_mode", "batch")
         # One pipeline at a time: NRL / Ray owns its own worker threads.
         self._executor: ThreadPoolExecutor = ThreadPoolExecutor(max_workers=1)
         logger.info(
@@ -96,61 +159,247 @@ class NemoRetrieverHandler:
         extract_override: dict[str, Any] | None = None,
         store_images: bool = True,
     ) -> IngestSchemaManager:
-        """Run the full extraction → split → (caption) → (store) → embed pipeline.
+        """Run the full extraction → split → (caption) → embed → (store) pipeline.
+
+        Files are first classified by extension into type groups.  A dedicated
+        ``GraphIngestor`` pipeline is built for each non-empty group using the
+        appropriate NRL extraction method.  Type groups are processed
+        **sequentially** — one group fully completes before the next begins.
+        Results from all groups are concatenated into a single
+        ``IngestSchemaManager``.
 
         Parameters
         ----------
         filepaths:
-            Absolute paths (or glob patterns) of documents to ingest.
+            Absolute paths of documents to ingest.  Mixed file types are
+            supported; see module docstring for the full extension matrix.
         vdb_op:
             Active ``VDBRag`` instance; controls whether embed / store stages
             are added.  ``None`` skips both.
         split_options:
-            When not ``None``, a ``TextChunkParams``-compatible override dict is
-            merged with config defaults and a split stage is added.  Pass ``{}``
-            to split with config defaults only.
+            Reserved for future per-call split overrides (not yet applied).
         extract_override:
-            Field overrides forwarded directly to ``make_extract_params``.
+            Field overrides forwarded directly to ``make_extract_params``
+            (applies to pdf_doc and image groups only).
         store_images:
             When ``True`` *and* ``vdb_op`` is not ``None``, a store stage for
-            extracted images is added before embedding.
+            extracted images is added to the pdf_doc and image pipelines.
 
         Returns
         -------
         IngestSchemaManager
-            Stable wrapper around the raw NRL result DataFrame.
+            Stable wrapper around the concatenated NRL result DataFrame.
         """
-        ingestor = self._build_ingestor(
+        logger.info(
+            "ingest() called with %d filepath(s), vdb_op=%s, store_images=%s",
+            len(filepaths),
+            vdb_op is not None,
+            store_images,
+        )
+
+        type_ingestors = self._build_ingestors(
             filepaths, split_options, extract_override, vdb_op, store_images
         )
+
+        if not type_ingestors:
+            logger.warning(
+                "No supported files found among %d filepath(s); returning empty result",
+                len(filepaths),
+            )
+            return IngestSchemaManager(pd.DataFrame())
+
+        logger.info(
+            "Executing %d type group(s) sequentially: %s",
+            len(type_ingestors),
+            [tk for tk, _ in type_ingestors],
+        )
+
         loop = asyncio.get_running_loop()
-        df = await loop.run_in_executor(self._executor, self._run_sync, ingestor)
-        return IngestSchemaManager(df)
+        frames: list[pd.DataFrame] = []
+
+        # Sequential execution: each group is awaited before the next starts.
+        # Parallelising across type groups is not safe — Ray manages its own
+        # internal concurrency and running overlapping pipelines would race
+        # for GPU resources (same reason max_workers=1 is used).
+        for idx, (type_key, gi) in enumerate(type_ingestors, start=1):
+            logger.info(
+                "Starting type group %d/%d: %s",
+                idx,
+                len(type_ingestors),
+                type_key,
+            )
+            t0 = time.perf_counter()
+            df = await loop.run_in_executor(
+                self._executor, self._run_sync, gi, type_key
+            )
+            elapsed = time.perf_counter() - t0
+            logger.info(
+                "Finished type group %d/%d: %s — %d rows in %.2fs",
+                idx,
+                len(type_ingestors),
+                type_key,
+                len(df),
+                elapsed,
+            )
+            frames.append(df)
+
+        combined = (
+            pd.concat(frames, ignore_index=True) if len(frames) > 1 else frames[0]
+        )
+        logger.info(
+            "All type groups complete: %d total rows from %d group(s)",
+            len(combined),
+            len(type_ingestors),
+        )
+        return IngestSchemaManager(combined)
 
     async def ingest_shallow(self, filepaths: list[str]) -> IngestSchemaManager:
         """Text-only extraction with no embed and no VDB write — for fast summarisation.
 
+        Only PDF / DOCX / PPTX files are processed; other file types are skipped
+        with a warning because the shallow pipeline runs text-only PDF extraction.
         Equivalent to ``extract(images=False, tables=False, charts=False,
         infographics=False)`` with no ``.embed()`` stage.
         """
-        ingestor = self._build_shallow_ingestor(filepaths)
+        logger.info("ingest_shallow() called with %d filepath(s)", len(filepaths))
+
+        supported = [
+            fp for fp in filepaths if Path(fp).suffix.lower() in _PDF_DOC_EXTS
+        ]
+        skipped_count = len(filepaths) - len(supported)
+        if skipped_count:
+            skipped_paths = [
+                fp for fp in filepaths
+                if Path(fp).suffix.lower() not in _PDF_DOC_EXTS
+            ]
+            logger.warning(
+                "ingest_shallow: skipping %d non-PDF/DOC/PPTX file(s) "
+                "(shallow extraction is text-only): %s",
+                skipped_count,
+                skipped_paths,
+            )
+
+        if not supported:
+            logger.warning(
+                "ingest_shallow: no supported files remain after filtering; "
+                "returning empty result"
+            )
+            return IngestSchemaManager(pd.DataFrame())
+
+        logger.info(
+            "ingest_shallow: processing %d PDF/DOC/PPTX file(s)", len(supported)
+        )
+        ingestor = self._build_shallow_ingestor(supported)
         loop = asyncio.get_running_loop()
-        df = await loop.run_in_executor(self._executor, self._run_sync, ingestor)
+        t0 = time.perf_counter()
+        df = await loop.run_in_executor(
+            self._executor, self._run_sync, ingestor, "pdf_doc_shallow"
+        )
+        logger.info(
+            "ingest_shallow complete: %d rows in %.2fs", len(df), time.perf_counter() - t0
+        )
         return IngestSchemaManager(df)
 
     # ------------------------------------------------------------------
-    # Internal pipeline builders
+    # File classification
     # ------------------------------------------------------------------
 
-    def _build_ingestor(
+    def _classify_filepaths(self, filepaths: list[str]) -> dict[str, list[str]]:
+        """Group *filepaths* by file-type key using ``_EXT_TO_TYPE``.
+
+        Unknown extensions are warned about and assigned to ``pdf_doc`` as a
+        backward-compatible fallback so existing integrations are not broken.
+
+        Returns
+        -------
+        dict[str, list[str]]
+            Keys are ``_TYPE_ORDER`` entries; values are (possibly empty) lists
+            of file paths belonging to that group.
+        """
+        classified: dict[str, list[str]] = {t: [] for t in _TYPE_ORDER}
+
+        for fp in filepaths:
+            ext = Path(fp).suffix.lower()
+            type_key = _EXT_TO_TYPE.get(ext)
+            if type_key is None:
+                logger.warning(
+                    "Unrecognised file extension %r for %r; "
+                    "defaulting to pdf_doc pipeline",
+                    ext,
+                    fp,
+                )
+                type_key = "pdf_doc"
+            classified[type_key].append(fp)
+
+        non_empty = {k: len(v) for k, v in classified.items() if v}
+        logger.info(
+            "File classification result (%d file(s) total): %s", len(filepaths), non_empty
+        )
+        return classified
+
+    # ------------------------------------------------------------------
+    # Pipeline builders
+    # ------------------------------------------------------------------
+
+    def _build_ingestors(
         self,
         filepaths: list[str],
         split_options: dict[str, Any] | None,
         extract_override: dict[str, Any] | None,
         vdb_op: VDBRag | None,
         store_images: bool,
+    ) -> list[tuple[str, GraphIngestor]]:
+        """Classify *filepaths* and build one ``GraphIngestor`` per type group.
+
+        Uses a dispatch table keyed on type strings so adding a new file type
+        requires only a new entry in the table and a corresponding
+        ``_build_*_ingestor`` method — no branching logic here.
+
+        Returns
+        -------
+        list[tuple[str, GraphIngestor]]
+            Ordered by ``_TYPE_ORDER``; only non-empty groups are included.
+        """
+        classified = self._classify_filepaths(filepaths)
+
+        builders: dict[str, Any] = {
+            "pdf_doc":     self._build_pdf_doc_ingestor,
+            "image":       self._build_image_ingestor,
+            "text":        self._build_text_ingestor,
+            "html":        self._build_html_ingestor,
+            "audio_video": self._build_audio_video_ingestor,
+        }
+
+        result: list[tuple[str, GraphIngestor]] = []
+        for type_key in _TYPE_ORDER:
+            paths = classified[type_key]
+            if not paths:
+                continue
+            logger.debug(
+                "Building %s ingestor for %d file(s): %s",
+                type_key,
+                len(paths),
+                paths,
+            )
+            gi = builders[type_key](paths, split_options, extract_override, vdb_op, store_images)
+            result.append((type_key, gi))
+
+        logger.info(
+            "_build_ingestors: %d ingestor(s) prepared for type group(s): %s",
+            len(result),
+            [tk for tk, _ in result],
+        )
+        return result
+
+    def _build_pdf_doc_ingestor(
+        self,
+        filepaths: list[str],
+        split_options: dict[str, Any] | None,  # noqa: ARG002
+        extract_override: dict[str, Any] | None,
+        vdb_op: VDBRag | None,
+        store_images: bool,
     ) -> GraphIngestor:
-        """Construct and configure the full GraphIngestor pipeline.
+        """Pipeline: extract → split → [caption] → [embed] → [store].
 
         Does NOT call ``.vdb_upload()`` — VDB write is handled by the caller
         via ``VectorStore`` backends after the ingest completes.
@@ -160,31 +409,162 @@ class NemoRetrieverHandler:
             gi = gi.vdb_upload(backend)  # backend implements VectorStore ABC
         and remove the post-ingest ``write_rows()`` call in main.py.
         """
+        stages = ["extract"]
+        if self._config.nv_ingest.enable_split:
+            stages.append("split")
+        if self._config.nv_ingest.extract_images:
+            stages.append("caption")
+        if vdb_op is not None:
+            stages.append("embed")
+        if store_images and vdb_op is not None:
+            stages.append("store")
+        logger.debug("pdf_doc pipeline stages: %s", " → ".join(stages))
+
         gi = GraphIngestor(run_mode=self._run_mode)
         gi = gi.files(filepaths)
         gi = gi.extract(make_extract_params(self._config, extract_override))
-
-        gi = gi.split(make_split_params(self._config))
-
+        if self._config.nv_ingest.enable_split:
+            gi = gi.split(make_split_params(self._config))
         if self._config.nv_ingest.extract_images:
             gi = gi.caption(make_caption_params(self._config))
-
         if vdb_op is not None:
             gi = gi.embed(make_embed_params(self._config))
-        
         if store_images and vdb_op is not None:
             gi = gi.store(make_store_params(self._config, vdb_op))
+        return gi
 
+    def _build_image_ingestor(
+        self,
+        filepaths: list[str],
+        split_options: dict[str, Any] | None,  # noqa: ARG002
+        extract_override: dict[str, Any] | None,
+        vdb_op: VDBRag | None,
+        store_images: bool,
+    ) -> GraphIngestor:
+        """Pipeline: extract_image_files → [caption] → [embed] → [store].
+
+        No split stage: each detected page element (text region, table, chart)
+        produced by the image extraction pipeline is already its own row;
+        splitting image-derived text is not meaningful.
+        """
+        stages = ["extract_image_files"]
+        if self._config.nv_ingest.extract_images:
+            stages.append("caption")
+        if vdb_op is not None:
+            stages.append("embed")
+        if store_images and vdb_op is not None:
+            stages.append("store")
+        logger.debug("image pipeline stages: %s", " → ".join(stages))
+
+        gi = GraphIngestor(run_mode=self._run_mode)
+        gi = gi.files(filepaths)
+        gi = gi.extract_image_files(make_extract_params(self._config, extract_override))
+        if self._config.nv_ingest.extract_images:
+            gi = gi.caption(make_caption_params(self._config))
+        if vdb_op is not None:
+            gi = gi.embed(make_embed_params(self._config))
+        if store_images and vdb_op is not None:
+            gi = gi.store(make_store_params(self._config, vdb_op))
+        return gi
+
+    def _build_text_ingestor(
+        self,
+        filepaths: list[str],
+        split_options: dict[str, Any] | None,  # noqa: ARG002
+        extract_override: dict[str, Any] | None,  # noqa: ARG002
+        vdb_op: VDBRag | None,
+        store_images: bool,  # noqa: ARG002
+    ) -> GraphIngestor:
+        """Pipeline: extract_txt → [embed].
+
+        Chunking is built into ``TextChunkParams`` passed to ``extract_txt``;
+        no separate split stage is added.  Caption and store stages are not
+        applicable to plain-text content.
+        """
+        stages = ["extract_txt"]
+        if vdb_op is not None:
+            stages.append("embed")
+        logger.debug("text pipeline stages: %s", " → ".join(stages))
+
+        gi = GraphIngestor(run_mode=self._run_mode)
+        gi = gi.files(filepaths)
+        gi = gi.extract_txt(make_split_params(self._config))
+        if vdb_op is not None:
+            gi = gi.embed(make_embed_params(self._config))
+        return gi
+
+    def _build_html_ingestor(
+        self,
+        filepaths: list[str],
+        split_options: dict[str, Any] | None,  # noqa: ARG002
+        extract_override: dict[str, Any] | None,  # noqa: ARG002
+        vdb_op: VDBRag | None,
+        store_images: bool,  # noqa: ARG002
+    ) -> GraphIngestor:
+        """Pipeline: extract_html → [embed].
+
+        Chunking is built into ``HtmlChunkParams`` passed to ``extract_html``;
+        no separate split stage is added.  Caption and store stages are not
+        applicable to HTML content.
+        """
+        stages = ["extract_html"]
+        if vdb_op is not None:
+            stages.append("embed")
+        logger.debug("html pipeline stages: %s", " → ".join(stages))
+
+        gi = GraphIngestor(run_mode=self._run_mode)
+        gi = gi.files(filepaths)
+        gi = gi.extract_html(make_html_chunk_params(self._config))
+        if vdb_op is not None:
+            gi = gi.embed(make_embed_params(self._config))
+        return gi
+
+    def _build_audio_video_ingestor(
+        self,
+        filepaths: list[str],
+        split_options: dict[str, Any] | None,  # noqa: ARG002
+        extract_override: dict[str, Any] | None,  # noqa: ARG002
+        vdb_op: VDBRag | None,
+        store_images: bool,  # noqa: ARG002
+    ) -> GraphIngestor:
+        """Pipeline: extract_audio → [embed].
+
+        Audio/video chunking and ASR transcription are configured via
+        ``AudioChunkParams`` and ``ASRParams``; no separate split stage is
+        added.  Caption and store stages are not applicable to transcribed
+        audio content.
+        """
+        stages = ["extract_audio"]
+        if vdb_op is not None:
+            stages.append("embed")
+        logger.debug("audio_video pipeline stages: %s", " → ".join(stages))
+
+        gi = GraphIngestor(run_mode=self._run_mode)
+        gi = gi.files(filepaths)
+        gi = gi.extract_audio(
+            make_audio_chunk_params(self._config),
+            asr_params=make_asr_params(self._config),
+        )
+        if vdb_op is not None:
+            gi = gi.embed(make_embed_params(self._config))
         return gi
 
     def _build_shallow_ingestor(self, filepaths: list[str]) -> GraphIngestor:
-        """Construct a text-only GraphIngestor for fast summarisation."""
+        """Construct a text-only GraphIngestor for fast summarisation.
+
+        Callers must pre-filter *filepaths* to PDF/DOC/PPTX before calling
+        this method; ``ingest_shallow`` handles that filtering.
+        """
         shallow_override: dict[str, Any] = {
             "extract_images": False,
             "extract_tables": False,
             "extract_charts": False,
             "extract_infographics": False,
         }
+        logger.debug(
+            "pdf_doc_shallow pipeline: extract (text-only) for %d file(s)",
+            len(filepaths),
+        )
         gi = GraphIngestor(run_mode=self._run_mode)
         gi = gi.files(filepaths)
         gi = gi.extract(make_extract_params(self._config, shallow_override))
@@ -194,12 +574,23 @@ class NemoRetrieverHandler:
     # Synchronous execution (runs inside ThreadPoolExecutor)
     # ------------------------------------------------------------------
 
-    def _run_sync(self, ingestor: GraphIngestor) -> pd.DataFrame:
+    def _run_sync(
+        self, ingestor: GraphIngestor, type_label: str = ""
+    ) -> pd.DataFrame:
         """Call ``ingestor.ingest()`` and materialise the result as a DataFrame.
 
         ``inprocess`` mode returns a ``pandas.DataFrame`` directly.
         ``batch`` mode returns a Ray Dataset that must be materialised with
         ``take_all()`` before this thread exits.
+
+        Parameters
+        ----------
+        ingestor:
+            Fully configured ``GraphIngestor`` ready to execute.
+        type_label:
+            Short string identifying the file-type group (e.g. ``"pdf_doc"``,
+            ``"audio_video"``).  Prepended to every log line so mixed-type
+            runs remain easy to trace in the logs.
 
         TODO(NRL-ASYNC): When NRL adds progress callbacks to GraphIngestor,
         wire them into ``IngestionStateManager.update_document_status()`` here.
@@ -207,9 +598,13 @@ class NemoRetrieverHandler:
             ingestor.on_document_complete = lambda doc_id: state_mgr.mark_completed(doc_id)
             ingestor.on_document_failed   = lambda doc_id, err: state_mgr.mark_failed(doc_id, err)
         """
+        label = f"[{type_label}] " if type_label else ""
         logger.info(
-            "NemoRetrieverHandler._run_sync starting (run_mode=%s)", self._run_mode
+            "NemoRetrieverHandler._run_sync %sstarting (run_mode=%s)",
+            label,
+            self._run_mode,
         )
+
         result = ingestor.ingest()
 
         if self._run_mode == "batch":
@@ -217,16 +612,16 @@ class NemoRetrieverHandler:
             # Ray is already initialised by GraphIngestor.ingest() in batch mode,
             # so we don't need to import it here — take_all() is a method on the
             # Dataset object that GraphIngestor returned.
+            logger.debug("%smaterialising Ray Dataset via take_all()", label)
             records = result.take_all()
             df = pd.DataFrame(records)
         else:
             df = result  # already a pandas.DataFrame in inprocess mode
 
-        # ------------------------------------------------------------------------------------------
-        # Ingestion summary for debugging.
+        # Per-type ingestion summary for debugging.
         chunks = df.to_dict(orient="records")
         ct_counts = Counter(dict(r).get("_content_type") for r in chunks)
-        logger.info("Ingestion using Nemo Retriever summary:")
+        logger.info("Ingestion %ssummary:", label)
         logger.info("  - Number of chunks: %d", len(chunks))
         logger.info("  - _content_type counts: %s", dict(ct_counts))
         if chunks:
@@ -234,9 +629,8 @@ class NemoRetrieverHandler:
                 "  - Contains embeddings: %s",
                 chunks[0].get("_contains_embeddings"),
             )
-        # ------------------------------------------------------------------------------------------
 
         logger.debug(
-            "NemoRetrieverHandler._run_sync complete (%d rows)", len(df)
+            "NemoRetrieverHandler._run_sync %scomplete (%d rows)", label, len(df)
         )
         return df

--- a/src/nvidia_rag/ingestor_server/nemo_retriever/handler.py
+++ b/src/nvidia_rag/ingestor_server/nemo_retriever/handler.py
@@ -169,11 +169,11 @@ class NemoRetrieverHandler:
         if self._config.nv_ingest.extract_images:
             gi = gi.caption(make_caption_params(self._config))
 
-        if store_images and vdb_op is not None:
-            gi = gi.store(make_store_params(self._config, vdb_op))
-
         if vdb_op is not None:
             gi = gi.embed(make_embed_params(self._config))
+        
+        if store_images and vdb_op is not None:
+            gi = gi.store(make_store_params(self._config, vdb_op))
 
         return gi
 

--- a/src/nvidia_rag/ingestor_server/nemo_retriever/params.py
+++ b/src/nvidia_rag/ingestor_server/nemo_retriever/params.py
@@ -27,10 +27,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from nemo_retriever.params import (
+    ASRParams,
+    AudioChunkParams,
     BatchTuningParams,
     CaptionParams,
     EmbedParams,
     ExtractParams,
+    HtmlChunkParams,
     StoreParams,
     TextChunkParams,
 )
@@ -163,6 +166,37 @@ def make_caption_params(config: NvidiaRAGConfig) -> CaptionParams:
     #     params["api_key"] = api_key
 
     return CaptionParams(**params)
+
+
+def make_html_chunk_params(config: NvidiaRAGConfig) -> HtmlChunkParams:
+    """Build ``HtmlChunkParams`` from ``NvidiaRAGConfig``.
+
+    ``HtmlChunkParams`` inherits ``TextChunkParams`` with no extra fields;
+    the same chunk_size / chunk_overlap config values are reused.
+    """
+    return HtmlChunkParams(
+        max_tokens=config.nv_ingest.chunk_size,
+        overlap_tokens=config.nv_ingest.chunk_overlap,
+    )
+
+
+def make_audio_chunk_params(config: NvidiaRAGConfig) -> AudioChunkParams:  # noqa: ARG001
+    """Build ``AudioChunkParams`` from ``NvidiaRAGConfig``.
+
+    NRL defaults (split_type="size", split_interval=450) are used; no
+    audio-specific fields exist in NvIngestConfig yet.
+    """
+    return AudioChunkParams()
+
+
+def make_asr_params(config: NvidiaRAGConfig) -> ASRParams:
+    """Build ``ASRParams`` from ``NvidiaRAGConfig``.
+
+    Maps:
+        ``config.nv_ingest.segment_audio`` → ``ASRParams.segment_audio``
+    All other ASR fields (endpoints, protocol, auth) use NRL defaults.
+    """
+    return ASRParams(segment_audio=config.nv_ingest.segment_audio)
 
 
 def make_store_params(config: NvidiaRAGConfig, vdb_op: VDBRag) -> StoreParams:

--- a/src/nvidia_rag/ingestor_server/nvingest.py
+++ b/src/nvidia_rag/ingestor_server/nvingest.py
@@ -159,8 +159,8 @@ def get_nv_ingest_ingestor(
         )
     ingestor = ingestor.extract(**extract_kwargs)
 
-    # Add splitting task (By default only works for text documents)
-    if split_options is not None:
+    # Add splitting task (controlled by enable_split flag, disabled by default)
+    if config.nv_ingest.enable_split and split_options is not None:
         split_source_types = ["text", "html", "mp3", "docx", "pptx"]
         split_source_types = (
             ["PDF"] + split_source_types
@@ -178,6 +178,8 @@ def get_nv_ingest_ingestor(
             ),
             params={"split_source_types": split_source_types},
         )
+    elif not config.nv_ingest.enable_split:
+        logger.info("Split task disabled (APP_NVINGEST_ENABLESPLIT=False). Skipping split stage.")
 
     # Add captioning task if extract_images is enabled
     if config.nv_ingest.extract_images:

--- a/src/nvidia_rag/utils/configuration.py
+++ b/src/nvidia_rag/utils/configuration.py
@@ -399,6 +399,11 @@ class NvIngestConfig(_ConfigBase):
             )
         return self
 
+    enable_split: bool = Field(
+        default=False,
+        env="APP_NVINGEST_ENABLESPLIT",
+        description="Enable text splitting/chunking stage during ingestion",
+    )
     enable_pdf_splitter: bool = Field(
         default=True,
         env="APP_NVINGEST_ENABLEPDFSPLITTER",

--- a/tests/integration/test_sequences.yaml
+++ b/tests/integration/test_sequences.yaml
@@ -94,7 +94,7 @@ sequences:
   nemo_retriever_library:
     name: "Nemo Retriever Library Tests"
     description: "Nemo Retriever Library functionality tests"
-    test_numbers: [1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 14]
+    test_numbers: [1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 14, 39, 40, 50, 51]
     pre_sequence: [18]  # Cleanup collection before tests
     post_sequence: [16, 17, 18, 19]  # Cleanup tests after sequence
 

--- a/tests/unit/test_ingestor_server/test_nemo_retriever/test_handler.py
+++ b/tests/unit/test_ingestor_server/test_nemo_retriever/test_handler.py
@@ -50,13 +50,13 @@ class TestNemoRetrieverHandlerBuildIngestor:
         for name in ("files", "extract", "split", "caption", "store", "embed"):
             getattr(mock_chain, name).return_value = mock_chain
 
-        nv = _nv_ingest_for_handler(extract_images=True)
+        nv = _nv_ingest_for_handler(extract_images=True, enable_split=True)
         config = NvidiaRAGConfig(nv_ingest=nv)
         h = NemoRetrieverHandler(config)
         try:
             vdb = MagicMock()
             vdb.collection_name = "c1"
-            h._build_ingestor(
+            h._build_pdf_doc_ingestor(
                 ["/tmp/a.pdf"],
                 split_options=None,
                 extract_override=None,
@@ -85,7 +85,7 @@ class TestNemoRetrieverHandlerBuildIngestor:
 
         h = NemoRetrieverHandler(nemo_config)
         try:
-            h._build_ingestor(
+            h._build_pdf_doc_ingestor(
                 ["/x.pdf"],
                 split_options=None,
                 extract_override=None,
@@ -146,7 +146,7 @@ class TestNemoRetrieverHandlerRunSync:
 class TestNemoRetrieverHandlerAsync:
     @pytest.mark.asyncio
     @patch.object(NemoRetrieverHandler, "_run_sync")
-    @patch.object(NemoRetrieverHandler, "_build_ingestor")
+    @patch.object(NemoRetrieverHandler, "_build_ingestors")
     async def test_ingest_returns_schema_manager(
         self,
         mock_build: MagicMock,
@@ -156,7 +156,7 @@ class TestNemoRetrieverHandlerAsync:
         df = pd.DataFrame({"c": [1]})
         mock_run.return_value = df
         mock_gi = MagicMock()
-        mock_build.return_value = mock_gi
+        mock_build.return_value = [("pdf_doc", mock_gi)]
 
         h = NemoRetrieverHandler(nemo_config)
         try:
@@ -168,7 +168,7 @@ class TestNemoRetrieverHandlerAsync:
         assert isinstance(result, IngestSchemaManager)
         assert result.row_count() == 1
         mock_build.assert_called_once()
-        mock_run.assert_called_once_with(mock_gi)
+        mock_run.assert_called_once_with(mock_gi, "pdf_doc")
 
     @pytest.mark.asyncio
     @patch.object(NemoRetrieverHandler, "_run_sync")

--- a/tests/unit/test_ingestor_server/test_nemo_retriever/test_package_exports.py
+++ b/tests/unit/test_ingestor_server/test_nemo_retriever/test_package_exports.py
@@ -7,6 +7,11 @@ from nvidia_rag.ingestor_server import nemo_retriever as pkg
 
 
 def test_public_exports() -> None:
-    assert set(pkg.__all__) == {"NemoRetrieverHandler", "IngestSchemaManager"}
+    assert set(pkg.__all__) == {
+        "NemoRetrieverHandler",
+        "IngestSchemaManager",
+        "filter_unsupported",
+    }
     assert pkg.NemoRetrieverHandler.__name__ == "NemoRetrieverHandler"
     assert pkg.IngestSchemaManager.__name__ == "IngestSchemaManager"
+    assert pkg.filter_unsupported.__name__ == "filter_unsupported"

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,10 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "pillow", specifier = ">=12.1.0" }]
+overrides = [
+    { name = "lance-namespace", specifier = ">=0.4.5,<0.7" },
+    { name = "pillow", specifier = ">=12.1.0" },
+]
 
 [[package]]
 name = "absl-py"

--- a/uv.lock
+++ b/uv.lock
@@ -59,6 +59,18 @@ wheels = [
 ]
 
 [[package]]
+name = "aiofile"
+version = "3.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/25/da1f0b4dd970e52bf5a36c204c107e11a0c6d3ed195eba0bfbc664c312b2/aiofile-3.9.0-py3-none-any.whl", hash = "sha256:ce2f6c1571538cbdfa0143b04e16b208ecb0e9cb4148e528af8a640ed51cc8aa", size = 19539, upload-time = "2024-10-08T10:39:32.955Z" },
+]
+
+[[package]]
 name = "aiofiles"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -327,6 +339,19 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/82/4d0603f30c1b4629b1f091bb266b0d7986434891d6940a8c87f8098db24e/authlib-1.7.0.tar.gz", hash = "sha256:b3e326c9aa9cc3ea95fe7d89fd880722d3608da4d00e8a27e061e64b48d801d5", size = 175890, upload-time = "2026-04-18T11:00:28.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/48/c954218b2a250e23f178f10167c4173fecb5a75d2c206f0a67ba58006c26/authlib-1.7.0-py2.py3-none-any.whl", hash = "sha256:e36817afb02f6f0b6bf55f150782499ddd6ddf44b402bb055d3263cc65ac9ae0", size = 258779, upload-time = "2026-04-18T11:00:26.64Z" },
+]
+
+[[package]]
 name = "azure-core"
 version = "1.38.0"
 source = { registry = "https://pypi.org/simple" }
@@ -370,6 +395,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
 ]
 
 [[package]]
@@ -450,6 +484,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/86/e7/18ea2907d2ca91e9c0697596b8e60cd485b091152eb4109fad1e468e457d/cachetools-6.2.5.tar.gz", hash = "sha256:6d8bfbba1ba94412fb9d9196c4da7a87e9d4928fffc5e93542965dca4740c77f", size = 32168, upload-time = "2026-01-25T14:57:40.349Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/a6/24169d70ec5264b65ba54ba49b3d10f46d6b1ad97e185c94556539b3dfc8/cachetools-6.2.5-py3-none-any.whl", hash = "sha256:db3ae5465e90befb7c74720dd9308d77a09b7cf13433570e07caa0845c30d5fe", size = 11553, upload-time = "2026-01-25T14:57:39.112Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
 ]
 
 [[package]]
@@ -805,6 +856,21 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclopts"
+version = "4.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/2c/fced34890f6e5a93a4b7afb2c71e8eee2a0719fb26193a0abf159ecb714d/cyclopts-4.10.2.tar.gz", hash = "sha256:d7b950457ef2563596d56331f80cbbbf86a2772535fb8b315c4f03bc7e6127f1", size = 166664, upload-time = "2026-04-08T23:57:45.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/bd/05055d8360cef0757d79367157f3b15c0a0715e81e08f86a04018ec045f0/cyclopts-4.10.2-py3-none-any.whl", hash = "sha256:a1f2d6f8f7afac9456b48f75a40b36658778ddc9c6d406b520d017ae32c990fe", size = 204314, upload-time = "2026-04-08T23:57:46.969Z" },
+]
+
+[[package]]
 name = "dataclass-wizard"
 version = "0.39.1"
 source = { registry = "https://pypi.org/simple" }
@@ -929,6 +995,24 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.22.4"
 source = { registry = "https://pypi.org/simple" }
@@ -971,6 +1055,31 @@ vectorstore-mmr = [
 ]
 
 [[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
 name = "face"
 version = "24.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1004,6 +1113,39 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", hash = "sha256:1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a", size = 365682, upload-time = "2025-12-27T15:21:13.714Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", hash = "sha256:aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d", size = 103094, upload-time = "2025-12-27T15:21:12.154Z" },
+]
+
+[[package]]
+name = "fastmcp"
+version = "3.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "authlib" },
+    { name = "cyclopts" },
+    { name = "exceptiongroup" },
+    { name = "griffelib" },
+    { name = "httpx" },
+    { name = "jsonref" },
+    { name = "jsonschema-path" },
+    { name = "mcp" },
+    { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pyperclip" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "uncalled-for" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/13/29544fbc6dfe45ea38046af0067311e0bad7acc7d1f2ad38bb08f2409fe2/fastmcp-3.2.4.tar.gz", hash = "sha256:083ecb75b44a4169e7fc0f632f94b781bdb0ff877c6b35b9877cbb566fd4d4d1", size = 28746127, upload-time = "2026-04-14T01:42:24.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/76/b310d52fa0e30d39bd937eb58ec2c1f1ea1b5f519f0575e9dd9612f01deb/fastmcp-3.2.4-py3-none-any.whl", hash = "sha256:e6c9c429171041455e47ab94bb3f83c4657622a0ec28922f6940053959bd58a9", size = 728599, upload-time = "2026-04-14T01:42:26.85Z" },
 ]
 
 [[package]]
@@ -1228,6 +1370,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/ba/56699ff9b7c76ca12f1cdc27a886d0f81f2189c3455ff9f65246780f713d/greenlet-3.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ab97cf74045343f6c60a39913fa59710e4bd26a536ce7ab2397adf8b27e67c39", size = 1567256, upload-time = "2025-12-04T15:04:25.276Z" },
     { url = "https://files.pythonhosted.org/packages/1e/37/f31136132967982d698c71a281a8901daf1a8fbab935dce7c0cf15f942cc/greenlet-3.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5375d2e23184629112ca1ea89a53389dddbffcf417dad40125713d88eb5f96e8", size = 1636483, upload-time = "2025-12-04T14:27:30.804Z" },
     { url = "https://files.pythonhosted.org/packages/7e/71/ba21c3fb8c5dce83b8c01f458a42e99ffdb1963aeec08fff5a18588d8fd7/greenlet-3.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:9ee1942ea19550094033c35d25d20726e4f1c40d59545815e1128ac58d416d38", size = 301833, upload-time = "2025-12-04T14:32:23.929Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
 ]
 
 [[package]]
@@ -1484,6 +1635,48 @@ wheels = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176", size = 10481, upload-time = "2025-12-21T09:29:42.27Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1557,6 +1750,18 @@ wheels = [
 ]
 
 [[package]]
+name = "joserfc"
+version = "1.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866, upload-time = "2026-04-13T13:15:40.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464, upload-time = "2026-04-13T13:15:39.259Z" },
+]
+
+[[package]]
 name = "jsonpatch"
 version = "1.33"
 source = { registry = "https://pypi.org/simple" }
@@ -1578,6 +1783,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonref"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1593,6 +1807,20 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema-path"
+version = "0.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/8a/7e6102f2b8bdc6705a9eb5294f8f6f9ccd3a8420e8e8e19671d1dd773251/jsonschema_path-0.4.5.tar.gz", hash = "sha256:c6cd7d577ae290c7defd4f4029e86fdb248ca1bd41a07557795b3c95e5144918", size = 15113, upload-time = "2026-03-03T09:56:46.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/d5/4e96c44f6c1ea3d812cf5391d81a4f5abaa540abf8d04ecd7f66e0ed11df/jsonschema_path-0.4.5-py3-none-any.whl", hash = "sha256:7d77a2c3f3ec569a40efe5c5f942c44c1af2a6f96fe0866794c9ef5b8f87fd65", size = 19368, upload-time = "2026-03-03T09:56:45.39Z" },
+]
+
+[[package]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1602,6 +1830,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -2195,6 +2440,31 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+]
+
+[[package]]
 name = "mdit-py-plugins"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2268,6 +2538,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/df/6dfc6540f96a74125a11653cce717603fd5b7d0001a8e847b3e54e72d238/minio-7.2.20.tar.gz", hash = "sha256:95898b7a023fbbfde375985aa77e2cd6a0762268db79cf886f002a9ea8e68598", size = 136113, upload-time = "2025-11-27T00:37:15.569Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/9a/b697530a882588a84db616580f2ba5d1d515c815e11c30d219145afeec87/minio-7.2.20-py3-none-any.whl", hash = "sha256:eb33dd2fb80e04c3726a76b13241c6be3c4c46f8d81e1d58e757786f6501897e", size = 93751, upload-time = "2025-11-27T00:37:13.993Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804", size = 144659, upload-time = "2026-04-09T15:01:33.297Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4", size = 71939, upload-time = "2026-04-09T15:01:32.21Z" },
 ]
 
 [[package]]
@@ -2396,11 +2675,12 @@ wheels = [
 
 [[package]]
 name = "nemo-retriever"
-version = "2026.4.15.dev62"
+version = "2026.4.21.dev68"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "debugpy" },
     { name = "fastapi" },
+    { name = "fastmcp" },
     { name = "httpx" },
     { name = "lancedb" },
     { name = "langchain-nvidia-ai-endpoints" },
@@ -2418,15 +2698,16 @@ dependencies = [
     { name = "ray", extra = ["data", "serve"] },
     { name = "requests" },
     { name = "rich" },
+    { name = "sqlglot" },
     { name = "tqdm" },
     { name = "typer" },
     { name = "universal-pathlib" },
     { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/10/f07c59a9c36a32695f5d7f4659de6bf75ba9bea4718e7fd8b86d0bcc0682/nemo_retriever-2026.4.15.dev62.tar.gz", hash = "sha256:75ed8c6d497f43cd3a4739e4dba057bfa03363af93c125b8d666527c10c15d97", size = 411485, upload-time = "2026-04-15T23:49:21.817Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/e8/082beef9b087ed8d4a10cfe0694600093bc97370bdc672203a552a6f9150/nemo_retriever-2026.4.21.dev68.tar.gz", hash = "sha256:224d9c1e8b43d601e8089042196c0db8d132f6231870967988d8acb0701eab15", size = 671832, upload-time = "2026-04-21T23:47:44.779Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/08/39542041d1978669807165708b25f0cd301fd7178551e36354f4c4f65667/nemo_retriever-2026.4.15.dev62-py3-none-any.whl", hash = "sha256:6c78874fac3f05831b69a4c187c56d3c8ae0d37a5c41211a75f20ae8a7efb63a", size = 449023, upload-time = "2026-04-15T23:49:16.498Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/96/82ec9fde87bb395793596aa200dc0b0c64e0398bb9c55a518630643885c0/nemo_retriever-2026.4.21.dev68-py3-none-any.whl", hash = "sha256:9f9cf34ef213b92885574bb1ea21c7fb9eaea6f4b7f81d3387c8f7295c7189e5", size = 750139, upload-time = "2026-04-21T23:47:39.539Z" },
 ]
 
 [[package]]
@@ -2506,7 +2787,7 @@ wheels = [
 
 [[package]]
 name = "nv-ingest"
-version = "2026.4.15.dev20260415"
+version = "2026.4.21.dev20260421"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-core" },
@@ -2561,14 +2842,14 @@ dependencies = [
     { name = "urllib3" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/aa/c4e1eb9ff3da3d998d9069a9199fc3d16cae5427e29e85b8280b7f316be3/nv_ingest-2026.4.15.dev20260415.tar.gz", hash = "sha256:f0f282de362aee199154c29306790556171f56c83d7aa3e8862fb3cbc0acc2c5", size = 155271, upload-time = "2026-04-15T23:49:20.541Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/85/3f3aafa0c94bedf6ef75512f038501ac0d5774164db15131e9ef75921ea4/nv_ingest-2026.4.21.dev20260421.tar.gz", hash = "sha256:643121742affa8dd3dbd00eded01a84cf758b04f20eff40f7e7bf4e3e7c29425", size = 155265, upload-time = "2026-04-21T23:47:43.599Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/01/d3ddcde6c6378b4b87d9c4faf05bb0515c12dbcfc442e3e4231c94c55d13/nv_ingest-2026.4.15.dev20260415-py3-none-any.whl", hash = "sha256:8e7ddcaaab36ca187016feb2cc575f0b5d31532049165b0641a60a7d1b5f8418", size = 223370, upload-time = "2026-04-15T23:49:14.845Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/db/bbf3cb6adba02c578d938ca09948a202be5d09617b2d23fed134e06a3db2/nv_ingest-2026.4.21.dev20260421-py3-none-any.whl", hash = "sha256:e6347e02bc347997965743b0e7440d2d32a5c60b1ad5743c2408cad40496629c", size = 223369, upload-time = "2026-04-21T23:47:37.861Z" },
 ]
 
 [[package]]
 name = "nv-ingest-api"
-version = "2026.4.15.dev20260415"
+version = "2026.4.21.dev20260421"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
@@ -2582,14 +2863,14 @@ dependencies = [
     { name = "tritonclient" },
     { name = "universal-pathlib" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/fb/d12650f99ce74a9261747c4cd29365e07df796dc13657194915ffb6489f3/nv_ingest_api-2026.4.15.dev20260415.tar.gz", hash = "sha256:92422eaf7c542f9c1b9e1bf14aa4719a7faa9810ea141553681c871522fc652d", size = 280564, upload-time = "2026-04-15T23:49:18.224Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/3b/b48fd6963b285cd33d665c504ff4e440030f7a7d99e8f6c9c8ebc483c991/nv_ingest_api-2026.4.21.dev20260421.tar.gz", hash = "sha256:2c3b47191a3311751e188c658b1190e02e7c9226b095c80e71d624b14065b6ff", size = 280648, upload-time = "2026-04-21T23:47:41.189Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/da/1e8ca505b4d14192825f3d155afba6be53d1acecb73060262d5bcb35b1b0/nv_ingest_api-2026.4.15.dev20260415-py3-none-any.whl", hash = "sha256:2b6d879cd1c3c12c8caf4a56a402a64745aa42d239570b6d85b80ee0ebffad20", size = 378695, upload-time = "2026-04-15T23:49:11.051Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/d5/789b483864490956452399f79d39dd7c58977f1be5d887e78075dce3dcd8/nv_ingest_api-2026.4.21.dev20260421-py3-none-any.whl", hash = "sha256:65c7d57e255f5c09ae156407e608d3e9ca56fc859e4f9e0d7b372afa32bd78e0", size = 378696, upload-time = "2026-04-21T23:47:34.655Z" },
 ]
 
 [[package]]
 name = "nv-ingest-client"
-version = "2026.4.15.dev20260415"
+version = "2026.4.21.dev20260421"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build" },
@@ -2605,9 +2886,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/c6/68d51b4c5ca539d75f3adea2cc5cefbaf4e892c5ec480006928dc30e42e0/nv_ingest_client-2026.4.15.dev20260415.tar.gz", hash = "sha256:04266abac617dfe61ba6cd4b0d2ec224257db33a99c948ed89be2dae8fd10e0a", size = 125678, upload-time = "2026-04-15T23:49:19.575Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/8a/1bcbd1fde7998648f068dbaafb2fc8aba6afd965cd95292d2bc53d5317ab/nv_ingest_client-2026.4.21.dev20260421.tar.gz", hash = "sha256:42da5e3e39c559e942035ae8c5d37690510c102878c1786715a83bbf4d158feb", size = 125675, upload-time = "2026-04-21T23:47:42.393Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/1b/5a5c0f3ce0af7059742a7958a873531f487dc583e1c000fe0bbe7e495cac/nv_ingest_client-2026.4.15.dev20260415-py3-none-any.whl", hash = "sha256:a753879392322c735fb1ad28962a71b47a18803307e6153fd766c189358c3fed", size = 147184, upload-time = "2026-04-15T23:49:12.995Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/a3/4c2325a233e178462997035f87b5ff2e613f119b9fbba4b89e42b3c0848c/nv_ingest_client-2026.4.21.dev20260421-py3-none-any.whl", hash = "sha256:12f7b843e135f28589782096ab8bb83e7bf536f029927988b4a15bc3bd8c04c7", size = 147187, upload-time = "2026-04-21T23:47:36.273Z" },
 ]
 
 [[package]]
@@ -2754,14 +3035,14 @@ requires-dist = [
     { name = "langchain-openai", marker = "extra == 'rag'", specifier = ">=0.2,<1.1.9" },
     { name = "lark", specifier = ">=1.2.2" },
     { name = "minio", specifier = ">=7.2,<8.0" },
-    { name = "nemo-retriever", marker = "extra == 'all'", specifier = "==2026.4.15.dev62" },
-    { name = "nemo-retriever", marker = "extra == 'ingest'", specifier = "==2026.4.15.dev62" },
-    { name = "nv-ingest", marker = "extra == 'all'", specifier = "==2026.4.15.dev20260415" },
-    { name = "nv-ingest", marker = "extra == 'ingest'", specifier = "==2026.4.15.dev20260415" },
-    { name = "nv-ingest-api", marker = "extra == 'all'", specifier = "==2026.4.15.dev20260415" },
-    { name = "nv-ingest-api", marker = "extra == 'ingest'", specifier = "==2026.4.15.dev20260415" },
-    { name = "nv-ingest-client", marker = "extra == 'all'", specifier = "==2026.4.15.dev20260415" },
-    { name = "nv-ingest-client", marker = "extra == 'ingest'", specifier = "==2026.4.15.dev20260415" },
+    { name = "nemo-retriever", marker = "extra == 'all'", specifier = "==2026.4.21.dev68" },
+    { name = "nemo-retriever", marker = "extra == 'ingest'", specifier = "==2026.4.21.dev68" },
+    { name = "nv-ingest", marker = "extra == 'all'", specifier = "==2026.4.21.dev20260421" },
+    { name = "nv-ingest", marker = "extra == 'ingest'", specifier = "==2026.4.21.dev20260421" },
+    { name = "nv-ingest-api", marker = "extra == 'all'", specifier = "==2026.4.21.dev20260421" },
+    { name = "nv-ingest-api", marker = "extra == 'ingest'", specifier = "==2026.4.21.dev20260421" },
+    { name = "nv-ingest-client", marker = "extra == 'all'", specifier = "==2026.4.21.dev20260421" },
+    { name = "nv-ingest-client", marker = "extra == 'ingest'", specifier = "==2026.4.21.dev20260421" },
     { name = "opentelemetry-api", marker = "extra == 'all'", specifier = ">=1.29,<2.0" },
     { name = "opentelemetry-api", marker = "extra == 'ingest'", specifier = ">=1.29,<2.0" },
     { name = "opentelemetry-api", marker = "extra == 'rag'", specifier = ">=1.29,<2.0" },
@@ -2894,6 +3175,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/94/f4/4690ecb5d70023ce6bfcfeabfe717020f654bde59a775058ec6ac4692463/openai-2.15.0.tar.gz", hash = "sha256:42eb8cbb407d84770633f31bf727d4ffb4138711c670565a41663d9439174fba", size = 627383, upload-time = "2026-01-09T22:10:08.603Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/df/c306f7375d42bafb379934c2df4c2fa3964656c8c782bac75ee10c102818/openai-2.15.0-py3-none-any.whl", hash = "sha256:6ae23b932cd7230f7244e52954daa6602716d6b9bf235401a107af731baea6c3", size = 1067879, upload-time = "2026-01-09T22:10:06.446Z" },
+]
+
+[[package]]
+name = "openapi-pydantic"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
 ]
 
 [[package]]
@@ -3289,6 +3582,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pathable"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/55/b748445cb4ea6b125626f15379be7c96d1035d4fa3e8fee362fa92298abf/pathable-0.5.0.tar.gz", hash = "sha256:d81938348a1cacb525e7c75166270644782c0fb9c8cecc16be033e71427e0ef1", size = 16655, upload-time = "2026-02-20T08:47:00.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/96/5a770e5c461462575474468e5af931cff9de036e7c2b4fea23c1c58d2cbe/pathable-0.5.0-py3-none-any.whl", hash = "sha256:646e3d09491a6351a0c82632a09c02cdf70a252e73196b36d8a15ba0a114f0a6", size = 16867, upload-time = "2026-02-20T08:46:59.536Z" },
+]
+
+[[package]]
 name = "pathlib-abc"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3533,6 +3835,31 @@ wheels = [
 ]
 
 [[package]]
+name = "py-key-value-aio"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/69/f1b537ee70b7def42d63124a539ed3026a11a3ffc3086947a1ca6e861868/py_key_value_aio-0.4.4-py3-none-any.whl", hash = "sha256:18e17564ecae61b987f909fc2cd41ee2012c84b4b1dcb8c055cf8b4bc1bf3f5d", size = 152291, upload-time = "2026-02-16T21:21:44.241Z" },
+]
+
+[package.optional-dependencies]
+filetree = [
+    { name = "aiofile" },
+    { name = "anyio" },
+]
+keyring = [
+    { name = "keyring" },
+]
+memory = [
+    { name = "cachetools" },
+]
+
+[[package]]
 name = "py-spy"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3651,6 +3978,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
 ]
 
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
+]
+
 [[package]]
 name = "pydantic-core"
 version = "2.41.5"
@@ -3733,6 +4065,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -3824,6 +4170,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/90/47/eda4904f715fb98561e34012826e883816945934a851745570521ec89520/pypdfium2-4.30.0-py3-none-win32.whl", hash = "sha256:ee2410f15d576d976c2ab2558c93d392a25fb9f6635e8dd0a8a3a5241b275e0e", size = 2775951, upload-time = "2024-05-09T18:33:10.567Z" },
     { url = "https://files.pythonhosted.org/packages/25/bd/56d9ec6b9f0fc4e0d95288759f3179f0fcd34b1a1526b75673d2f6d5196f/pypdfium2-4.30.0-py3-none-win_amd64.whl", hash = "sha256:90dbb2ac07be53219f56be09961eb95cf2473f834d01a42d901d13ccfad64b4c", size = 2892098, upload-time = "2024-05-09T18:33:13.107Z" },
     { url = "https://files.pythonhosted.org/packages/be/7a/097801205b991bc3115e8af1edb850d30aeaf0118520b016354cf5ccd3f6/pypdfium2-4.30.0-py3-none-win_arm64.whl", hash = "sha256:119b2969a6d6b1e8d55e99caaf05290294f2d0fe49c12a3f17102d01c441bd29", size = 2752118, upload-time = "2024-05-09T18:33:15.489Z" },
+]
+
+[[package]]
+name = "pyperclip"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
 ]
 
 [[package]]
@@ -3992,6 +4347,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -4229,6 +4606,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich-rst"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl", hash = "sha256:a99b4907cbe118cf9d18b0b44de272efa61f15117c61e39ebdc431baf5df722a", size = 12567, upload-time = "2025-10-14T16:49:42.953Z" },
+]
+
+[[package]]
 name = "roman-numerals"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4421,6 +4811,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/90/b8/4f0f5cf0c5ea4d7548424e6533e6b17d164f34a6e2fb2e43ffebb6697b06/scipy-1.17.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:cacbaddd91fcffde703934897c5cd2c7cb0371fac195d383f4e1f1c5d3f3bd04", size = 37438061, upload-time = "2026-01-10T21:28:19.684Z" },
     { url = "https://files.pythonhosted.org/packages/f9/cc/2bd59140ed3b2fa2882fb15da0a9cb1b5a6443d67cfd0d98d4cec83a57ec/scipy-1.17.0-cp313-cp313t-win_amd64.whl", hash = "sha256:edce1a1cf66298cccdc48a1bdf8fb10a3bf58e8b58d6c3883dd1530e103f87c0", size = 36328593, upload-time = "2026-01-10T21:28:28.007Z" },
     { url = "https://files.pythonhosted.org/packages/13/1b/c87cc44a0d2c7aaf0f003aef2904c3d097b422a96c7e7c07f5efd9073c1b/scipy-1.17.0-cp313-cp313t-win_arm64.whl", hash = "sha256:30509da9dbec1c2ed8f168b8d8aa853bc6723fede1dbc23c7d43a56f5ab72a67", size = 24625083, upload-time = "2026-01-10T21:28:35.188Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
 ]
 
 [[package]]
@@ -4735,6 +5138,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/8d/bb40a5d10e7a5f2195f235c0b2f2c79b0bf6e8f00c0c223130a4fbd2db09/sqlalchemy-2.0.45-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:83d7009f40ce619d483d26ac1b757dfe3167b39921379a8bd1b596cf02dab4a6", size = 3521998, upload-time = "2025-12-09T22:13:28.622Z" },
     { url = "https://files.pythonhosted.org/packages/75/a5/346128b0464886f036c039ea287b7332a410aa2d3fb0bb5d404cb8861635/sqlalchemy-2.0.45-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d8a2ca754e5415cde2b656c27900b19d50ba076aa05ce66e2207623d3fe41f5a", size = 3473434, upload-time = "2025-12-09T22:13:30.188Z" },
     { url = "https://files.pythonhosted.org/packages/bf/e1/3ccb13c643399d22289c6a9786c1a91e3dcbb68bce4beb44926ac2c557bf/sqlalchemy-2.0.45-py3-none-any.whl", hash = "sha256:5225a288e4c8cc2308dbdd874edad6e7d0fd38eac1e9e5f23503425c8eee20d0", size = 1936672, upload-time = "2025-12-09T21:54:52.608Z" },
+]
+
+[[package]]
+name = "sqlglot"
+version = "30.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/66/6ece15f197874e56c76e1d0269cebf284ba992a80dfadca9d1972fdf7edf/sqlglot-30.6.0.tar.gz", hash = "sha256:246d34d39927422a50a3fa155f37b2f6346fba85f1a755b13c941eb32ef93361", size = 5835307, upload-time = "2026-04-20T20:11:08.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/e7/64fe971cbca33a0446b06f4a5ff8e3fa4a1dbd0a039ceabcc3e6cf4087a9/sqlglot-30.6.0-py3-none-any.whl", hash = "sha256:e005fc2f47994f90d7d8df341f1cbe937518497b0b7b1507d4c03c4c9dfd2778", size = 673920, upload-time = "2026-04-20T20:11:05.758Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/7f/3de5402f39890ac5660b86bcf5c03f9d855dad5c4ed764866d7b592b46fd/sse_starlette-3.3.4-py3-none-any.whl", hash = "sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1", size = 14330, upload-time = "2026-03-29T09:00:21.846Z" },
 ]
 
 [[package]]
@@ -5053,6 +5478,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
+]
+
+[[package]]
+name = "uncalled-for"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/68/35c1d87e608940badbcfeb630347aa0509897284684f61fab6423d02b253/uncalled_for-0.3.1.tar.gz", hash = "sha256:5e412ac6708f04b56bef5867b5dcf6690ebce4eb7316058d9c50787492bb4bca", size = 49693, upload-time = "2026-04-07T13:05:06.462Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/e1/7ec67882ad8fc9f86384bef6421fa252c9cbe5744f8df6ce77afc9eca1f5/uncalled_for-0.3.1-py3-none-any.whl", hash = "sha256:074cdc92da8356278f93d0ded6f2a66dd883dbecaf9bc89437646ee2289cc200", size = 11361, upload-time = "2026-04-07T13:05:05.341Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# NRL: nightly bump, embed-before-store, filetype filter, HTML/audio pipelines

## Summary

- Bump `nemo-retriever` / `nv-ingest*` to **2026.4.21** nightlies (`uv.lock`, small notebook tweak).
- NRL image path: run **`.embed()` before `.store()`**.
- Pre-filter unsupported extensions (`filter_unsupported` + `main.py`) so users get **Unsupported file type** instead of silent empty chunks.
- Handler gains **HTML / audio+ASR** pipelines and param builders; NRL integration sequence adds tests **39, 40, 50, 51**.
- Add disable split() config 

## Checklist
- [X] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [X] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [X] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.