### PR TITLE
Added VLM generation support in NRL | Added INGESTOR_BACKEND in rag-server | Moved store before embed for stored_image_uri in lancedb fix

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1140,6 +1140,58 @@ jobs:
           docker logs compose-nv-ingest-ms-runtime-1 > logs/nemo-retriever-library/nvingest.log 2>&1 || true
           cp tests/integration/integration_test.log logs/nemo-retriever-library/ 2>/dev/null || true
 
+      # ------------------------------------------------------------------------
+      # NRL + LanceDB: VLM generation (same API tests as vlm_generation)
+      # ------------------------------------------------------------------------
+      - name: Configure environment for NeMo Retriever Library VLM generation tests
+        run: |
+          echo "ENABLE_VLM_INFERENCE=True" >> $GITHUB_ENV
+          echo "APP_NVINGEST_EXTRACTIMAGES=False" >> $GITHUB_ENV
+          echo "ENABLE_QUERYREWRITER=False" >> $GITHUB_ENV
+          echo "CONVERSATION_HISTORY=0" >> $GITHUB_ENV
+
+      - name: Restart services for NeMo Retriever Library VLM generation tests
+        env:
+          CI_NVSTAGING_BLUEPRINT_KEY: ${{ secrets.CI_NVSTAGING_BLUEPRINT_KEY }}
+        run: |
+          echo "Relaunching RAG and ingestor with LanceDB + NRL + VLM generation..."
+          export APP_VECTORSTORE_URL=/volumes/lancedb/lancedb
+          export APP_VECTORSTORE_NAME=lancedb
+          export INGESTOR_BACKEND=nrl
+          export APP_EMBEDDINGS_MODELNAME=nvidia/llama-nemotron-embed-1b-v2
+          export APP_EMBEDDINGS_SERVERURL=https://integrate.api.nvidia.com/v1
+          export APP_NVINGEST_EXTRACTIMAGES=False
+          export APP_NVINGEST_IMAGE_ELEMENTS_MODALITY=
+          export APP_TRACING_ENABLED=False
+          export ENABLE_VLM_INFERENCE=True
+          export ENABLE_RERANKER=True
+          export APP_RANKING_SERVERURL=
+          docker compose -f deploy/compose/docker-compose-rag-server.yaml down || true
+          docker compose -f deploy/compose/docker-compose-ingestor-server.yaml down || true
+          sleep 5
+          docker compose -f deploy/compose/docker-compose-rag-server.yaml up -d --build
+          docker compose -f deploy/compose/docker-compose-ingestor-server.yaml up -d --build
+          sleep 30
+          docker ps
+
+      - name: Run NeMo Retriever Library VLM generation integration tests
+        id: nemo-retriever-library-vlm-generation-tests
+        continue-on-error: true
+        run: |
+          source venv/bin/activate
+          echo "Running NeMo Retriever Library VLM generation integration tests (sequence nemo_retriever_library_vlm_generation)..."
+          python -m tests.integration.main --sequence nemo_retriever_library_vlm_generation
+          echo "NeMo Retriever Library VLM generation integration tests completed"
+
+      - name: Collect logs after NeMo Retriever Library VLM generation tests
+        if: always()
+        run: |
+          mkdir -p logs/nemo-retriever-library-vlm-generation
+          docker logs rag-server > logs/nemo-retriever-library-vlm-generation/rag-server.log 2>&1 || true
+          docker logs ingestor-server > logs/nemo-retriever-library-vlm-generation/ingestor-server.log 2>&1 || true
+          docker logs compose-nv-ingest-ms-runtime-1 > logs/nemo-retriever-library-vlm-generation/nvingest.log 2>&1 || true
+          cp tests/integration/integration_test.log logs/nemo-retriever-library-vlm-generation/ 2>/dev/null || true
+
       - name: Restore default vector store and ingestor backend after NRL tests
         if: always()
         env:
@@ -1166,7 +1218,7 @@ jobs:
       # All test steps use continue-on-error so every suite runs; this step
       # marks the job as failed if any of them failed.
       - name: Fail job if any integration test failed
-        if: always() && (steps.basic-tests.outcome == 'failure' || steps.milvus-sequence-tests.outcome == 'failure' || steps.query-rewriter-tests.outcome == 'failure' || steps.reflection-tests.outcome == 'failure' || steps.guardrails-tests.outcome == 'failure' || steps.image-captioning-tests.outcome == 'failure' || steps.vlm-generation-tests.outcome == 'failure' || steps.multimodal-query-tests.outcome == 'failure' || steps.custom-prompt-tests.outcome == 'failure' || steps.library-usage-tests.outcome == 'failure' || steps.library-summarization-tests.outcome == 'failure' || steps.observability-tests.outcome == 'failure' || steps.milvus-vdb-auth-tests.outcome == 'failure' || steps.nemo-retriever-library-tests.outcome == 'failure')
+        if: always() && (steps.basic-tests.outcome == 'failure' || steps.milvus-sequence-tests.outcome == 'failure' || steps.query-rewriter-tests.outcome == 'failure' || steps.reflection-tests.outcome == 'failure' || steps.guardrails-tests.outcome == 'failure' || steps.image-captioning-tests.outcome == 'failure' || steps.vlm-generation-tests.outcome == 'failure' || steps.multimodal-query-tests.outcome == 'failure' || steps.custom-prompt-tests.outcome == 'failure' || steps.library-usage-tests.outcome == 'failure' || steps.library-summarization-tests.outcome == 'failure' || steps.observability-tests.outcome == 'failure' || steps.milvus-vdb-auth-tests.outcome == 'failure' || steps.nemo-retriever-library-tests.outcome == 'failure' || steps.nemo-retriever-library-vlm-generation-tests.outcome == 'failure')
         run: |
           echo "=== Failed integration test suites ==="
           [ "${{ steps.basic-tests.outcome }}" = "failure" ] && echo "  - basic-tests"
@@ -1183,6 +1235,7 @@ jobs:
           [ "${{ steps.observability-tests.outcome }}" = "failure" ] && echo "  - observability-tests"
           [ "${{ steps.milvus-vdb-auth-tests.outcome }}" = "failure" ] && echo "  - milvus-vdb-auth-tests"
           [ "${{ steps.nemo-retriever-library-tests.outcome }}" = "failure" ] && echo "  - nemo-retriever-library-tests"
+          [ "${{ steps.nemo-retriever-library-vlm-generation-tests.outcome }}" = "failure" ] && echo "  - nemo-retriever-library-vlm-generation-tests"
           echo "One or more integration test suites failed. Failing job."
           exit 1
 

--- a/deploy/compose/docker-compose-rag-server.yaml
+++ b/deploy/compose/docker-compose-rag-server.yaml
@@ -132,6 +132,9 @@ services:
       # VLM model name
       APP_VLM_MODELNAME: ${APP_VLM_MODELNAME:-"nvidia/nemotron-nano-12b-v2-vl"}
 
+      # Ingestion backend: "nv_ingest" (NV-Ingest microservice) or "nrl" (NeMo-Retriever Library in-process)
+      INGESTOR_BACKEND: ${INGESTOR_BACKEND:-nv_ingest}
+
       NVIDIA_API_KEY: ${NGC_API_KEY:?"NGC_API_KEY is required"}
 
       # ==== Service-Specific API Keys (Optional) ====

--- a/deploy/helm/nvidia-blueprint-rag/values.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/values.yaml
@@ -218,6 +218,8 @@ envVars:
   APP_TEXTSPLITTER_CHUNKOVERLAP: "200"
 
   # === General ===
+  # Ingestion backend: "nv_ingest" (NV-Ingest microservice) or "nrl" (NeMo-Retriever Library in-process)
+  INGESTOR_BACKEND: "nv_ingest"
   # Choose whether to enable citations in the response
   ENABLE_CITATIONS: "True"
   # Choose whether to enable/disable guardrails

--- a/src/nvidia_rag/ingestor_server/nemo_retriever/handler.py
+++ b/src/nvidia_rag/ingestor_server/nemo_retriever/handler.py
@@ -427,10 +427,10 @@ class NemoRetrieverHandler:
             gi = gi.split(make_split_params(self._config))
         if self._config.nv_ingest.extract_images:
             gi = gi.caption(make_caption_params(self._config))
-        if vdb_op is not None:
-            gi = gi.embed(make_embed_params(self._config))
         if store_images and vdb_op is not None:
             gi = gi.store(make_store_params(self._config, vdb_op))
+        if vdb_op is not None:
+            gi = gi.embed(make_embed_params(self._config))
         return gi
 
     def _build_image_ingestor(
@@ -461,10 +461,10 @@ class NemoRetrieverHandler:
         gi = gi.extract_image_files(make_extract_params(self._config, extract_override))
         if self._config.nv_ingest.extract_images:
             gi = gi.caption(make_caption_params(self._config))
-        if vdb_op is not None:
-            gi = gi.embed(make_embed_params(self._config))
         if store_images and vdb_op is not None:
             gi = gi.store(make_store_params(self._config, vdb_op))
+        if vdb_op is not None:
+            gi = gi.embed(make_embed_params(self._config))
         return gi
 
     def _build_text_ingestor(

--- a/src/nvidia_rag/rag_server/main.py
+++ b/src/nvidia_rag/rag_server/main.py
@@ -365,14 +365,13 @@ class NvidiaRAG:
 
     @property
     def _is_nrl_mode(self) -> bool:
-        """Return True when the active vector store is LanceDB (NRL ingestion mode).
+        """Return True when the NRL ingestion backend is active.
 
-        NRL (NemoRetriever Library) always uses LanceDB as its vector store.
         When this flag is True, ``prepare_citations_nrl`` is used instead of
         ``prepare_citations`` because NRL documents carry flat text metadata
         rather than the nv-ingest structured metadata (with MinIO image assets).
         """
-        return self.config.vector_store.name == "lancedb"
+        return self.config.nv_ingest.backend == "nrl"
 
     def _validate_collections_exist(
         self, collection_names: list[str], vdb_op: VDBRag
@@ -2853,10 +2852,16 @@ class NvidiaRAG:
                 try:
                     for d in context_to_show:
                         meta = getattr(d, "metadata", {}) or {}
-                        content_md = meta.get("content_metadata", {}) or {}
-                        if content_md.get("type") in ["image", "structured"]:
-                            has_images_in_context = True
-                            break
+                        if self._is_nrl_mode:
+                            # NRL uses flat stored_image_uri to signal visual chunks
+                            if meta.get("stored_image_uri"):
+                                has_images_in_context = True
+                                break
+                        else:
+                            content_md = meta.get("content_metadata", {}) or {}
+                            if content_md.get("type") in ["image", "structured"]:
+                                has_images_in_context = True
+                                break
                 except Exception:
                     # If metadata inspection fails, be conservative and proceed
                     has_images_in_context = False
@@ -2956,6 +2961,7 @@ class NvidiaRAG:
                             top_p=vlm_top_p_cfg,
                             max_tokens=vlm_max_tokens_cfg,
                             max_total_images=vlm_max_total_images_cfg,
+                            nrl_mode=self._is_nrl_mode,
                         )
                         # Eagerly prefetch first chunk to trigger any errors before creating RAGResponse
                         # ensures connection errors are caught early

--- a/src/nvidia_rag/rag_server/vlm.py
+++ b/src/nvidia_rag/rag_server/vlm.py
@@ -251,6 +251,7 @@ class VLM:
         question_text: str | None,
         max_total_images: int | None = None,
         organize_by_page: bool = False,
+        nrl_mode: bool = False,
     ) -> tuple[
         SystemMessage, HumanMessage, list[HumanMessage | AIMessage | SystemMessage]
     ]:
@@ -258,6 +259,8 @@ class VLM:
         Build system and user messages from template, normalize chat history, and
         extract any query/context images to be attached to the last human message.
         When organize_by_page=True, interleaves text and images per page.
+        When nrl_mode=True, uses NRL metadata layout (stored_image_uri) instead of
+        nv-ingest nested content_metadata.
         """
         textual_context = (
             context_text if context_text is not None else self._format_docs_text(docs)
@@ -296,6 +299,7 @@ class VLM:
                 question_text,
                 docs,
                 remaining_image_budget,
+                nrl_mode=nrl_mode,
             )
         else:
             human_template = vlm_template.get("human") or "{context}\n\n{question}"
@@ -304,9 +308,14 @@ class VLM:
                 question=(question_text or "").strip(),
             )
             content_parts = [{"type": "text", "text": formatted_human}]
-            content_parts.extend(
-                self._extract_images_from_docs(docs, remaining_image_budget)
-            )
+            if nrl_mode:
+                content_parts.extend(
+                    self._extract_images_from_docs_nrl(docs, remaining_image_budget)
+                )
+            else:
+                content_parts.extend(
+                    self._extract_images_from_docs(docs, remaining_image_budget)
+                )
 
         citations_instruct_user_message = HumanMessage(content=content_parts)
         return (system_message, citations_instruct_user_message, chat_history_messages)
@@ -348,7 +357,7 @@ class VLM:
         docs: list[Any],
         remaining_image_budget: int | None,
     ) -> list[dict[str, Any]]:
-        """Extract image parts from docs for MinIO thumbnails."""
+        """Extract image parts from nv-ingest docs using source_location from MinIO."""
         parts: list[dict[str, Any]] = []
         for doc in docs or []:
             if remaining_image_budget is not None and remaining_image_budget <= 0:
@@ -394,6 +403,42 @@ class VLM:
                 continue
         return parts
 
+    def _extract_images_from_docs_nrl(
+        self,
+        docs: list[Any],
+        remaining_image_budget: int | None,
+    ) -> list[dict[str, Any]]:
+        """Extract image parts from NRL docs using stored_image_uri from MinIO.
+
+        In NRL mode every chunk (including text chunks) may carry a page image
+        URI in ``stored_image_uri``.  This method fetches those images and
+        returns them as base64-PNG image_url parts for VLM consumption.
+        """
+        parts: list[dict[str, Any]] = []
+        for doc in docs or []:
+            if remaining_image_budget is not None and remaining_image_budget <= 0:
+                break
+            metadata = getattr(doc, "metadata", {}) or {}
+            stored_image_uri: str = metadata.get("stored_image_uri") or ""
+            if not stored_image_uri:
+                continue
+            try:
+                object_name = object_key_from_storage_uri(stored_image_uri)
+                raw_content = get_minio_operator().get_object(object_name)
+                content_b64 = base64.b64encode(raw_content).decode("ascii")
+                if not content_b64:
+                    continue
+                png_b64 = VLM._convert_image_url_to_png_b64(content_b64)
+                parts.append({
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/png;base64,{png_b64}"},
+                })
+                if remaining_image_budget is not None:
+                    remaining_image_budget -= 1
+            except Exception:
+                continue
+        return parts
+
     def _build_content_parts_by_page(
         self,
         vlm_template: dict[str, Any],
@@ -401,8 +446,16 @@ class VLM:
         question_text: str | None,
         docs: list[Any],
         remaining_image_budget: int | None,
+        nrl_mode: bool = False,
     ) -> list[dict[str, Any]]:
-        """Build content_parts with text and images interleaved per page."""
+        """Build content_parts with text and images interleaved per page.
+
+        When nrl_mode=True, uses flat NRL metadata fields (page_number,
+        filename/path/source, stored_image_uri) instead of the nested
+        nv-ingest content_metadata structure.  In NRL mode a single chunk may
+        carry both text content (page_content) *and* a page image
+        (stored_image_uri), so both are included.
+        """
         human_template = vlm_template.get("human") or "{context}\n\n{question}"
         intro = human_template.format(context="", question="").rstrip()
         if intro.endswith("Context:"):
@@ -413,13 +466,28 @@ class VLM:
         no_page: list[Any] = []
         for doc in docs or []:
             meta = getattr(doc, "metadata", {}) or {}
-            content_md = meta.get("content_metadata", {}) or {}
-            page_num = content_md.get("page_number")
-            source = meta.get("source", {})
-            source_path = (
-                source.get("source_name", "") if isinstance(source, dict) else source
-            )
-            source_key = str(source_path) if source_path else ""
+            if nrl_mode:
+                raw_page = meta.get("page_number")
+                if raw_page is not None:
+                    try:
+                        page_num: int | None = int(raw_page)
+                    except (TypeError, ValueError):
+                        page_num = None
+                else:
+                    page_num = None
+                raw_source = (
+                    meta.get("path") or meta.get("filename") or meta.get("source") or ""
+                )
+                source_key = str(raw_source) if raw_source else ""
+            else:
+                content_md = meta.get("content_metadata", {}) or {}
+                page_num = content_md.get("page_number")
+                source = meta.get("source", {})
+                source_path = (
+                    source.get("source_name", "") if isinstance(source, dict) else source
+                )
+                source_key = str(source_path) if source_path else ""
+
             if page_num is not None:
                 has_page.append((source_key, int(page_num), doc))
             else:
@@ -437,11 +505,21 @@ class VLM:
             text_parts: list[str] = []
             image_docs: list[Any] = []
             for d in doc_list:
-                content_md = (getattr(d, "metadata", {}) or {}).get("content_metadata", {}) or {}
-                if content_md.get("type") in ["image", "structured"]:
-                    image_docs.append(d)
+                if nrl_mode:
+                    # In NRL mode a chunk can contribute text AND a page image.
+                    text_content = getattr(d, "page_content", "") or ""
+                    if text_content:
+                        text_parts.append(text_content)
+                    d_meta = getattr(d, "metadata", {}) or {}
+                    if d_meta.get("stored_image_uri"):
+                        image_docs.append(d)
                 else:
-                    text_parts.append(getattr(d, "page_content", "") or "")
+                    content_md = (getattr(d, "metadata", {}) or {}).get("content_metadata", {}) or {}
+                    if content_md.get("type") in ["image", "structured"]:
+                        image_docs.append(d)
+                    else:
+                        text_parts.append(getattr(d, "page_content", "") or "")
+
             filename = os.path.splitext(os.path.basename(source_key))[0] if source_key else "unknown"
             page_text = f"=== Page {page_num} ({filename}) ===\n" + "\n\n".join(p for p in text_parts if p)
             if page_text.strip():
@@ -449,7 +527,10 @@ class VLM:
             for img_doc in image_docs:
                 if remaining_image_budget is not None and remaining_image_budget <= 0:
                     break
-                img_parts = self._extract_images_from_docs([img_doc], remaining_image_budget)
+                if nrl_mode:
+                    img_parts = self._extract_images_from_docs_nrl([img_doc], remaining_image_budget)
+                else:
+                    img_parts = self._extract_images_from_docs([img_doc], remaining_image_budget)
                 content_parts.extend(img_parts)
                 if remaining_image_budget is not None and img_parts:
                     remaining_image_budget -= len(img_parts)
@@ -661,6 +742,7 @@ class VLM:
         top_p: float | None = None,
         max_tokens: int | None = None,
         max_total_images: int | None = None,
+        nrl_mode: bool = False,
         **_: Any,
     ) -> str:
         """
@@ -710,6 +792,7 @@ class VLM:
             context_text,
             question_text,
             max_total_images=eff_max_total_images,
+            nrl_mode=nrl_mode,
         )
 
         lc_messages = self.assemble_messages(
@@ -758,6 +841,7 @@ class VLM:
         max_tokens: int | None = None,
         max_total_images: int | None = None,
         organize_by_page: bool = False,
+        nrl_mode: bool = False,
         **_: Any,
     ) -> AsyncGenerator[str, None]:
         """
@@ -797,6 +881,7 @@ class VLM:
                 question_text,
                 max_total_images=eff_max_total_images,
                 organize_by_page=organize_by_page,
+                nrl_mode=nrl_mode,
             )
 
             lc_messages = self.assemble_messages(

--- a/tests/integration/test_sequences.yaml
+++ b/tests/integration/test_sequences.yaml
@@ -98,6 +98,13 @@ sequences:
     pre_sequence: [18]  # Cleanup collection before tests
     post_sequence: [16, 17, 18, 19]  # Cleanup tests after sequence
 
+  nemo_retriever_library_vlm_generation:
+    name: "NeMo Retriever Library VLM Generation Tests"
+    description: "VLM generation with INGESTOR_BACKEND=nrl and LanceDB (same cases as vlm_generation)"
+    test_numbers: [61, 62, 63, 64]
+    pre_sequence: [65]  # Cleanup collection before VLM generation tests
+    post_sequence: [65]  # Cleanup tests after sequence
+
   library_usage:
     name: "Python Library Usage Tests"
     description: "Tests nvidia_rag Python library directly as shown in notebooks/rag_library_usage.ipynb. Assumes cloud deployed models (NVIDIA API catalog). Covers imports, config, collection management, document upload/status/retrieval, health check, RAG generation, search, and cleanup."

--- a/tests/unit/test_rag_server/test_vlm.py
+++ b/tests/unit/test_rag_server/test_vlm.py
@@ -302,3 +302,71 @@ class TestVLM:
         formatted = self.vlm._format_docs_text([doc])
         assert "File: foo" in formatted
         assert "Important text" in formatted
+
+    def test_extract_images_from_docs_nrl_fetches_stored_uri_and_returns_png_parts(self):
+        mock_minio = MagicMock()
+        b64_img = self.create_test_image_b64()
+        mock_minio.get_object.return_value = base64.b64decode(b64_img)
+        doc = SimpleNamespace(
+            metadata={
+                "stored_image_uri": "s3://default-bucket/collection/page.png",
+            },
+            page_content="chunk text",
+        )
+        with patch("nvidia_rag.rag_server.vlm.get_minio_operator", return_value=mock_minio):
+            parts = self.vlm._extract_images_from_docs_nrl([doc], remaining_image_budget=None)
+
+        mock_minio.get_object.assert_called_once_with("collection/page.png")
+        assert len(parts) == 1
+        assert parts[0]["type"] == "image_url"
+        assert parts[0]["image_url"]["url"].startswith("data:image/png;base64,")
+
+    def test_extract_images_from_docs_nrl_skips_without_stored_image_uri(self):
+        doc = SimpleNamespace(metadata={}, page_content="text only")
+        with patch("nvidia_rag.rag_server.vlm.get_minio_operator") as mock_get_minio:
+            parts = self.vlm._extract_images_from_docs_nrl([doc], remaining_image_budget=5)
+
+        assert parts == []
+        mock_get_minio.return_value.get_object.assert_not_called()
+
+    def test_extract_images_from_docs_nrl_respects_remaining_image_budget(self):
+        mock_minio = MagicMock()
+        b64_img = self.create_test_image_b64()
+        raw_png = base64.b64decode(b64_img)
+        mock_minio.get_object.return_value = raw_png
+        docs = [
+            SimpleNamespace(
+                metadata={"stored_image_uri": "s3://b/a/1.png"},
+                page_content="a",
+            ),
+            SimpleNamespace(
+                metadata={"stored_image_uri": "s3://b/a/2.png"},
+                page_content="b",
+            ),
+        ]
+        with patch("nvidia_rag.rag_server.vlm.get_minio_operator", return_value=mock_minio):
+            parts = self.vlm._extract_images_from_docs_nrl(docs, remaining_image_budget=1)
+
+        assert len(parts) == 1
+        mock_minio.get_object.assert_called_once_with("a/1.png")
+
+    def test_extract_images_from_docs_nrl_continues_on_minio_error(self):
+        mock_minio = MagicMock()
+        b64_img = self.create_test_image_b64()
+        good_raw = base64.b64decode(b64_img)
+        docs = [
+            SimpleNamespace(
+                metadata={"stored_image_uri": "s3://b/bad.png"},
+                page_content="x",
+            ),
+            SimpleNamespace(
+                metadata={"stored_image_uri": "s3://b/good.png"},
+                page_content="y",
+            ),
+        ]
+        mock_minio.get_object.side_effect = [RuntimeError("unavailable"), good_raw]
+        with patch("nvidia_rag.rag_server.vlm.get_minio_operator", return_value=mock_minio):
+            parts = self.vlm._extract_images_from_docs_nrl(docs, remaining_image_budget=None)
+
+        assert len(parts) == 1
+        assert parts[0]["type"] == "image_url"


### PR DESCRIPTION
## Description
- **VLM (`vlm.py`)**: `nrl_mode` flag on `extract_and_process_messages` and `_build_content_parts_by_page`; NRL uses flat metadata (`stored_image_uri`, `page_number`, path/filename/source) and `_extract_images_from_docs_nrl` to load page images from MinIO for the VLM prompt.
- **RAG server (`main.py`)**: `_is_nrl_mode` now follows `config.nv_ingest.backend == "nrl"` (instead of inferring from LanceDB only); image-in-context detection uses `stored_image_uri` in NRL mode; VLM calls pass `nrl_mode=self._is_nrl_mode`.
- **Ingestor (`handler.py`)**: Runs **store** before **embed** when persisting images so `stored_image_uri` is available for LanceDB-backed flows.
- **Deploy / config**: `INGESTOR_BACKEND` exposed in `docker-compose-rag-server.yaml` and Helm `values.yaml`.
- **Tests**: Unit tests for `_extract_images_from_docs_nrl` in `tests/unit/test_rag_server/test_vlm.py`; integration sequence `nemo_retriever_library_vlm_generation` in `test_sequences.yaml`.
- **CI**: Nemo Retriever Library VLM generation integration job (LanceDB + NRL + VLM), log collection, and failure aggregation in `ci-pipeline.yml`.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [X] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [X] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.