### PR TITLE
Agentic Rag Onboarding

### DIFF
--- a/deploy/compose/docker-compose-rag-server.yaml
+++ b/deploy/compose/docker-compose-rag-server.yaml
@@ -78,7 +78,7 @@ services:
       # url on which llm model is hosted. If "", Nvidia hosted API is used
       APP_LLM_SERVERURL: ${APP_LLM_SERVERURL-"nim-llm:8000"}
       # LLM model parameters
-      LLM_MAX_TOKENS: ${LLM_MAX_TOKENS:-131072}
+      LLM_MAX_TOKENS: ${LLM_MAX_TOKENS:-128000}
       LLM_TEMPERATURE: ${LLM_TEMPERATURE:-0}
       LLM_TOP_P: ${LLM_TOP_P:-1.0}
 
@@ -149,6 +149,10 @@ services:
       APP_VLM_APIKEY: ${APP_VLM_APIKEY:-""}
       SUMMARY_LLM_APIKEY: ${SUMMARY_LLM_APIKEY:-""}
       REFLECTION_LLM_APIKEY: ${REFLECTION_LLM_APIKEY:-""}
+      AGENTIC_PLANNER_LLM_APIKEY: ${AGENTIC_PLANNER_LLM_APIKEY:-""}
+      AGENTIC_TASK_LLM_APIKEY: ${AGENTIC_TASK_LLM_APIKEY:-""}
+      AGENTIC_SEED_GEN_LLM_APIKEY: ${AGENTIC_SEED_GEN_LLM_APIKEY:-""}
+      AGENTIC_SYNTHESIS_LLM_APIKEY: ${AGENTIC_SYNTHESIS_LLM_APIKEY:-""}
 
       # Number of document chunks to insert in LLM prompt, used only when ENABLE_RERANKER is set to True
       APP_RETRIEVER_TOPK: ${APP_RETRIEVER_TOPK:-10}
@@ -211,6 +215,34 @@ services:
       REDIS_HOST: ${REDIS_HOST:-redis}
       REDIS_PORT: ${REDIS_PORT:-6379}
       REDIS_DB: ${REDIS_DB:-0}
+
+      # === Agentic RAG (LangGraph plan-and-execute pipeline) ===
+      ENABLE_AGENTIC_RAG: ${ENABLE_AGENTIC_RAG:-false}
+
+      ##===Agentic Planner LLM configurations===
+      AGENTIC_PLANNER_LLM_SERVERURL: ${AGENTIC_PLANNER_LLM_SERVERURL-"nim-llm:8000"}
+      AGENTIC_PLANNER_LLM_MODEL: ${AGENTIC_PLANNER_LLM_MODEL:-"nvidia/nemotron-3-super-120b-a12b"}
+
+      ##===Agentic Task LLM configurations===
+      AGENTIC_TASK_LLM_SERVERURL: ${AGENTIC_TASK_LLM_SERVERURL-"nim-llm:8000"}
+      AGENTIC_TASK_LLM_MODEL: ${AGENTIC_TASK_LLM_MODEL:-"nvidia/nemotron-3-super-120b-a12b"}
+
+      ##===Agentic Seed Gen LLM configurations===
+      AGENTIC_SEED_GEN_LLM_SERVERURL: ${AGENTIC_SEED_GEN_LLM_SERVERURL-"nim-llm:8000"}
+      AGENTIC_SEED_GEN_LLM_MODEL: ${AGENTIC_SEED_GEN_LLM_MODEL:-"nvidia/nemotron-3-super-120b-a12b"}
+
+      ##===Agentic Synthesis LLM configurations===
+      AGENTIC_SYNTHESIS_LLM_SERVERURL: ${AGENTIC_SYNTHESIS_LLM_SERVERURL-"nim-llm:8000"}
+      AGENTIC_SYNTHESIS_LLM_MODEL: ${AGENTIC_SYNTHESIS_LLM_MODEL:-"nvidia/nemotron-3-super-120b-a12b"}
+
+      # Agent behaviour tuning
+      AGENTIC_LOG_LEVEL: ${AGENTIC_LOG_LEVEL:-INFO}
+
+      # Verification pass (disabled by default)
+      AGENTIC_VERIFICATION_ENABLED: ${AGENTIC_VERIFICATION_ENABLED:-false}
+
+      # Context window budget for retrieved chunks
+      AGENTIC_CONTEXT_MAX_TOKENS: ${AGENTIC_CONTEXT_MAX_TOKENS:-100000}
 
     ports:
       - "8081:8081"

--- a/deploy/compose/nvdev.env
+++ b/deploy/compose/nvdev.env
@@ -95,3 +95,33 @@ export APP_QUERYREWRITER_SERVERURL=""
 export APP_QUERYREWRITER_MODELNAME="nvidia/nemotron-3-super-120b-a12b"
 # export ENABLE_QUERYREWRITER="True" # Uncomment to enable query rewriting
 # export MULTITURN_RETRIEVER_SIMPLE="True" # Enable/disable concatenating conversation history with query for retrieval (when query rewriter is disabled, default: False)
+
+# Agentic RAG feature (LangGraph plan-and-execute pipeline)
+# Uncomment ENABLE_AGENTIC_RAG to route knowledge-base queries through the agentic pipeline.
+# When enabled, each query is broken into a multi-step plan; sub-questions are answered
+# via iterative retrieval and a final synthesis LLM produces the response.
+
+# Per-role LLM configuration (all four roles use the same model in the reference config).
+# Set different values per role to use a smaller/cheaper model for non-critical roles.
+export AGENTIC_PLANNER_LLM_SERVERURL=https://integrate.api.nvidia.com/v1
+export AGENTIC_PLANNER_LLM_MODEL=nvidia/nemotron-3-super-120b-a12b
+export AGENTIC_TASK_LLM_SERVERURL=https://integrate.api.nvidia.com/v1
+export AGENTIC_TASK_LLM_MODEL=nvidia/nemotron-3-super-120b-a12b
+export AGENTIC_SEED_GEN_LLM_SERVERURL=https://integrate.api.nvidia.com/v1
+export AGENTIC_SEED_GEN_LLM_MODEL=nvidia/nemotron-3-super-120b-a12b
+export AGENTIC_SYNTHESIS_LLM_SERVERURL=https://integrate.api.nvidia.com/v1
+export AGENTIC_SYNTHESIS_LLM_MODEL=nvidia/nemotron-3-super-120b-a12b
+# Per-role API key overrides (default: inherits NVIDIA_API_KEY)
+# export AGENTIC_PLANNER_LLM_APIKEY=""
+# export AGENTIC_TASK_LLM_APIKEY=""
+# export AGENTIC_SEED_GEN_LLM_APIKEY=""
+# export AGENTIC_SYNTHESIS_LLM_APIKEY=""
+
+# Agent behaviour tuning (values match reference config defaults)
+export AGENTIC_LOG_LEVEL=INFO
+
+# Verification pass (disabled by default; enable for higher-accuracy at extra cost)
+export AGENTIC_VERIFICATION_ENABLED=false
+
+# Context window budget for retrieved chunks passed to the agent
+export AGENTIC_CONTEXT_MAX_TOKENS=100000

--- a/deploy/helm/nvidia-blueprint-rag/templates/deployment.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
                   name: {{ .Values.ngcApiSecret.name }}
                   key: NVIDIA_API_KEY
           {{- $apiKeysSecretName := include "apiKeysSecretName" . }}
-          {{- $hasAnyKey := or .Values.apiKeysSecret.llmApiKey .Values.apiKeysSecret.embeddingsApiKey .Values.apiKeysSecret.rankingApiKey .Values.apiKeysSecret.queryRewriterApiKey .Values.apiKeysSecret.filterExpressionGeneratorApiKey .Values.apiKeysSecret.vlmApiKey .Values.apiKeysSecret.summaryLlmApiKey .Values.apiKeysSecret.reflectionLlmApiKey }}
+          {{- $hasAnyKey := or .Values.apiKeysSecret.llmApiKey .Values.apiKeysSecret.embeddingsApiKey .Values.apiKeysSecret.rankingApiKey .Values.apiKeysSecret.queryRewriterApiKey .Values.apiKeysSecret.filterExpressionGeneratorApiKey .Values.apiKeysSecret.vlmApiKey .Values.apiKeysSecret.summaryLlmApiKey .Values.apiKeysSecret.reflectionLlmApiKey .Values.apiKeysSecret.agenticPlannerLlmApiKey .Values.apiKeysSecret.agenticTaskLlmApiKey .Values.apiKeysSecret.agenticSeedGenLlmApiKey .Values.apiKeysSecret.agenticSynthesisLlmApiKey }}
           {{- $shouldCreateSecret := and .Values.apiKeysSecret.create (not .Values.apiKeysSecret.existingSecret) $hasAnyKey }}
           {{- $useExistingSecret := .Values.apiKeysSecret.existingSecret }}
           {{- if or $shouldCreateSecret $useExistingSecret }}
@@ -135,6 +135,34 @@ spec:
                 secretKeyRef:
                   name: {{ $apiKeysSecretName }}
                   key: REFLECTION_LLM_APIKEY
+          {{- end }}
+          {{- if or $useExistingSecret .Values.apiKeysSecret.agenticPlannerLlmApiKey }}
+            - name: AGENTIC_PLANNER_LLM_APIKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $apiKeysSecretName }}
+                  key: AGENTIC_PLANNER_LLM_APIKEY
+          {{- end }}
+          {{- if or $useExistingSecret .Values.apiKeysSecret.agenticTaskLlmApiKey }}
+            - name: AGENTIC_TASK_LLM_APIKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $apiKeysSecretName }}
+                  key: AGENTIC_TASK_LLM_APIKEY
+          {{- end }}
+          {{- if or $useExistingSecret .Values.apiKeysSecret.agenticSeedGenLlmApiKey }}
+            - name: AGENTIC_SEED_GEN_LLM_APIKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $apiKeysSecretName }}
+                  key: AGENTIC_SEED_GEN_LLM_APIKEY
+          {{- end }}
+          {{- if or $useExistingSecret .Values.apiKeysSecret.agenticSynthesisLlmApiKey }}
+            - name: AGENTIC_SYNTHESIS_LLM_APIKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $apiKeysSecretName }}
+                  key: AGENTIC_SYNTHESIS_LLM_APIKEY
           {{- end }}
           {{- end }}
           {{- if .Values.livenessProbe }}

--- a/deploy/helm/nvidia-blueprint-rag/templates/secrets.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/templates/secrets.yaml
@@ -35,7 +35,7 @@ data:
 {{- end }}
 
 {{ if and .Values.apiKeysSecret.create (not .Values.apiKeysSecret.existingSecret) -}}
-{{- $hasAnyKey := or .Values.apiKeysSecret.llmApiKey .Values.apiKeysSecret.embeddingsApiKey .Values.apiKeysSecret.rankingApiKey .Values.apiKeysSecret.queryRewriterApiKey .Values.apiKeysSecret.filterExpressionGeneratorApiKey .Values.apiKeysSecret.vlmApiKey .Values.apiKeysSecret.summaryLlmApiKey .Values.apiKeysSecret.reflectionLlmApiKey -}}
+{{- $hasAnyKey := or .Values.apiKeysSecret.llmApiKey .Values.apiKeysSecret.embeddingsApiKey .Values.apiKeysSecret.rankingApiKey .Values.apiKeysSecret.queryRewriterApiKey .Values.apiKeysSecret.filterExpressionGeneratorApiKey .Values.apiKeysSecret.vlmApiKey .Values.apiKeysSecret.summaryLlmApiKey .Values.apiKeysSecret.reflectionLlmApiKey .Values.apiKeysSecret.agenticPlannerLlmApiKey .Values.apiKeysSecret.agenticTaskLlmApiKey .Values.apiKeysSecret.agenticSeedGenLlmApiKey .Values.apiKeysSecret.agenticSynthesisLlmApiKey -}}
 {{- if $hasAnyKey -}}
 ---
 apiVersion: v1
@@ -73,6 +73,18 @@ data:
   {{- end }}
   {{- if .Values.apiKeysSecret.reflectionLlmApiKey }}
   REFLECTION_LLM_APIKEY: {{ .Values.apiKeysSecret.reflectionLlmApiKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.apiKeysSecret.agenticPlannerLlmApiKey }}
+  AGENTIC_PLANNER_LLM_APIKEY: {{ .Values.apiKeysSecret.agenticPlannerLlmApiKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.apiKeysSecret.agenticTaskLlmApiKey }}
+  AGENTIC_TASK_LLM_APIKEY: {{ .Values.apiKeysSecret.agenticTaskLlmApiKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.apiKeysSecret.agenticSeedGenLlmApiKey }}
+  AGENTIC_SEED_GEN_LLM_APIKEY: {{ .Values.apiKeysSecret.agenticSeedGenLlmApiKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.apiKeysSecret.agenticSynthesisLlmApiKey }}
+  AGENTIC_SYNTHESIS_LLM_APIKEY: {{ .Values.apiKeysSecret.agenticSynthesisLlmApiKey | b64enc | quote }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/nvidia-blueprint-rag/values.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/values.yaml
@@ -53,6 +53,10 @@ apiKeysSecret:
   vlmApiKey: ""
   summaryLlmApiKey: ""
   reflectionLlmApiKey: ""
+  agenticPlannerLlmApiKey: ""
+  agenticTaskLlmApiKey: ""
+  agenticSeedGenLlmApiKey: ""
+  agenticSynthesisLlmApiKey: ""
 
 # -- RAG server container image
 image:
@@ -167,7 +171,7 @@ envVars:
   APP_LLM_SERVERURL: "nim-llm:8000"
   # LLM model parameters
   # For Nemotron 3 Super on RTX 6000 Pro: uncomment and set to 16256 (reasoning) or 1024 (non-reasoning); comment LLM_MAX_TOKENS above
-  LLM_MAX_TOKENS: "131072" # "16256" for RTX 6000 Pro
+  LLM_MAX_TOKENS: "128000" # "16256" for RTX 6000 Pro
   LLM_TEMPERATURE: "0"
   LLM_TOP_P: "1.0"
 
@@ -275,6 +279,39 @@ envVars:
   ENABLE_QUERY_DECOMPOSITION: "false"
   # maximum recursion depth for iterative query decomposition
   MAX_RECURSION_DEPTH: "3"
+
+  # === Agentic RAG (LangGraph plan-and-execute pipeline) ===
+  # Enable agentic RAG pipeline for knowledge-base queries
+  ENABLE_AGENTIC_RAG: "false"
+
+  ##===Agentic Planner LLM configurations===
+  # URL on which agentic planner LLM is hosted. If "", Nvidia hosted API is used
+  AGENTIC_PLANNER_LLM_SERVERURL: "nim-llm:8000"
+  AGENTIC_PLANNER_LLM_MODEL: "nvidia/nemotron-3-super-120b-a12b"
+
+  ##===Agentic Task LLM configurations===
+  # URL on which agentic task LLM is hosted. If "", Nvidia hosted API is used
+  AGENTIC_TASK_LLM_SERVERURL: "nim-llm:8000"
+  AGENTIC_TASK_LLM_MODEL: "nvidia/nemotron-3-super-120b-a12b"
+
+  ##===Agentic Seed Gen LLM configurations===
+  # URL on which agentic seed-gen LLM is hosted. If "", Nvidia hosted API is used
+  AGENTIC_SEED_GEN_LLM_SERVERURL: "nim-llm:8000"
+  AGENTIC_SEED_GEN_LLM_MODEL: "nvidia/nemotron-3-super-120b-a12b"
+
+  ##===Agentic Synthesis LLM configurations===
+  # URL on which agentic synthesis LLM is hosted. If "", Nvidia hosted API is used
+  AGENTIC_SYNTHESIS_LLM_SERVERURL: "nim-llm:8000"
+  AGENTIC_SYNTHESIS_LLM_MODEL: "nvidia/nemotron-3-super-120b-a12b"
+
+  # Agent behaviour tuning
+  AGENTIC_LOG_LEVEL: "INFO"
+
+  # Verification pass (disabled by default)
+  AGENTIC_VERIFICATION_ENABLED: "false"
+
+  # Context window budget for retrieved chunks
+  AGENTIC_CONTEXT_MAX_TOKENS: "100000"
 
 # -- Ingestor Server
 # subsection: ingestor-server

--- a/deploy/workbench/compose.yaml
+++ b/deploy/workbench/compose.yaml
@@ -555,6 +555,40 @@ services:
       # reflection llm server url. If "", Nvidia hosted API is used
       REFLECTION_LLM_SERVERURL: ${REFLECTION_LLM_SERVERURL-"nim-llm:8000"}
 
+      # === Agentic RAG (LangGraph plan-and-execute pipeline) ===
+      ENABLE_AGENTIC_RAG: ${ENABLE_AGENTIC_RAG:-false}
+
+      ##===Agentic Planner LLM configurations===
+      AGENTIC_PLANNER_LLM_SERVERURL: ${AGENTIC_PLANNER_LLM_SERVERURL-"nim-llm:8000"}
+      AGENTIC_PLANNER_LLM_MODEL: ${AGENTIC_PLANNER_LLM_MODEL:-"nvidia/nemotron-3-super-120b-a12b"}
+
+      ##===Agentic Task LLM configurations===
+      AGENTIC_TASK_LLM_SERVERURL: ${AGENTIC_TASK_LLM_SERVERURL-"nim-llm:8000"}
+      AGENTIC_TASK_LLM_MODEL: ${AGENTIC_TASK_LLM_MODEL:-"nvidia/nemotron-3-super-120b-a12b"}
+
+      ##===Agentic Seed Gen LLM configurations===
+      AGENTIC_SEED_GEN_LLM_SERVERURL: ${AGENTIC_SEED_GEN_LLM_SERVERURL-"nim-llm:8000"}
+      AGENTIC_SEED_GEN_LLM_MODEL: ${AGENTIC_SEED_GEN_LLM_MODEL:-"nvidia/nemotron-3-super-120b-a12b"}
+
+      ##===Agentic Synthesis LLM configurations===
+      AGENTIC_SYNTHESIS_LLM_SERVERURL: ${AGENTIC_SYNTHESIS_LLM_SERVERURL-"nim-llm:8000"}
+      AGENTIC_SYNTHESIS_LLM_MODEL: ${AGENTIC_SYNTHESIS_LLM_MODEL:-"nvidia/nemotron-3-super-120b-a12b"}
+
+      # Per-role agentic API keys (optional; empty uses NVIDIA_API_KEY fallback)
+      AGENTIC_PLANNER_LLM_APIKEY: ${AGENTIC_PLANNER_LLM_APIKEY:-""}
+      AGENTIC_TASK_LLM_APIKEY: ${AGENTIC_TASK_LLM_APIKEY:-""}
+      AGENTIC_SEED_GEN_LLM_APIKEY: ${AGENTIC_SEED_GEN_LLM_APIKEY:-""}
+      AGENTIC_SYNTHESIS_LLM_APIKEY: ${AGENTIC_SYNTHESIS_LLM_APIKEY:-""}
+
+      # Agent behaviour tuning
+      AGENTIC_LOG_LEVEL: ${AGENTIC_LOG_LEVEL:-INFO}
+
+      # Verification pass (disabled by default)
+      AGENTIC_VERIFICATION_ENABLED: ${AGENTIC_VERIFICATION_ENABLED:-false}
+
+      # Context window budget for retrieved chunks
+      AGENTIC_CONTEXT_MAX_TOKENS: ${AGENTIC_CONTEXT_MAX_TOKENS:-100000}
+
     ports:
       - "8081:8081"
     expose:

--- a/docs/api-rag.md
+++ b/docs/api-rag.md
@@ -10,8 +10,6 @@ This documentation contains the OpenAPI reference for the RAG server.
 :::{tip}
 To view this documentation on docs.nvidia.com, browse to [https://docs.nvidia.com/rag/latest/api-rag](https://docs.nvidia.com/rag/latest/api-rag.html).
 :::
-=======
-To view this documentation on docs.nvidia.com, browse to [https://docs.nvidia.com/rag/latest/api-rag](https://docs.nvidia.com/rag/latest/api-rag.html).
 
 
 :::{swagger-plugin} ../docs/api_reference/openapi_schema_rag_server.json

--- a/docs/api_reference/openapi_schema_ingestor_server.json
+++ b/docs/api_reference/openapi_schema_ingestor_server.json
@@ -964,7 +964,7 @@
                         "type": "string",
                         "title": "Vdb Endpoint",
                         "description": "Endpoint of the vector database.",
-                        "default": "http://milvus:19530"
+                        "default": "http://elasticsearch:9200"
                     },
                     "collection_name": {
                         "type": "string",

--- a/docs/api_reference/openapi_schema_rag_server.json
+++ b/docs/api_reference/openapi_schema_rag_server.json
@@ -1,9 +1,9 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "APIs for NVIDIA RAG Server",
-    "description": "This API schema describes all the retriever endpoints exposed for NVIDIA RAG server Blueprint. Includes v1 APIs and v2 OpenAI-compatible APIs.",
-    "version": "2.0.0"
+    "title": "APIs for NVIDIA RAG Server (v1)",
+    "description": "This API schema describes all the retriever endpoints exposed for NVIDIA RAG server Blueprint",
+    "version": "1.0.0"
   },
   "paths": {
     "/v1/health": {
@@ -270,89 +270,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SummaryResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v2/vector_stores/{vector_store_id}/search": {
-      "post": {
-        "tags": [
-          "Retrieval APIs"
-        ],
-        "summary": "Vector Store Search",
-        "description": "OpenAI-compatible vector store search endpoint (v2 only).\n\nThis is the primary OpenAI-compatible endpoint for vector store search.\nSearch within a vector store using natural language queries with full OpenAI API compatibility.\n\n**Note:** This endpoint is exclusive to the v2 API and is not available in v1.\n\nArgs:\n    request: FastAPI request object\n    vector_store_id: The ID of the vector store (collection name) to search\n    search_request: Search request parameters in OpenAI format\n\nReturns:\n    JSONResponse: Search results in OpenAI-compatible format",
-        "operationId": "vector_store_search_v2_vector_stores__vector_store_id__search_post",
-        "parameters": [
-          {
-            "name": "vector_store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Vector Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/VectorStoreSearchRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VectorStoreSearchResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "example": {
-                  "detail": "Invalid request parameters"
-                }
-              }
-            }
-          },
-          "499": {
-            "description": "Client Closed Request",
-            "content": {
-              "application/json": {
-                "example": {
-                  "detail": "The client cancelled the request"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "example": {
-                  "detail": "Internal server error occurred"
                 }
               }
             }
@@ -661,7 +578,7 @@
             "type": "string",
             "title": "Vdb Endpoint",
             "description": "Endpoint url of the vector database server.",
-            "default": "http://milvus:19530"
+            "default": "http://elasticsearch:9200"
           },
           "collection_names": {
             "items": {
@@ -707,7 +624,7 @@
             "maxLength": 256,
             "title": "Embedding Model",
             "description": "Name of the embedding model used for vectorization.",
-            "default": "nvdev/nvidia/llama-nemotron-embed-1b-v2"
+            "default": "nvidia/llama-nemotron-embed-1b-v2"
           },
           "embedding_endpoint": {
             "type": "string",
@@ -1237,7 +1154,7 @@
             "format": "int64",
             "title": "Max Tokens",
             "description": "The maximum number of tokens to generate in any given call. Note that the model is not aware of this value,  and generation will simply stop at the number of tokens specified.",
-            "default": 32768
+            "default": 128000
           },
           "min_thinking_tokens": {
             "type": "integer",
@@ -1273,7 +1190,7 @@
             "type": "string",
             "title": "Vdb Endpoint",
             "description": "Endpoint url of the vector database server.",
-            "default": "http://milvus:19530"
+            "default": "http://elasticsearch:9200"
           },
           "collection_names": {
             "items": {
@@ -1342,7 +1259,7 @@
             "maxLength": 256,
             "title": "Embedding Model",
             "description": "Name of the embedding model used for vectorization.",
-            "default": "nvdev/nvidia/llama-nemotron-embed-1b-v2"
+            "default": "nvidia/llama-nemotron-embed-1b-v2"
           },
           "embedding_endpoint": {
             "anyOf": [
@@ -1469,6 +1386,33 @@
             "title": "Confidence Threshold",
             "description": "Minimum confidence score threshold for filtering chunks. Only chunks with relevance scores >= this threshold will be included. Range: 0.0 to 1.0. Default: 0.0 (no filtering). Note: Requires enable_reranker=True to generate relevance scores.",
             "default": 0
+          },
+          "fetch_full_page_context": {
+            "type": "boolean",
+            "title": "Fetch Full Page Context",
+            "description": "Fetch ALL chunks for retrieved pages and organize context by page. When True, enables page-based grouping for LLM/VLM.",
+            "default": false
+          },
+          "fetch_neighboring_pages": {
+            "type": "integer",
+            "maximum": 10,
+            "minimum": 0,
+            "title": "Fetch Neighboring Pages",
+            "description": "N pages before/after each retrieved page (0=disabled, 1=+/-1 page).",
+            "default": 0
+          },
+          "agentic": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agentic",
+            "description": "Route this request through the agentic RAG pipeline (LangGraph plan-and-execute). When None (default), the server-level CONFIG.enable_agentic_rag config value is used. Explicitly passing True or False overrides the server default for this request.",
+            "default": false
           }
         },
         "type": "object",
@@ -1706,6 +1650,14 @@
             "description": "Relevance score of the document",
             "default": 0
           },
+          "stage": {
+            "type": "string",
+            "maxLength": 100,
+            "pattern": "[\\s\\S]*",
+            "title": "Stage",
+            "description": "Pipeline stage that produced this result (e.g. 'rag', 'initial_retrieval', 'execute', 'verify_execute')",
+            "default": "rag"
+          },
           "metadata": {
             "$ref": "#/components/schemas/SourceMetadata"
           }
@@ -1895,7 +1847,7 @@
           },
           "text": {
             "type": "string",
-            "maxLength": 131072,
+            "maxLength": 128000,
             "pattern": "[\\s\\S]*",
             "title": "Text",
             "description": "The text content"
@@ -1974,397 +1926,6 @@
           "type"
         ],
         "title": "ValidationError"
-      },
-      "ComparisonFilter": {
-        "properties": {
-          "key": {
-            "type": "string",
-            "title": "Key",
-            "description": "The key to compare against the value.",
-            "examples": [
-              "author",
-              "page_number",
-              "category"
-            ]
-          },
-          "type": {
-            "type": "string",
-            "title": "Type",
-            "description": "Specifies the comparison operator: eq (equals), ne (not equal), gt (greater than), gte (greater than or equal), lt (less than), lte (less than or equal), in, nin (not in).",
-            "examples": [
-              "eq",
-              "gt",
-              "in"
-            ]
-          },
-          "value": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "integer"
-              },
-              {
-                "type": "number"
-              },
-              {
-                "type": "boolean"
-              },
-              {
-                "items": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "boolean"
-                    }
-                  ]
-                },
-                "type": "array"
-              }
-            ],
-            "title": "Value",
-            "description": "The value to compare against the attribute key; supports string, number, boolean, or array types.",
-            "examples": [
-              "John Doe",
-              5,
-              true,
-              [
-                "tech",
-                "science"
-              ]
-            ]
-          }
-        },
-        "type": "object",
-        "required": [
-          "key",
-          "type",
-          "value"
-        ],
-        "title": "ComparisonFilter",
-        "description": "A filter used to compare a specified attribute key to a given value using a defined comparison operation.",
-        "examples": [
-          {
-            "key": "<KEYNAME>",
-            "type": "eq",
-            "value": "John Doe"
-          }
-        ]
-      },
-      "CompoundFilter": {
-        "properties": {
-          "type": {
-            "type": "string",
-            "title": "Type",
-            "description": "Type of operation: 'and' or 'or'.",
-            "examples": [
-              "and",
-              "or"
-            ]
-          },
-          "filters": {
-            "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/ComparisonFilter"
-                },
-                {
-                  "$ref": "#/components/schemas/CompoundFilter"
-                }
-              ]
-            },
-            "type": "array",
-            "title": "Filters",
-            "description": "Array of filters to combine. Items can be ComparisonFilter or CompoundFilter."
-          }
-        },
-        "type": "object",
-        "required": [
-          "type",
-          "filters"
-        ],
-        "title": "CompoundFilter",
-        "description": "Combine multiple filters using 'and' or 'or'.",
-        "examples": [
-          {
-            "filters": [
-              {
-                "key": "author",
-                "type": "eq",
-                "value": "John Doe"
-              },
-              {
-                "key": "page_number",
-                "type": "gte",
-                "value": 5
-              }
-            ],
-            "type": "and"
-          }
-        ]
-      },
-      "RankingOptions": {
-        "properties": {
-          "ranker": {
-            "type": "string",
-            "title": "Ranker",
-            "description": "Control re-ranking behavior. To enable: 'auto', 'true', 'on', 'enabled', 'yes', '1'. To disable (reduces latency): 'none', 'false', 'off', 'disabled', 'no', '0'. Case-insensitive.",
-            "default": "auto",
-            "examples": [
-              "auto",
-              "none",
-              "false"
-            ]
-          },
-          "score_threshold": {
-            "type": "number",
-            "maximum": 1,
-            "minimum": 0,
-            "title": "Score Threshold",
-            "description": "Minimum score threshold for filtering results. Only results with scores >= this value will be returned.",
-            "default": 0,
-            "examples": [
-              0,
-              0.5,
-              0.75
-            ]
-          }
-        },
-        "type": "object",
-        "title": "RankingOptions",
-        "description": "Ranking options for vector store search.",
-        "examples": [
-          {
-            "ranker": "auto",
-            "score_threshold": 0.5
-          }
-        ]
-      },
-      "VectorStoreSearchRequest": {
-        "properties": {
-          "query": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/TextContent"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ImageContent"
-                    }
-                  ]
-                },
-                "type": "array"
-              }
-            ],
-            "title": "Query",
-            "description": "A query string for a search or an array of content objects for multimodal queries.",
-            "examples": [
-              "What is the return policy?",
-              "Tell me about machine learning"
-            ]
-          },
-          "filters": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ComparisonFilter"
-              },
-              {
-                "$ref": "#/components/schemas/CompoundFilter"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Filters",
-            "description": "A filter to apply based on file attributes. Can be a comparison filter or compound filter."
-          },
-          "max_num_results": {
-            "type": "integer",
-            "maximum": 50,
-            "minimum": 1,
-            "title": "Max Num Results",
-            "description": "The maximum number of results to return. This number should be between 1 and 50 inclusive.",
-            "default": 10,
-            "examples": [
-              10,
-              5,
-              20
-            ]
-          },
-          "ranking_options": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/RankingOptions"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Ranking options for search."
-          },
-          "rewrite_query": {
-            "type": "boolean",
-            "title": "Rewrite Query",
-            "description": "Whether to rewrite the natural language query for vector search.",
-            "default": false,
-            "examples": [
-              false,
-              true
-            ]
-          }
-        },
-        "type": "object",
-        "required": [
-          "query"
-        ],
-        "title": "VectorStoreSearchRequest",
-        "description": "OpenAI-compatible vector store search request.",
-        "examples": [
-          {
-            "max_num_results": 10,
-            "query": "What is the return policy?",
-            "ranking_options": {
-              "ranker": "auto",
-              "score_threshold": 0.5
-            },
-            "rewrite_query": false
-          },
-          {
-            "max_num_results": 5,
-            "query": "machine learning basics",
-            "ranking_options": {
-              "ranker": "none",
-              "score_threshold": 0
-            },
-            "rewrite_query": true
-          }
-        ]
-      },
-      "VectorStoreSearchResponse": {
-        "properties": {
-          "object": {
-            "type": "string",
-            "title": "Object",
-            "description": "Object type identifier",
-            "default": "vector_store.search_results.page"
-          },
-          "search_query": {
-            "type": "string",
-            "title": "Search Query",
-            "description": "The search query that was executed"
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/VectorStoreSearchResultItem"
-            },
-            "type": "array",
-            "title": "Data",
-            "description": "List of search results"
-          },
-          "has_more": {
-            "type": "boolean",
-            "title": "Has More",
-            "description": "Whether there are more results available",
-            "default": false
-          },
-          "next_page": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Next Page",
-            "description": "Token for retrieving the next page of results"
-          }
-        },
-        "type": "object",
-        "required": [
-          "search_query",
-          "data"
-        ],
-        "title": "VectorStoreSearchResponse",
-        "description": "OpenAI-compatible vector store search response."
-      },
-      "VectorStoreSearchResultContent": {
-        "properties": {
-          "type": {
-            "type": "string",
-            "title": "Type",
-            "description": "Type of content (e.g., 'text')"
-          },
-          "text": {
-            "type": "string",
-            "title": "Text",
-            "description": "Text content"
-          }
-        },
-        "type": "object",
-        "required": [
-          "type",
-          "text"
-        ],
-        "title": "VectorStoreSearchResultContent",
-        "description": "Content object in search result."
-      },
-      "VectorStoreSearchResultItem": {
-        "properties": {
-          "file_id": {
-            "type": "string",
-            "title": "File Id",
-            "description": "Identifier for the file"
-          },
-          "filename": {
-            "type": "string",
-            "title": "Filename",
-            "description": "Name of the file"
-          },
-          "score": {
-            "type": "number",
-            "title": "Score",
-            "description": "Relevance score"
-          },
-          "attributes": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Attributes",
-            "description": "File attributes/metadata"
-          },
-          "content": {
-            "items": {
-              "$ref": "#/components/schemas/VectorStoreSearchResultContent"
-            },
-            "type": "array",
-            "title": "Content",
-            "description": "Content chunks from the file"
-          }
-        },
-        "type": "object",
-        "required": [
-          "file_id",
-          "filename",
-          "score",
-          "attributes",
-          "content"
-        ],
-        "title": "VectorStoreSearchResultItem",
-        "description": "Single search result item in OpenAI format."
       }
     }
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "httpx-sse>=0.4.3",
     "langchain>=1.2.7",
     "langchain-community>=0.4",
+    "langgraph>=0.2",
     "langchain-milvus>=0.3.0",
     "langchain-nvidia-ai-endpoints>=1.2.1",
     "minio>=7.2,<8.0",
@@ -55,6 +56,7 @@ rag = [
     "azure-core>=1.35,<2.0",
     "azure-storage-blob>=12.26,<13.0",
     "pyarrow>=21.0,<22.0",
+    "tiktoken>=0.7",
 ]
 ingest = [
     # nv-ingest dependencies (required for ingestion operations)

--- a/src/nvidia_rag/rag_server/agentic_rag/__init__.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/__init__.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agentic RAG package for nvidia_rag.rag_server.
+
+Public API:
+
+  AgenticRag              — LangGraph plan-and-execute agent (core logic).
+  AgenticRAGGraphState    — Pydantic state model for the LangGraph graph.
+  AgenticSearchParams     — Dataclass of all per-request NvidiaRAG.search()
+                            parameters forwarded by the agentic retriever.
+  _agentic_search_params  — ContextVar[AgenticSearchParams]; set by
+                            NvidiaRAG._agentic_chain before graph.ainvoke().
+  build_agentic_rag_agent — Factory: builds + compiles the agent from a
+                            NvidiaRAG instance and its AgenticRAGConfig.
+  make_retriever_fn       — Creates an async retriever backed by NvidiaRAG.search().
+"""
+
+from nvidia_rag.rag_server.agentic_rag.agentic_rag import (
+    AgenticRag,
+    AgenticRAGGraphState,
+)
+from nvidia_rag.rag_server.agentic_rag.builder import (
+    AgenticSearchParams,
+    _agentic_search_params,
+    build_agentic_rag_agent,
+    make_retriever_fn,
+)
+from nvidia_rag.rag_server.agentic_rag.runner import run_agentic_pipeline
+
+__all__ = [
+    "AgenticRag",
+    "AgenticRAGGraphState",
+    "AgenticSearchParams",
+    "_agentic_search_params",
+    "build_agentic_rag_agent",
+    "make_retriever_fn",
+    "run_agentic_pipeline",
+]

--- a/src/nvidia_rag/rag_server/agentic_rag/agentic_rag.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/agentic_rag.py
@@ -1,0 +1,1555 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Graph-Based Agentic RAG Agent.
+
+Architecture: plan-and-execute with two-phase planning + verification gate.
+
+  initial_retrieval → plan → execute ──(scope_only?)──→ plan (replan) → execute
+                                      └─(otherwise)──→ synthesize → verify
+                                                        └─(pass)──→ END
+                                                        └─(fail)──→ verify_execute → synthesize → END
+
+Phase 1 — scope discovery:
+  When the query needs comprehensive coverage or has unresolved ambiguity, the
+  planner creates scope-discovery tasks.  After they execute the planner is
+  called again with the results.
+
+Phase 2 — data retrieval:
+  The planner creates targeted answer tasks.  Each task is a mini-agent with
+  smart retry logic (seed-query generation on partial/none results).
+
+Verification:
+  After first synthesis a verification LLM checks the answer for gaps.  If
+  issues are found, targeted re-retrieval tasks run and synthesis is repeated.
+"""
+
+import asyncio
+import json
+import logging
+import re
+import time
+from collections.abc import Callable
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.prompts.chat import ChatPromptTemplate
+from langgraph.graph import END, StateGraph
+from opentelemetry import trace as otel_trace
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+_P = "[AGENTIC_RAG]"
+
+
+# ---------------------------------------------------------------------------
+# Local fallback config dataclasses
+# Used when no config objects are passed to AgenticRag.__init__.
+# Production code passes AgenticRAGConfig sub-objects from
+# nvidia_rag.utils.configuration, which expose the same attribute names.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _PlannerConfig:
+    max_plan_tasks: int = 5
+    max_scope_rounds: int = 2
+    max_attempts: int = 3
+
+
+@dataclass
+class _TaskExecutionConfig:
+    scope_max_retries: int = 1
+    answer_max_retries: int = 3
+
+
+@dataclass
+class _LLMTransportConfig:
+    call_timeout: int = 300
+    max_retries: int = 4
+
+
+@dataclass
+class _VerificationConfig:
+    enabled: bool = True
+    max_tasks: int = 3
+
+
+@dataclass
+class _ContextConfig:
+    max_tokens: int = 100000
+
+
+# =============================================================================
+# STATE
+# =============================================================================
+
+
+class AgenticRAGGraphState(BaseModel):
+    """LangGraph state passed between nodes."""
+
+    user_query: str = Field(default="")
+    initial_context: list[Any] = Field(default_factory=list)
+    retrieval_plan: dict = Field(default_factory=dict)
+    task_results: dict[str, dict] = Field(default_factory=dict)
+    scope_results: dict[str, str] = Field(default_factory=dict)
+    needs_replan: bool = Field(default=False)
+    scope_rounds: int = Field(default=0)
+    final_answer: str = Field(default="")
+    verification_tasks: list[dict] = Field(default_factory=list)
+    verification_results: dict[str, dict] = Field(default_factory=dict)
+    verification_issues: list[str] = Field(default_factory=list)
+    verification_round: int = Field(default=0)
+
+
+# =============================================================================
+# AGENT
+# =============================================================================
+
+
+class AgenticRag:
+    """Plan-and-execute RAG agent with scope discovery and verification.
+
+    Graph topology::
+
+        retrieve → plan → execute → [replan?] → synthesize → [verify?] → END
+    """
+
+    _TEXT_DOCUMENT_TYPES = frozenset({"text", "audio"})
+    _CHARS_PER_TOKEN_ESTIMATE = 2.5
+
+    @staticmethod
+    def _rebuild_result(chunk: dict) -> dict:
+        """Reconstruct a retrieval-result dict from a stored chunk."""
+        doc_type = chunk.get("document_type", "text")
+        result: dict = {
+            "document_name": chunk["doc_name"],
+            "content": chunk["content"],
+            "score": chunk.get("score", 0.0),
+            "document_type": doc_type,
+        }
+        if doc_type not in AgenticRag._TEXT_DOCUMENT_TYPES:
+            result["metadata"] = {"description": chunk["content"]}
+        return result
+
+    def __init__(
+        self,
+        planner_llm: BaseChatModel,
+        task_llm: BaseChatModel,
+        seed_gen_llm: BaseChatModel,
+        synthesis_llm: BaseChatModel,
+        retriever_fn: Callable[..., Any],
+        log_level: str = "INFO",
+        concurrency_limit: int = 3,
+        planner_config=None,
+        task_execution_config=None,
+        llm_config=None,
+        verification_config=None,
+        context_config=None,
+    ):
+        self.planner_llm = planner_llm
+        self.task_llm = task_llm
+        self.seed_gen_llm = seed_gen_llm
+        self.synthesis_llm = synthesis_llm
+        self.retriever_fn = retriever_fn
+        self.graph = None
+
+        level = getattr(logging, log_level.upper(), logging.INFO)
+        logger.setLevel(level)
+
+        self.planner_cfg = planner_config or _PlannerConfig()
+        self.task_exec_cfg = task_execution_config or _TaskExecutionConfig()
+        self.llm_cfg = llm_config or _LLMTransportConfig()
+        self.verification_cfg = verification_config or _VerificationConfig()
+        self.context_cfg = context_config or _ContextConfig()
+
+        self._tokenizer = None
+        self._semaphore = asyncio.Semaphore(concurrency_limit)
+
+        from nvidia_rag.rag_server.agentic_rag.tracing import AgentMetrics
+
+        self.metrics = AgentMetrics()
+
+        from nvidia_rag.rag_server.agentic_rag.prompt import build_prompts
+
+        prompts = build_prompts(
+            max_plan_tasks=self.planner_cfg.max_plan_tasks,
+            max_verification_tasks=self.verification_cfg.max_tasks,
+        )
+        self.planner_prompt = prompts["planner_prompt"]
+        self.task_answer_prompt = prompts["task_answer_prompt"]
+        self.seed_gen_prompt = prompts["seed_gen_prompt"]
+        self.synthesis_prompt = prompts["synthesis_prompt"]
+        self.verification_prompt = prompts["verification_prompt"]
+        self.planner_replan_instruction = prompts["planner_replan_instruction"]
+
+        self._otel = otel_trace.get_tracer("agentic_rag")
+
+        logger.info("%s Agent initialized (log_level=%s)", _P, log_level.upper())
+
+    @contextmanager
+    def _otel_and_trace(self, span_name: str, span_kind: str = "CHAIN"):
+        """Open an OTel span and record QueryTrace node timing together."""
+        from nvidia_rag.rag_server.agentic_rag.tracing import get_current_trace
+
+        trace = get_current_trace()
+        with self._otel.start_as_current_span(span_name) as span:
+            span.set_attribute("openinference.span.kind", span_kind)
+            if trace:
+                with trace.trace_node(span_name):
+                    yield span
+            else:
+                yield span
+
+    # =========================================================================
+    # TOKEN COUNTING
+    # =========================================================================
+
+    def _get_tokenizer(self):
+        if self._tokenizer is not None:
+            return self._tokenizer
+        try:
+            import tiktoken
+
+            self._tokenizer = tiktoken.get_encoding("cl100k_base")
+            return self._tokenizer
+        except Exception:
+            return None
+
+    def _estimate_tokens(self, text: str) -> int:
+        """Fast approximate token count for budgeting (context truncation, etc.).
+
+        Uses tiktoken ``cl100k_base`` as a reasonable cross-model estimator.
+        NOT used for metrics — actual API-reported counts are used there.
+        """
+        try:
+            tok = self._get_tokenizer()
+            if tok is not None:
+                return len(tok.encode(text))
+            return len(text) // 4
+        except Exception:
+            return len(text) // 4
+
+    # =========================================================================
+    # LLM CALL (retry + timeout + rate-limit)
+    # =========================================================================
+
+    @staticmethod
+    def _filter_think_tokens(content: str) -> str:
+        """Strip <think>…</think> blocks from LLM output."""
+        if not content or "<think>" not in content:
+            return content
+        if "</think>" in content:
+            return content[content.rfind("</think>") + len("</think>") :].strip()
+        logger.warning("%s Truncated <think> block (no closing tag), discarding", _P)
+        return ""
+
+    @staticmethod
+    def _sanitize_json_string(raw: str) -> str:
+        """Escape unescaped control characters inside JSON string values."""
+        out: list[str] = []
+        in_string = False
+        i = 0
+        length = len(raw)
+        while i < length:
+            ch = raw[i]
+            if ch == "\\" and in_string:
+                out.append(ch)
+                if i + 1 < length:
+                    i += 1
+                    out.append(raw[i])
+                i += 1
+                continue
+            if ch == '"':
+                in_string = not in_string
+                out.append(ch)
+                i += 1
+                continue
+            if in_string:
+                if ch == "\n":
+                    out.append("\\n")
+                    i += 1
+                    continue
+                if ch == "\r":
+                    out.append("\\r")
+                    i += 1
+                    continue
+                if ch == "\t":
+                    out.append("\\t")
+                    i += 1
+                    continue
+            out.append(ch)
+            i += 1
+        return "".join(out)
+
+    async def _call_llm(
+        self,
+        llm: BaseChatModel,
+        prompt: ChatPromptTemplate,
+        inputs: dict[str, Any],
+        step_name: str = "LLM Call",
+        json_mode: bool = False,
+    ) -> str:
+        from nvidia_rag.rag_server.agentic_rag.tracing import get_current_trace
+
+        if json_mode:
+            model_name = getattr(llm, "model_name", "") or getattr(llm, "model", "") or ""
+            if not any(kw in model_name.lower() for kw in ("claude", "anthropic", "gpt", "gemini")):
+                llm = llm.bind(response_format={"type": "json_object"})
+
+        chain = prompt | llm
+        max_retries = self.llm_cfg.max_retries
+        llm_timeout = self.llm_cfg.call_timeout
+
+        with self._otel.start_as_current_span(f"llm:{step_name}") as ospan:
+            ospan.set_attribute("openinference.span.kind", "LLM")
+            ospan.set_attribute("input.value", json.dumps(inputs, indent=2, default=str))
+            ospan.set_attribute("input.mime_type", "application/json")
+            t0 = time.perf_counter()
+            final_attempt = 1
+
+            for attempt in range(max_retries + 1):
+                final_attempt = attempt + 1
+                try:
+                    async with self._semaphore:
+                        response = await asyncio.wait_for(
+                            chain.ainvoke(inputs), timeout=llm_timeout
+                        )
+                    break
+                except TimeoutError:
+                    logger.warning(
+                        "%s [%s] Timeout after %ds (attempt %d/%d)",
+                        _P,
+                        step_name,
+                        llm_timeout,
+                        attempt + 1,
+                        max_retries + 1,
+                    )
+                    if attempt < max_retries:
+                        continue
+                    raise TimeoutError(
+                        f"[{step_name}] LLM timed out after {max_retries + 1} attempts"
+                    ) from None
+                except Exception as ex:
+                    ex_str = str(ex)
+                    is_retryable = any(
+                        code in ex_str
+                        for code in (
+                            "429",
+                            "500",
+                            "502",
+                            "503",
+                            "504",
+                            "timeout",
+                            "Timeout",
+                        )
+                    )
+                    if is_retryable and attempt < max_retries:
+                        wait = 2**attempt * 5
+                        logger.warning(
+                            "%s [%s] Transient error (attempt %d/%d), retry in %ds — %s",
+                            _P,
+                            step_name,
+                            attempt + 1,
+                            max_retries + 1,
+                            wait,
+                            ex_str[:200],
+                        )
+                        await asyncio.sleep(wait)
+                    else:
+                        raise
+
+            reasoning = getattr(response, "reasoning_content", None)
+            if not reasoning and hasattr(response, "additional_kwargs"):
+                reasoning = (response.additional_kwargs or {}).get("reasoning_content")
+            if reasoning:
+                preview = str(reasoning)[:300].replace("\n", " ")
+                logger.debug(
+                    "%s [%s] Reasoning: %s%s",
+                    _P,
+                    step_name,
+                    preview,
+                    "..." if len(str(reasoning)) > 300 else "",
+                )
+
+            response_content = self._filter_think_tokens(str(response.content))
+
+            # Prefer API-reported token counts; fall back to tiktoken estimate.
+            # usage_metadata can be a dict (ChatNVIDIA) or an object (other providers).
+            usage = getattr(response, "usage_metadata", None)
+            if usage:
+                if isinstance(usage, dict):
+                    input_tokens = usage.get("input_tokens", 0)
+                    output_tokens = usage.get("output_tokens", 0)
+                else:
+                    input_tokens = getattr(usage, "input_tokens", 0)
+                    output_tokens = getattr(usage, "output_tokens", 0)
+            else:
+                input_tokens = 0
+                output_tokens = self._estimate_tokens(response_content)
+                if reasoning:
+                    output_tokens += self._estimate_tokens(str(reasoning))
+
+            duration_ms = (time.perf_counter() - t0) * 1000
+            trace = get_current_trace()
+            if trace:
+                trace.record_llm_call(
+                    step_name=step_name,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    duration_ms=duration_ms,
+                    attempt_number=final_attempt,
+                )
+
+            ospan.set_attribute("output.value", response_content)
+            ospan.set_attribute("output.mime_type", "text/plain")
+            ospan.set_attribute("llm.token_count.prompt", input_tokens)
+            ospan.set_attribute("llm.token_count.completion", output_tokens)
+            ospan.set_attribute("llm.token_count.total", input_tokens + output_tokens)
+            meta = {
+                "latency_ms": round(duration_ms, 1),
+                "attempts": final_attempt,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            }
+            if reasoning:
+                meta["reasoning"] = str(reasoning)
+            ospan.set_attribute("metadata", json.dumps(meta))
+
+            logger.debug(
+                "%s [%s] Response — in: %d tok, out: %d tok%s, %.0fms",
+                _P,
+                step_name,
+                input_tokens,
+                output_tokens,
+                " (incl. reasoning)" if reasoning else "",
+                duration_ms,
+            )
+
+            return response_content
+
+    # =========================================================================
+    # JSON PARSING
+    # =========================================================================
+
+    def _parse_json_response(self, response: str) -> dict[str, Any]:
+        """Parse a JSON object from an LLM response, with fallback sanitization."""
+        try:
+            return json.loads(response)
+        except json.JSONDecodeError:
+            pass
+
+        start = response.find("{")
+        end = response.rfind("}") + 1
+        if start == -1 or end <= start:
+            logger.warning("%s No JSON object found in response: %.200s", _P, response)
+            return {"error": "Failed to parse JSON", "raw_response": response}
+
+        json_str = response[start:end]
+        try:
+            return json.loads(json_str)
+        except json.JSONDecodeError:
+            pass
+
+        try:
+            return json.loads(self._sanitize_json_string(json_str))
+        except json.JSONDecodeError:
+            pass
+
+        logger.warning("%s JSON parse failed: %.200s", _P, response)
+        return {"error": "Failed to parse JSON", "raw_response": response}
+
+    # =========================================================================
+    # CONTENT HELPERS
+    # =========================================================================
+
+    @staticmethod
+    def _get_text_content(doc: dict) -> str:
+        """Return usable text from a retrieval result."""
+        doc_type = doc.get("document_type", "text")
+        if doc_type in AgenticRag._TEXT_DOCUMENT_TYPES:
+            content = doc.get("content", "")
+            if content and content.strip():
+                return content
+        description = doc.get("metadata", {}).get("description", "")
+        if description and description.strip():
+            return description
+        return ""
+
+    def _extract_chunks(self, raw_context: Any) -> list[dict[str, str]]:
+        """Flatten raw retrieval results into a list of text chunks."""
+        chunks = []
+        discarded = 0
+        items = raw_context if isinstance(raw_context, list) else [raw_context]
+        for item in items:
+            if isinstance(item, dict):
+                results = item.get("results", [item])
+                for doc in results:
+                    doc_type = doc.get("document_type", "text")
+                    text = self._get_text_content(doc)
+                    if not text or not text.strip():
+                        discarded += 1
+                        continue
+                    chunks.append(
+                        {
+                            "doc_name": doc.get("document_name", "Unknown"),
+                            "content": text,
+                            "score": doc.get("score", 0.0),
+                            "document_type": doc_type,
+                        }
+                    )
+        if discarded:
+            logger.debug(
+                "%s Discarded %d chunks (image/chart with no description)",
+                _P,
+                discarded,
+            )
+        return chunks
+
+    def _format_chunks_for_prompt(self, chunks: list[dict], max_tokens: int | None = None) -> str:
+        """Format chunks as a numbered list sorted by relevance, truncated to token budget."""
+        if not chunks:
+            return "(no documents)"
+
+        if max_tokens is None:
+            max_tokens = self.context_cfg.max_tokens
+
+        sorted_chunks = sorted(chunks, key=lambda c: c.get("score", 0), reverse=True)
+
+        parts = []
+        current_tokens = 0
+        for idx, c in enumerate(sorted_chunks, 1):
+            dtype = c.get("document_type", "text")
+            label = {"table": "Table", "chart": "Chart"}.get(dtype, "Chunk")
+            doc_name = c.get("doc_name", "")
+            header = f"[{label} {idx}] File: {doc_name}" if doc_name else f"[{label} {idx}]"
+            section = f"{header}\n{c['content']}"
+
+            section_tokens = self._estimate_tokens(section)
+            if current_tokens + section_tokens > max_tokens:
+                remaining = max_tokens - current_tokens
+                if remaining > 100:
+                    chars = int(remaining * self._CHARS_PER_TOKEN_ESTIMATE)
+                    parts.append(section[:chars] + "\n... [truncated]")
+                break
+            parts.append(section)
+            current_tokens += section_tokens
+
+        return "\n\n".join(parts)
+
+    @staticmethod
+    def _clean_answer(text: str) -> str:
+        """Strip markdown formatting artifacts from LLM output."""
+        if not text:
+            return text
+
+        text = re.sub(r"\*\*(.+?)\*\*", r"\1", text)
+        text = re.sub(r"(?<!\w)\*([^*\n]+?)\*(?!\w)", r"\1", text)
+        text = re.sub(r"^#{1,6}\s+", "", text, flags=re.MULTILINE)
+
+        lines = text.split("\n")
+        result_lines: list[str] = []
+        bullet_buffer: list[str] = []
+
+        def flush_bullets():
+            if bullet_buffer:
+                result_lines.append("; ".join(bullet_buffer) + ".")
+                bullet_buffer.clear()
+
+        for line in lines:
+            stripped = line.strip()
+            if re.match(r"^(?:[-*+•]\s|\d+[.)]\s)", stripped):
+                content = re.sub(r"^(?:[-*+•]\s|\d+[.)]\s)\s*", "", stripped).rstrip(".;,")
+                if content:
+                    bullet_buffer.append(content)
+            else:
+                flush_bullets()
+                result_lines.append(line)
+
+        flush_bullets()
+        text = "\n".join(result_lines)
+        text = re.sub(r":\s*;\s*", ": ", text)
+        text = re.sub(r"\n{3,}", "\n\n", text)
+        return text.strip()
+
+    # =========================================================================
+    # TASK EXECUTION ENGINE
+    # =========================================================================
+
+    def _build_execution_levels(self, tasks: list[dict]) -> list[list[dict]]:
+        """Return tasks grouped into parallel execution levels (currently one level)."""
+        if not tasks:
+            return []
+        for i, t in enumerate(tasks):
+            if "id" not in t:
+                t["id"] = f"auto_{i + 1}"
+        return [tasks]
+
+    def _parse_task_answer(self, raw_answer: str) -> dict:
+        """Parse structured task answer JSON; falls back to plain-text heuristic."""
+        if not raw_answer:
+            return {"completeness": "none", "answer": "[NO DATA]", "missing": ""}
+
+        parsed = self._parse_json_response(raw_answer)
+        if parsed and "completeness" in parsed:
+            return {
+                "completeness": parsed.get("completeness", "complete"),
+                "answer": self._clean_answer(parsed.get("answer", "") or ""),
+                "missing": parsed.get("missing", ""),
+            }
+
+        text = self._clean_answer(raw_answer.strip())
+        if not text or text == "[NO DATA]":
+            return {"completeness": "none", "answer": "[NO DATA]", "missing": ""}
+        return {"completeness": "complete", "answer": text, "missing": ""}
+
+    async def _execute_single_task(
+        self,
+        task: dict,
+        is_scope: bool = False,
+        stage: str = "execute",
+    ) -> dict:
+        """Execute one task as a mini-agent with seed-query retries and partial-answer merging."""
+        effective_max_retries = (
+            self.task_exec_cfg.scope_max_retries
+            if is_scope
+            else self.task_exec_cfg.answer_max_retries
+        )
+        question = task["question"]
+        query = task["query"]
+        tid = task["id"]
+
+        with self._otel.start_as_current_span(f"task:{tid}") as tspan:
+            tspan.set_attribute("openinference.span.kind", "CHAIN")
+            tspan.set_attribute("input.value", question)
+
+            def _finish_task(res: dict) -> dict:
+                tspan.set_attribute("output.value", res["answer"])
+                tspan.set_attribute(
+                    "metadata",
+                    json.dumps(
+                        {
+                            "question": question,
+                            "query": query,
+                            "status": res["status"],
+                            "attempts": res["attempts"],
+                        }
+                    ),
+                )
+                return res
+
+            attempt_log = []
+            accumulated_answer = ""
+
+            for attempt in range(effective_max_retries):
+                current_query = query if attempt == 0 else None
+
+                if attempt > 0:
+                    tried_summary = "\n".join(
+                        f'  {i + 1}. Query: "{e["query"]}" → {e["outcome"]}'
+                        for i, e in enumerate(attempt_log)
+                    )
+                    seed_response = await self._call_llm(
+                        self.seed_gen_llm,
+                        self.seed_gen_prompt,
+                        {"question": question, "tried_queries": tried_summary},
+                        step_name=f"Task {tid} seed gen (attempt {attempt + 1})",
+                        json_mode=False,
+                    )
+                    seed_result = self._parse_json_response(seed_response)
+
+                    if seed_result.get("stop", False):
+                        logger.debug(
+                            "%s Task %s stopping — %s",
+                            _P,
+                            tid,
+                            seed_result.get("reasoning", "exhausted"),
+                        )
+                        result = (
+                            {
+                                "answer": accumulated_answer,
+                                "status": "answered",
+                                "attempts": attempt + 1,
+                            }
+                            if accumulated_answer
+                            else {
+                                "answer": "[NO DATA]",
+                                "status": "no_data",
+                                "attempts": attempt + 1,
+                            }
+                        )
+                        return _finish_task(result)
+
+                    current_query = seed_result.get("seed_query") or query
+
+                logger.debug(
+                    "%s Task %s attempt %d — query: %s", _P, tid, attempt + 1, current_query
+                )
+
+                with self._otel.start_as_current_span(
+                    f"retrieve:task_{tid}_att{attempt + 1}"
+                ) as rspan:
+                    rspan.set_attribute("openinference.span.kind", "RETRIEVER")
+                    rspan.set_attribute("input.value", current_query or "")
+                    try:
+                        raw_context = await self.retriever_fn(current_query, stage)
+                        if raw_context is None:
+                            raw_context = []
+                    except Exception as ex:
+                        logger.warning("%s Task %s retrieval failed: %s", _P, tid, ex)
+                        rspan.set_attribute("metadata", json.dumps({"error": str(ex)[:200]}))
+                        raw_context = []
+
+                chunks = self._extract_chunks(
+                    raw_context if isinstance(raw_context, list) else [raw_context]
+                )
+
+                if not chunks:
+                    logger.debug("%s Task %s attempt %d — no chunks returned", _P, tid, attempt + 1)
+                    result = (
+                        {
+                            "answer": accumulated_answer,
+                            "status": "answered",
+                            "attempts": attempt + 1,
+                        }
+                        if accumulated_answer
+                        else {"answer": "[NO DATA]", "status": "no_data", "attempts": attempt + 1}
+                    )
+                    return _finish_task(result)
+
+                n_chunks = len(chunks)
+                docs_str = self._format_chunks_for_prompt(chunks)
+
+                task_question = question
+                if accumulated_answer:
+                    task_question = (
+                        f"{question}\n\n"
+                        f"IMPORTANT: A prior retrieval already found this partial answer:\n"
+                        f"{accumulated_answer}\n\n"
+                        f"Your job: find the MISSING information and produce a COMPLETE answer "
+                        f"that merges the prior data with any new data you find in these documents."
+                    )
+
+                raw_answer = await self._call_llm(
+                    self.task_llm,
+                    self.task_answer_prompt,
+                    {"question": task_question, "documents": docs_str},
+                    step_name=f"Task {tid} answer (attempt {attempt + 1})",
+                )
+                parsed = self._parse_task_answer(raw_answer)
+
+                if parsed["completeness"] == "complete":
+                    logger.debug("%s Task %s — complete answer found", _P, tid)
+                    result = {
+                        "answer": parsed["answer"],
+                        "status": "answered",
+                        "attempts": attempt + 1,
+                    }
+                    return _finish_task(result)
+
+                if parsed["completeness"] == "partial":
+                    accumulated_answer = parsed["answer"]
+                    attempt_log.append(
+                        {
+                            "query": current_query,
+                            "outcome": f"PARTIAL ({n_chunks} docs) — found: {parsed['answer'][:80]}... | still missing: {parsed['missing']}",
+                        }
+                    )
+                    logger.debug(
+                        "%s Task %s — partial (%d/%d), missing: %.100s",
+                        _P,
+                        tid,
+                        attempt + 1,
+                        effective_max_retries,
+                        parsed["missing"],
+                    )
+                    continue
+
+                logger.debug("%s Task %s — [NO DATA] from %d docs", _P, tid, n_chunks)
+                result = (
+                    {"answer": accumulated_answer, "status": "answered", "attempts": attempt + 1}
+                    if accumulated_answer
+                    else {"answer": "[NO DATA]", "status": "no_data", "attempts": attempt + 1}
+                )
+                return _finish_task(result)
+
+            result = (
+                {
+                    "answer": accumulated_answer,
+                    "status": "answered",
+                    "attempts": effective_max_retries,
+                }
+                if accumulated_answer
+                else {"answer": "[NO DATA]", "status": "no_data", "attempts": effective_max_retries}
+            )
+            return _finish_task(result)
+
+    async def _execute_plan(
+        self,
+        tasks: list[dict],
+        is_scope: bool = False,
+        stage: str = "execute",
+    ) -> dict[str, dict]:
+        """Execute all tasks in parallel."""
+        levels = self._build_execution_levels(tasks)
+        all_results: dict[str, dict] = {}
+
+        for level_tasks in levels:
+            logger.debug(
+                "%s Executing %d tasks: %s",
+                _P,
+                len(level_tasks),
+                [t["id"] for t in level_tasks],
+            )
+
+            coros = [self._execute_single_task(task, is_scope=is_scope, stage=stage) for task in level_tasks]
+            results = await asyncio.gather(*coros, return_exceptions=True)
+
+            for task, result in zip(level_tasks, results, strict=True):
+                if isinstance(result, Exception):
+                    logger.error("%s Task %s failed: %s", _P, task["id"], result)
+                    result = {"answer": "[NO DATA]", "status": "error", "attempts": 0}
+                all_results[task["id"]] = result
+
+        return all_results
+
+    # =========================================================================
+    # GRAPH NODES
+    # =========================================================================
+
+    async def initial_retrieval_node(self, state: AgenticRAGGraphState) -> dict[str, Any]:
+        """Single-query retrieval using the user's original query."""
+        from nvidia_rag.rag_server.agentic_rag.tracing import get_current_trace
+
+        with self._otel_and_trace("initial_retrieval") as ospan:
+            ospan.set_attribute("input.value", state.user_query)
+            logger.info("%s Initial retrieval started", _P)
+
+            with self._otel.start_as_current_span("retrieve:original") as rspan:
+                rspan.set_attribute("openinference.span.kind", "RETRIEVER")
+                rspan.set_attribute("input.value", state.user_query)
+                try:
+                    raw = await self.retriever_fn(state.user_query, "initial_retrieval")
+                    if raw is None:
+                        raw = []
+                    result = raw if isinstance(raw, list) else [raw]
+                    chunks = self._extract_chunks(result)
+                    for i, c in enumerate(chunks):
+                        rspan.set_attribute(
+                            f"retrieval.documents.{i}.document.content",
+                            c.get("content", ""),
+                        )
+                        rspan.set_attribute(
+                            f"retrieval.documents.{i}.document.score",
+                            c.get("score", 0.0),
+                        )
+                        rspan.set_attribute(
+                            f"retrieval.documents.{i}.document.metadata",
+                            json.dumps({"doc_name": c.get("doc_name", "")}),
+                        )
+                    rspan.set_attribute(
+                        "metadata",
+                        json.dumps({"document_count": len(chunks)}),
+                    )
+                except Exception as ex:
+                    logger.warning("%s Retrieval failed: %s", _P, ex)
+                    rspan.set_attribute("metadata", json.dumps({"error": str(ex)[:200]}))
+                    chunks = []
+
+            logger.info("%s Retrieval complete: %d chunks", _P, len(chunks))
+
+            stats = {"chunks": len(chunks)}
+            ospan.set_attribute("output.value", json.dumps(stats, indent=2))
+            ospan.set_attribute("output.mime_type", "application/json")
+            ospan.set_attribute("metadata", json.dumps(stats))
+
+            trace = get_current_trace()
+            if trace:
+                trace.retrieval_stats = stats
+
+            rebuilt_context = [{"results": [self._rebuild_result(c) for c in chunks]}]
+
+            return {"initial_context": rebuilt_context}
+
+    async def plan_node(self, state: AgenticRAGGraphState) -> dict[str, Any]:
+        """Create or refine the retrieval plan (called once or twice for scope discovery)."""
+        from nvidia_rag.rag_server.agentic_rag.tracing import get_current_trace
+
+        is_replan = bool(state.scope_results)
+        phase = "phase 2 (answer plan)" if is_replan else "phase 1 (scope discovery)"
+        with self._otel_and_trace(f"plan ({phase})") as ospan:
+            current_round = state.scope_rounds
+            ospan.set_attribute("input.value", state.user_query)
+            logger.info("%s Planning (%s, scope_round=%d)", _P, phase, current_round)
+
+            chunks = self._extract_chunks(state.initial_context)
+            initial_content = (
+                self._format_chunks_for_prompt(chunks) if chunks else "(no documents retrieved)"
+            )
+
+            scope_section = ""
+            if is_replan:
+                scope_parts = [f"[{tid}]: {answer}" for tid, answer in state.scope_results.items()]
+                scope_section = (
+                    "\nScope Discovery Results (what actually exists in the database):\n"
+                    + "\n".join(scope_parts)
+                    + "\n"
+                    + self.planner_replan_instruction
+                )
+
+            planner_max_attempts = self.planner_cfg.max_attempts
+            try:
+                plan = None
+                for planner_attempt in range(planner_max_attempts):
+                    response = await self._call_llm(
+                        self.planner_llm,
+                        self.planner_prompt,
+                        {
+                            "query": state.user_query,
+                            "initial_context": initial_content,
+                            "scope_section": scope_section,
+                        },
+                        step_name=f"Planner ({phase})",
+                        json_mode=False,
+                    )
+                    plan = self._parse_json_response(response)
+
+                    if "error" in plan:
+                        logger.warning(
+                            "%s Plan parse failed (attempt %d/%d)",
+                            _P,
+                            planner_attempt + 1,
+                            planner_max_attempts,
+                        )
+                        if planner_attempt < planner_max_attempts - 1:
+                            continue
+                        plan = {
+                            "scope_only": False,
+                            "scope_resolution": "Plan parsing failed — answering from initial retrieval",
+                            "resolved_query": state.user_query,
+                            "tasks": [],
+                            "synthesis_instruction": "Answer directly from initial retrieval context",
+                        }
+                        break
+
+                    is_degenerate = "resolved_query" not in plan and "scope_only" not in plan
+                    if is_degenerate and planner_attempt < planner_max_attempts - 1:
+                        logger.warning(
+                            "%s Degenerate plan (missing key fields), retrying (%d/%d)",
+                            _P,
+                            planner_attempt + 1,
+                            planner_max_attempts,
+                        )
+                        continue
+
+                    tasks_list = plan.get("tasks", [])
+                    if isinstance(tasks_list, list) and tasks_list:
+                        required_keys = {"id", "question", "query"}
+                        malformed_keys = [
+                            i
+                            for i, t in enumerate(tasks_list)
+                            if not isinstance(t, dict) or not required_keys.issubset(t.keys())
+                        ]
+                        if malformed_keys and planner_attempt < planner_max_attempts - 1:
+                            issues = []
+                            for i in malformed_keys:
+                                t = tasks_list[i]
+                                if not isinstance(t, dict):
+                                    issues.append(f"task[{i}] not a dict")
+                                else:
+                                    missing = required_keys - set(t.keys())
+                                    if missing:
+                                        issues.append(f"task[{i}] missing {missing}")
+                            logger.warning(
+                                "%s Malformed tasks (%s), retrying (%d/%d)",
+                                _P,
+                                ", ".join(issues),
+                                planner_attempt + 1,
+                                planner_max_attempts,
+                            )
+                            continue
+                        if malformed_keys:
+                            for i, t in enumerate(tasks_list):
+                                if isinstance(t, dict) and "id" not in t:
+                                    t["id"] = f"auto_{i + 1}"
+                    break
+
+                if not isinstance(plan.get("tasks"), list):
+                    plan["tasks"] = []
+                max_plan_tasks = self.planner_cfg.max_plan_tasks
+                plan["tasks"] = plan["tasks"][:max_plan_tasks]
+
+                if plan.get("scope_only", False) and not plan["tasks"]:
+                    plan["scope_only"] = False
+
+                if plan.get("scope_only", False) or not plan["tasks"]:
+                    plan["synthesis_instruction"] = ""
+
+                max_scope_rounds = self.planner_cfg.max_scope_rounds
+                if is_replan and current_round >= max_scope_rounds:
+                    if plan.get("scope_only", False):
+                        logger.warning(
+                            "%s Max scope rounds (%d) reached — forcing answer phase",
+                            _P,
+                            max_scope_rounds,
+                        )
+                        plan["scope_only"] = False
+
+                new_round = current_round + 1 if plan.get("scope_only", False) else current_round
+
+                logger.info(
+                    "%s Plan: scope_only=%s, %d tasks, resolved_query=%.80s",
+                    _P,
+                    plan.get("scope_only", False),
+                    len(plan.get("tasks", [])),
+                    plan.get("resolved_query", "")[:80],
+                )
+                logger.debug("%s Plan detail: %s", _P, json.dumps(plan, indent=2)[:2000])
+
+                task_ids = [t.get("id", "") for t in plan.get("tasks", [])]
+                plan_json = json.dumps(plan, indent=2)
+                ospan.set_attribute("output.value", plan_json)
+                ospan.set_attribute("output.mime_type", "application/json")
+                ospan.set_attribute(
+                    "metadata",
+                    json.dumps(
+                        {
+                            "phase": phase,
+                            "scope_only": plan.get("scope_only", False),
+                            "task_count": len(task_ids),
+                            "task_ids": task_ids,
+                            "resolved_query": plan.get("resolved_query", ""),
+                        }
+                    ),
+                )
+
+                trace = get_current_trace()
+                if trace:
+                    trace.plan_summary = {
+                        "scope_only": plan.get("scope_only", False),
+                        "task_count": len(task_ids),
+                        "scope_rounds": new_round,
+                        "resolved_query": plan.get("resolved_query", ""),
+                    }
+
+                return {
+                    "retrieval_plan": plan,
+                    "needs_replan": False,
+                    "scope_rounds": new_round,
+                }
+
+            except Exception as ex:
+                logger.exception("%s Planning failed: %s", _P, ex)
+                return {
+                    "retrieval_plan": {
+                        "scope_only": False,
+                        "scope_resolution": f"Planning failed: {ex}",
+                        "resolved_query": state.user_query,
+                        "tasks": [],
+                        "synthesis_instruction": "Answer directly from initial retrieval context",
+                    },
+                    "needs_replan": False,
+                }
+
+    async def execute_node(self, state: AgenticRAGGraphState) -> dict[str, Any]:
+        """Execute all tasks from the current plan."""
+        from nvidia_rag.rag_server.agentic_rag.tracing import get_current_trace
+
+        tasks = state.retrieval_plan.get("tasks", [])
+        is_scope_only = state.retrieval_plan.get("scope_only", False)
+        exec_label = "scope discovery" if is_scope_only else "answer"
+        with self._otel_and_trace(f"execute ({exec_label})") as ospan:
+            task_ids = [t.get("id", "") for t in tasks]
+            ospan.set_attribute("input.value", json.dumps(task_ids))
+            ospan.set_attribute("input.mime_type", "application/json")
+
+            if not tasks:
+                logger.info("%s Execute: no tasks — synthesizing from initial retrieval", _P)
+                return {"task_results": {}, "needs_replan": False}
+
+            logger.info("%s Executing %d %s tasks", _P, len(tasks), exec_label)
+
+            exec_stage = "execute_scope" if is_scope_only else "execute"
+            results = await self._execute_plan(tasks, is_scope=is_scope_only, stage=exec_stage)
+
+            statuses = [r.get("status", "unknown") for r in results.values()]
+            answered = statuses.count("answered")
+            no_data = statuses.count("no_data")
+            exec_output = {
+                tid: {"status": r.get("status", "unknown"), "answer": r.get("answer", "")}
+                for tid, r in results.items()
+            }
+            ospan.set_attribute("output.value", json.dumps(exec_output, indent=2))
+            ospan.set_attribute("output.mime_type", "application/json")
+            ospan.set_attribute(
+                "metadata",
+                json.dumps(
+                    {
+                        "mode": exec_label,
+                        "task_count": len(tasks),
+                        "answered": answered,
+                        "no_data": no_data,
+                    }
+                ),
+            )
+            logger.info("%s Execution complete: %d answered, %d no_data", _P, answered, no_data)
+            logger.debug(
+                "%s Execution detail: %s",
+                _P,
+                json.dumps(
+                    {tid: r.get("status", "unknown") for tid, r in results.items()},
+                    indent=2,
+                ),
+            )
+
+            trace = get_current_trace()
+            if trace:
+                trace.task_results_summary = {
+                    tid: {
+                        "status": r.get("status", "unknown"),
+                        "attempts": r.get("attempts", 0),
+                    }
+                    for tid, r in results.items()
+                }
+
+            if is_scope_only:
+                scope_answers = dict(state.scope_results) if state.scope_results else {}
+                for tid, r in results.items():
+                    ans = r.get("answer", "[NO DATA]")
+                    if ans and ans.strip() != "[NO DATA]":
+                        scope_answers[tid] = ans
+
+                if scope_answers:
+                    ospan.set_attribute(
+                        "metadata",
+                        json.dumps(
+                            {
+                                "mode": exec_label,
+                                "task_count": len(tasks),
+                                "answered": answered,
+                                "no_data": no_data,
+                                "replan_decision": f"REPLAN: {len(scope_answers)} of {len(results)} scope tasks returned data",
+                            }
+                        ),
+                    )
+                    logger.info(
+                        "%s Scope: %d/%d tasks returned data — re-planning",
+                        _P,
+                        len(scope_answers),
+                        len(results),
+                    )
+                    return {
+                        "task_results": results,
+                        "scope_results": scope_answers,
+                        "needs_replan": True,
+                    }
+                else:
+                    ospan.set_attribute(
+                        "metadata",
+                        json.dumps(
+                            {
+                                "mode": exec_label,
+                                "task_count": len(tasks),
+                                "answered": answered,
+                                "no_data": no_data,
+                                "replan_decision": "SKIP REPLAN: all scope tasks returned [NO DATA] — synthesizing from initial retrieval",
+                            }
+                        ),
+                    )
+                    logger.info("%s Scope: all tasks returned [NO DATA] — no replan", _P)
+                    return {"task_results": results, "needs_replan": False}
+
+            return {"task_results": results, "needs_replan": False}
+
+    async def synthesize_node(self, state: AgenticRAGGraphState) -> dict[str, Any]:
+        """Combine task sub-answers (and optionally verification data) into a final answer."""
+        is_verification_pass = state.verification_round > 0
+        synth_label = (
+            f"synthesize (verification pass {state.verification_round})"
+            if is_verification_pass
+            else "synthesize"
+        )
+        with self._otel_and_trace(synth_label) as ospan:
+            pass_label = synth_label
+            ospan.set_attribute("input.value", state.user_query)
+            logger.info("%s %s started", _P, pass_label)
+
+            tasks = state.retrieval_plan.get("tasks", [])
+            task_results = state.task_results
+            synthesis_instruction = (
+                state.retrieval_plan.get("synthesis_instruction", "")
+                or "Answer the question directly"
+            )
+
+            has_verification_data = (
+                any(
+                    r.get("answer", "").strip() not in ("", "[NO DATA]")
+                    for r in state.verification_results.values()
+                )
+                if state.verification_results
+                else False
+            )
+
+            if is_verification_pass and not has_verification_data:
+                logger.info(
+                    "%s %s — all verification tasks returned [NO DATA], keeping original answer",
+                    _P,
+                    pass_label,
+                )
+                return {"final_answer": state.final_answer}
+
+            chunks = self._extract_chunks(state.initial_context)
+
+            effective_tasks = [
+                t
+                for t in tasks
+                if task_results.get(t["id"], {}).get("answer", "[NO DATA]") != "[NO DATA]"
+            ]
+
+            if not effective_tasks and not state.verification_results:
+                if not chunks:
+                    return {
+                        "final_answer": "No relevant information found in the available documents."
+                    }
+
+                docs_str = self._format_chunks_for_prompt(chunks)
+                sub_answers = (
+                    f"[Source documents — synthesize the answer directly from these]\n{docs_str}"
+                )
+            else:
+                answer_parts = []
+
+                if is_verification_pass and has_verification_data:
+                    if state.final_answer:
+                        answer_parts.append(f"[PREVIOUS ANSWER]: {state.final_answer}")
+                    if state.verification_issues:
+                        issues_text = "\n".join(f"- {issue}" for issue in state.verification_issues)
+                        answer_parts.append(f"[GAPS IDENTIFIED IN PREVIOUS ANSWER]:\n{issues_text}")
+                    synthesis_instruction = (
+                        "IMPORTANT: The [PREVIOUS ANSWER] had gaps listed under [GAPS IDENTIFIED IN PREVIOUS ANSWER]. "
+                        "Keep the [PREVIOUS ANSWER] as the base. "
+                        "Fill the gaps using [VERIFICATION — NEW DATA] and the supplementary context. "
+                        "Do not rewrite parts that were already correct. "
+                        "Underlying retrieval goal: " + synthesis_instruction
+                    )
+
+                for task in effective_tasks:
+                    tid = task["id"]
+                    result = task_results.get(tid, {})
+                    answer = result.get("answer", "[NO DATA]")
+                    answer_parts.append(f"Task {tid} ({task.get('question', '')}): {answer}")
+
+                if state.verification_results:
+                    v_question_map = {
+                        t["id"]: t.get("question", "") for t in state.verification_tasks
+                    }
+                    for tid, result in state.verification_results.items():
+                        answer = result.get("answer", "[NO DATA]")
+                        v_question = v_question_map.get(tid, "")
+                        if answer and answer.strip() != "[NO DATA]":
+                            v_label = (
+                                f"[VERIFICATION — NEW DATA] {tid} ({v_question})"
+                                if v_question
+                                else f"[VERIFICATION — NEW DATA] {tid}"
+                            )
+                            answer_parts.append(f"{v_label}: {answer}")
+
+                sub_answers = "\n\n".join(answer_parts)
+
+                if chunks:
+                    initial_docs = self._format_chunks_for_prompt(chunks)
+                    sub_answers += (
+                        "\n\n--- Supplementary Context (from initial retrieval) ---\n"
+                        + initial_docs
+                    )
+
+            resolved_query = (
+                state.retrieval_plan.get("resolved_query", state.user_query) or state.user_query
+            )
+            resolved_section = ""
+            if resolved_query.strip().lower() != state.user_query.strip().lower():
+                resolved_section = (
+                    f"\nClarified question (an implicit or ambiguous reference in the question above "
+                    f"has been resolved from the documents; the User Question remains authoritative): "
+                    f"{resolved_query}\n"
+                )
+
+            try:
+                response = await self._call_llm(
+                    self.synthesis_llm,
+                    self.synthesis_prompt,
+                    {
+                        "query": state.user_query,
+                        "resolved_section": resolved_section,
+                        "synthesis_instruction": synthesis_instruction,
+                        "sub_answers": sub_answers,
+                    },
+                    step_name=pass_label,
+                )
+                answer = self._clean_answer(response) if response else ""
+
+                if not answer:
+                    answer = "No relevant information found in the available documents."
+
+                ospan.set_attribute("output.value", answer)
+                ospan.set_attribute(
+                    "metadata",
+                    json.dumps(
+                        {
+                            "is_verification_pass": is_verification_pass,
+                            "answer_length": len(answer),
+                        }
+                    ),
+                )
+                logger.info("%s %s complete", _P, pass_label)
+                logger.debug("%s Answer preview: %.300s", _P, answer)
+                return {"final_answer": answer}
+
+            except Exception as ex:
+                logger.exception("%s Synthesis failed: %s", _P, ex)
+                return {"final_answer": "I encountered an error generating the answer."}
+
+    def _build_resolved_query_section(self, state: AgenticRAGGraphState) -> str:
+        """Build the resolved-query header for the verification prompt."""
+        resolved = state.retrieval_plan.get("resolved_query", "") or ""
+        if resolved and resolved.strip().lower() != state.user_query.strip().lower():
+            return f"\nDisambiguated Question (implicit or ambiguous references in the original question were resolved from the documents): {resolved}\n"
+        return ""
+
+    async def verify_node(self, state: AgenticRAGGraphState) -> dict[str, Any]:
+        """Check answer completeness and identify retrieval gaps."""
+        from nvidia_rag.rag_server.agentic_rag.tracing import get_current_trace
+
+        with self._otel_and_trace("verify") as ospan:
+            ospan.set_attribute("input.value", state.final_answer)
+            logger.info("%s Verification started (round %d)", _P, state.verification_round)
+
+            tasks = state.retrieval_plan.get("tasks", [])
+            task_summary_parts = []
+            for task in tasks:
+                tid = task["id"]
+                result_entry = state.task_results.get(tid, {})
+                status = result_entry.get("status", "unknown")
+                answer = result_entry.get("answer", "")
+                answer_preview = (answer[:150] + "...") if len(answer) > 150 else answer
+                task_summary_parts.append(
+                    f"- {tid}: {task.get('question', '')} → {status}: {answer_preview}"
+                )
+            task_summary = (
+                "\n".join(task_summary_parts) if task_summary_parts else "(no tasks were executed)"
+            )
+
+            max_v_tasks = self.verification_cfg.max_tasks
+
+            try:
+                response = await self._call_llm(
+                    self.planner_llm,
+                    self.verification_prompt,
+                    {
+                        "query": state.user_query,
+                        "resolved_query_section": self._build_resolved_query_section(state),
+                        "answer": state.final_answer,
+                        "task_summary": task_summary,
+                    },
+                    step_name="Verification",
+                    json_mode=False,
+                )
+                result = self._parse_json_response(response)
+
+                passed = result.get("status") == "pass"
+                issues = result.get("issues", [])
+
+                if passed:
+                    ospan.set_attribute("output.value", json.dumps(result, indent=2))
+                    ospan.set_attribute("output.mime_type", "application/json")
+                    ospan.set_attribute(
+                        "metadata",
+                        json.dumps({"passed": True, "issues": 0, "follow_up_tasks": 0}),
+                    )
+                    logger.info("%s Verification PASSED", _P)
+                    logger.debug(
+                        "%s Verification reasoning: %s",
+                        _P,
+                        result.get("reasoning", ""),
+                    )
+                    trace = get_current_trace()
+                    if trace:
+                        trace.verification_outcome = {
+                            "passed": True,
+                            "issues": [],
+                            "follow_up_tasks": 0,
+                        }
+                    return {
+                        "verification_tasks": [],
+                        "verification_round": state.verification_round + 1,
+                    }
+
+                v_tasks = result.get("tasks", [])
+                if not isinstance(v_tasks, list):
+                    v_tasks = []
+                required_keys = {"id", "question", "query"}
+                v_tasks = [
+                    t for t in v_tasks if isinstance(t, dict) and required_keys.issubset(t.keys())
+                ][:max_v_tasks]
+
+                ospan.set_attribute("output.value", json.dumps(result, indent=2))
+                ospan.set_attribute("output.mime_type", "application/json")
+                ospan.set_attribute(
+                    "metadata",
+                    json.dumps(
+                        {
+                            "passed": False,
+                            "issues": len(issues),
+                            "follow_up_tasks": len(v_tasks),
+                        }
+                    ),
+                )
+
+                logger.info(
+                    "%s Verification FAILED: %d issues, %d follow-up tasks",
+                    _P,
+                    len(issues),
+                    len(v_tasks),
+                )
+                logger.debug("%s Verification issues: %s", _P, issues)
+                logger.debug(
+                    "%s Verification tasks: %s",
+                    _P,
+                    [t.get("id", "") for t in v_tasks],
+                )
+
+                trace = get_current_trace()
+                if trace:
+                    trace.verification_outcome = {
+                        "passed": False,
+                        "issues": issues if isinstance(issues, list) else [],
+                        "follow_up_tasks": len(v_tasks),
+                    }
+
+                return {
+                    "verification_tasks": v_tasks,
+                    "verification_issues": issues if isinstance(issues, list) else [],
+                    "verification_round": state.verification_round + 1,
+                }
+
+            except Exception as ex:
+                logger.exception("%s Verification failed: %s", _P, ex)
+                return {
+                    "verification_tasks": [],
+                    "verification_round": state.verification_round + 1,
+                }
+
+    async def verify_execute_node(self, state: AgenticRAGGraphState) -> dict[str, Any]:
+        """Execute verification follow-up tasks (targeted re-retrieval)."""
+        with self._otel_and_trace("verify_execute") as ospan:
+            v_tasks = state.verification_tasks
+            ospan.set_attribute(
+                "input.value", json.dumps([t.get("id", "") for t in (v_tasks or [])])
+            )
+            if not v_tasks:
+                return {"verification_results": {}}
+
+            logger.info("%s Verify-execute: running %d follow-up tasks", _P, len(v_tasks))
+            results = await self._execute_plan(v_tasks, stage="verify_execute")
+
+            statuses = [r.get("status", "unknown") for r in results.values()]
+            ospan.set_attribute(
+                "metadata",
+                json.dumps(
+                    {
+                        "task_count": len(v_tasks) if v_tasks else 0,
+                        "answered": statuses.count("answered"),
+                        "no_data": statuses.count("no_data"),
+                    }
+                ),
+            )
+            logger.info(
+                "%s Verify-execute complete: %d answered, %d no_data",
+                _P,
+                statuses.count("answered"),
+                statuses.count("no_data"),
+            )
+            return {"verification_results": results}
+
+    # =========================================================================
+    # GRAPH CONSTRUCTION
+    # =========================================================================
+
+    @staticmethod
+    def _route_after_execute(state: AgenticRAGGraphState) -> str:
+        """Route to replan (scope discovery follow-up) or synthesize."""
+        if state.needs_replan:
+            return "plan"
+        return "synthesize"
+
+    def _route_after_synthesize(self, state: AgenticRAGGraphState) -> str:
+        """Route to verification (if enabled and first pass) or end."""
+        if self.verification_cfg.enabled and state.verification_round == 0:
+            return "verify"
+        return END
+
+    @staticmethod
+    def _route_after_verify(state: AgenticRAGGraphState) -> str:
+        """Route to verify-execute (if gaps found) or end."""
+        if state.verification_tasks:
+            return "verify_execute"
+        return END
+
+    async def build_graph(self):
+        """Compile the LangGraph state machine."""
+        graph = StateGraph(AgenticRAGGraphState)
+
+        graph.add_node("initial_retrieval", self.initial_retrieval_node)
+        graph.add_node("plan", self.plan_node)
+        graph.add_node("execute", self.execute_node)
+        graph.add_node("synthesize", self.synthesize_node)
+        graph.add_node("verify", self.verify_node)
+        graph.add_node("verify_execute", self.verify_execute_node)
+
+        graph.set_entry_point("initial_retrieval")
+        graph.add_edge("initial_retrieval", "plan")
+        graph.add_edge("plan", "execute")
+        graph.add_conditional_edges(
+            "execute",
+            self._route_after_execute,
+            {
+                "plan": "plan",
+                "synthesize": "synthesize",
+            },
+        )
+        graph.add_conditional_edges(
+            "synthesize",
+            self._route_after_synthesize,
+            {
+                "verify": "verify",
+                END: END,
+            },
+        )
+        graph.add_conditional_edges(
+            "verify",
+            self._route_after_verify,
+            {
+                "verify_execute": "verify_execute",
+                END: END,
+            },
+        )
+        graph.add_edge("verify_execute", "synthesize")
+
+        self.graph = graph.compile()
+        logger.debug("%s Graph compiled", _P)
+        return self.graph

--- a/src/nvidia_rag/rag_server/agentic_rag/builder.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/builder.py
@@ -1,0 +1,305 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agentic RAG builder: wires NvidiaRAG infrastructure into AgenticRag.
+
+This module replaces the NAT register.py files from the standalone agentic_rag
+example.  It provides two public helpers:
+
+  make_retriever_fn       — creates an async retriever callable backed by
+                            NvidiaRAG.search(), returning Citations.model_dump()
+                            which is directly compatible with AgenticRag's
+                            _extract_chunks() parser.
+
+  build_agentic_rag_agent — constructs an AgenticRag and compiles its
+                            LangGraph from the NvidiaRAGConfig.agentic_rag
+                            sub-config.  Called lazily on the first agentic
+                            request; the result is cached by NvidiaRAG.
+
+Per-request search parameters
+------------------------------
+The agent and its compiled graph are built once and cached across requests.
+All runtime search() parameters (collection_names, reranker_top_k, etc.) are
+supplied per-request via the ``_agentic_search_params`` ContextVar.
+
+Before each graph.ainvoke() call, the caller (NvidiaRAG._agentic_chain) sets
+this ContextVar for the current asyncio task; the retriever_fn reads it at
+every invocation.  The ContextVar is async-safe: concurrent requests each see
+their own value.
+
+Usage from _agentic_chain (to be wired in main.py):
+
+    from nvidia_rag.rag_server.agentic_rag.builder import (
+        AgenticSearchParams,
+        _agentic_search_params,
+    )
+
+    params = AgenticSearchParams(
+        collection_names=collection_names,
+        reranker_top_k=reranker_top_k,
+        ...
+    )
+    token = _agentic_search_params.set(params)
+    try:
+        await graph.ainvoke(...)
+    finally:
+        _agentic_search_params.reset(token)
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+from collections import OrderedDict
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from nvidia_rag.rag_server.agentic_rag.agentic_rag import AgenticRag
+from nvidia_rag.rag_server.response_generator import SourceResult
+
+if TYPE_CHECKING:
+    from nvidia_rag.rag_server.main import NvidiaRAG
+    from nvidia_rag.utils.agentic_rag_config import AgenticAnyLLMConfig
+    from nvidia_rag.utils.configuration import NvidiaRAGConfig
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# PER-REQUEST SEARCH PARAMETERS
+# =============================================================================
+
+
+@dataclass
+class AgenticSearchParams:
+    """All runtime parameters forwarded to NvidiaRAG.search() per request.
+
+    Fields map 1-to-1 to NvidiaRAG.search() keyword arguments (excluding
+    ``query``, which is provided by the agent itself for each retrieval call).
+
+    Set via ``_agentic_search_params`` ContextVar before each graph.ainvoke().
+    """
+
+    # --- Retrieval scope ----------------------------------------------------
+    collection_names: list[str] | None = None
+    vdb_top_k: int | None = None
+    vdb_endpoint: str | None = None
+    vdb_auth_token: str = ""
+
+    # --- Reranking ----------------------------------------------------------
+    reranker_top_k: int | None = None
+    reranker_model: str | None = None
+    reranker_endpoint: str | None = None
+    enable_reranker: bool | None = None
+
+    # --- Embedding ----------------------------------------------------------
+    embedding_model: str | None = None
+    embedding_endpoint: str | None = None
+
+    # --- Query processing ---------------------------------------------------
+    enable_query_rewriting: bool | None = None
+    enable_filter_generator: bool | None = None
+    filter_expr: str | list[dict[str, Any]] = field(default_factory=str)
+
+    # --- Result filtering ---------------------------------------------------
+    confidence_threshold: float | None = None
+    enable_citations: bool | None = None
+
+
+# ContextVar holding per-request search params.
+# No mutable default is stored here (B039). Callers use .get(AgenticSearchParams()) so
+# each fallback access creates a fresh instance rather than sharing one mutable object.
+_agentic_search_params: contextvars.ContextVar[AgenticSearchParams] = contextvars.ContextVar(
+    "_agentic_search_params"
+)
+
+# ContextVar holding per-stage citations for the current agentic request.
+# Keys are stage names in insertion order; values are the SourceResults retrieved during that stage.
+# The last key is always the most recent stage that performed retrieval — runner.py reads it with
+# next(reversed(acc.values())) to return only the final stage's citations.
+# Must be initialised to a fresh OrderedDict before each graph.ainvoke() call (done in runner.py).
+_agentic_all_citations: contextvars.ContextVar[OrderedDict[str, list[SourceResult]]] = (
+    contextvars.ContextVar("_agentic_all_citations")
+)
+
+
+# =============================================================================
+# RETRIEVER BRIDGE
+# =============================================================================
+
+
+def make_retriever_fn(
+    nvidia_rag: "NvidiaRAG",
+    default_reranker_top_k: int,
+) -> Callable[[str], Any]:
+    """Return an async retriever function backed by NvidiaRAG.search().
+
+    The returned coroutine matches the signature expected by AgenticRag:
+
+        async def retriever_fn(query: str) -> dict | None
+
+    It calls NvidiaRAG.search() and returns Citations.model_dump(), whose
+    ``results`` list is directly parseable by AgenticRag._extract_chunks().
+    Each element carries ``document_name``, ``score``, ``document_type``, and
+    ``content`` — exactly what the agent needs.
+
+    All search parameters are resolved at call time from ``_agentic_search_params``
+    so that each request can override any search argument without rebuilding the
+    cached agent.  ``default_reranker_top_k`` is used only when the per-request
+    params leave ``reranker_top_k`` as None.
+
+    Args:
+        nvidia_rag: Initialised NvidiaRAG instance.
+        default_reranker_top_k: Fallback reranker_top_k from NvidiaRAGConfig.
+    """
+
+    async def retriever_fn(query: str, stage: str = "rag") -> dict | None:
+        # Read all per-request search parameters set by _agentic_chain.
+        # Passing the fallback here (not as ContextVar default) ensures each
+        # fallback access gets a fresh AgenticSearchParams rather than a shared one.
+        p = _agentic_search_params.get(AgenticSearchParams())
+        try:
+            citations = await nvidia_rag.search(
+                query=query,
+                collection_names=p.collection_names,
+                reranker_top_k=p.reranker_top_k if p.reranker_top_k is not None else default_reranker_top_k,
+                vdb_top_k=p.vdb_top_k,
+                vdb_endpoint=p.vdb_endpoint,
+                vdb_auth_token=p.vdb_auth_token,
+                enable_reranker=p.enable_reranker,
+                enable_query_rewriting=p.enable_query_rewriting,
+                enable_filter_generator=p.enable_filter_generator,
+                embedding_model=p.embedding_model,
+                embedding_endpoint=p.embedding_endpoint,
+                reranker_model=p.reranker_model,
+                reranker_endpoint=p.reranker_endpoint,
+                filter_expr=p.filter_expr,
+                confidence_threshold=p.confidence_threshold,
+                enable_citations=p.enable_citations,
+                stage=stage,
+            )
+            # Group citations by stage in insertion order so runner.py can pick
+            # the last stage's results via next(reversed(acc.values())).
+            try:
+                acc = _agentic_all_citations.get()
+                acc.setdefault(stage, []).extend(citations.results)
+            except LookupError:
+                pass  # Not in an agentic request context (e.g. direct search() call)
+            return citations.model_dump()
+        except Exception as ex:
+            logger.warning(
+                "Agentic retriever failed for query %r: %s", query[:80], ex
+            )
+            return None
+
+    return retriever_fn
+
+
+# =============================================================================
+# LLM FACTORY
+# =============================================================================
+
+
+def _make_role_llm(
+    role_cfg: "AgenticAnyLLMConfig",
+    fallback_cfg: "AgenticAnyLLMConfig",
+    rag_config: "NvidiaRAGConfig",
+) -> Any:
+    """Construct a LangChain LLM for one agentic role.
+
+    Resolution order for model_name / server_url / api_key:
+      1. role_cfg (if model_name is non-empty)
+      2. fallback_cfg (planner LLM config)
+      3. rag_config.llm (main RAG LLM config)
+    """
+    from nvidia_rag.utils.llm import get_llm
+
+    cfg = role_cfg if role_cfg.model_name else fallback_cfg
+
+    model_name = cfg.model_name or rag_config.llm.model_name
+    server_url = cfg.server_url or rag_config.llm.server_url
+    api_key = cfg.get_api_key() or rag_config.llm.get_api_key()
+
+    logger.debug(
+        "Creating agentic LLM: model=%s, url=%s",
+        model_name,
+        server_url or "(api-catalog)",
+    )
+
+    return get_llm(
+        config=rag_config,
+        model=model_name,
+        llm_endpoint=server_url,
+        api_key=api_key,
+    )
+
+
+# =============================================================================
+# AGENT BUILDER
+# =============================================================================
+
+
+async def build_agentic_rag_agent(
+    nvidia_rag: "NvidiaRAG",
+) -> tuple[AgenticRag, Any]:
+    """Build and compile an AgenticRag from a NvidiaRAG instance.
+
+    Reads nvidia_rag.config.agentic_rag for all tunable parameters and wires in
+    the NvidiaRAG.search()-backed retriever.  No search parameters are baked in
+    at build time — they are all supplied per-request via the
+    ``_agentic_search_params`` ContextVar before each graph.ainvoke() call.
+
+    Args:
+        nvidia_rag: Initialised NvidiaRAG instance (provides config + search).
+
+    Returns:
+        (agent, compiled_graph) — caller is responsible for caching these.
+    """
+    cfg = nvidia_rag.config.agentic_rag
+    rag_config = nvidia_rag.config
+
+    logger.info(
+        "Building AgenticRag (concurrency=%d, recursion_limit=%d)",
+        cfg.concurrency_limit,
+        cfg.recursion_limit,
+    )
+
+    planner_llm = _make_role_llm(cfg.planner_llm, cfg.planner_llm, rag_config)
+    task_llm = _make_role_llm(cfg.task_llm, cfg.planner_llm, rag_config)
+    seed_gen_llm = _make_role_llm(cfg.seed_gen_llm, cfg.planner_llm, rag_config)
+    synthesis_llm = _make_role_llm(cfg.synthesis_llm, cfg.planner_llm, rag_config)
+
+    default_reranker_top_k = rag_config.retriever.top_k
+    retriever_fn = make_retriever_fn(nvidia_rag, default_reranker_top_k)
+
+    agent = AgenticRag(
+        planner_llm=planner_llm,
+        task_llm=task_llm,
+        seed_gen_llm=seed_gen_llm,
+        synthesis_llm=synthesis_llm,
+        retriever_fn=retriever_fn,
+        log_level=cfg.log_level,
+        concurrency_limit=cfg.concurrency_limit,
+        planner_config=cfg.planner,
+        task_execution_config=cfg.task_execution,
+        llm_config=cfg.llm,
+        verification_config=cfg.verification,
+        context_config=cfg.context,
+    )
+
+    graph = await agent.build_graph()
+    logger.info("AgenticRag graph compiled successfully")
+    return agent, graph

--- a/src/nvidia_rag/rag_server/agentic_rag/prompt.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/prompt.py
@@ -1,0 +1,287 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Prompts for the Graph-Based Agentic RAG Agent.
+
+Five prompts:
+  1. planner_prompt              — query + scope → retrieval plan (task graph)
+  2. task_answer_prompt          — sub-question + docs → direct partial answer
+  3. seed_gen_prompt             — failed retrieval → new query or stop
+  4. synthesis_prompt            — sub-answers → final coherent answer
+  5. verification_prompt         — check answer quality, identify gaps
+
+Prompts that reference configurable limits use ``{placeholder}`` markers
+(e.g., {max_plan_tasks}).  Call ``build_prompts(...)`` at init time to inject
+the actual values from config via ``.replace()``.
+"""
+
+from langchain_core.prompts.chat import ChatPromptTemplate
+
+# =============================================================================
+# 1. PLANNER PROMPT
+# =============================================================================
+
+PLANNER_SYSTEM_PROMPT_TEMPLATE = """You are a retrieval planning assistant. You receive a user question and documents from an initial retrieval. Your job is to create a plan to fully and correctly answer the question.
+
+CRITICAL: The initial retrieval is a SAMPLE — it shows some top matches, NOT everything in the database. You MUST NOT conclude that data is absent from the database based on this sample alone. If the sample does not contain something, that does not mean it does not exist. You MAY conclude that data is present and sufficient if the sample explicitly and completely answers the question.
+
+Think through these steps:
+
+1. UNDERSTAND THE QUERY: What specific information is needed? What entities, metrics, and time periods are involved?
+
+1b. RESOLVE THE QUERY: Check if the question contains reference terms that are relative, implicit, or ambiguous without context. If the question is already explicit and self-contained, set resolved_query identical to the original. Otherwise, replace only the ambiguous reference terms with specific identifiers found in the documents. NEVER put answer values or factual findings into resolved_query — it must always remain a question.
+
+2. ASSESS THE SAMPLE AND CHOOSE A MODE:
+   - If the sample EXPLICITLY and COMPLETELY answers every part of the question → set scope_only=false, tasks can be empty (synthesis receives the initial context and can extract the answer directly)
+   - If the sample is missing some parts AND you know what to search for → set scope_only=false, create targeted answer tasks for the missing parts
+   - If you are unsure what data exists or what scope/period is relevant → set scope_only=true to run discovery first
+   - If the question requires a COMPLETE or EXHAUSTIVE picture across an open-ended set (e.g., all instances, all available periods, full coverage of a category) and the sample may only show a subset of what exists → set scope_only=true even if the sample contains some matching data, because partial visibility does not mean the database is exhausted
+
+3. SCOPE DISCOVERY (scope_only=true): The sample is not exhaustive — use scope discovery to go beyond it and learn what data the database actually contains. Create 2-3 discovery tasks with DIFFERENT search angles. Each task should use different vocabulary or target different aspects. Do NOT try to answer the question — just discover what exists.
+
+4. ANSWER TASKS (scope_only=false): Create tasks for each piece of information the question requires that is not already fully answered by the initial context:
+   - If the sample EXPLICITLY and COMPLETELY answers a sub-question → do NOT create a task for it (synthesis already has the initial context).
+   - If the context shows partial data or references information not fully included → create a task to retrieve the complete data.
+   - If the context does not contain the answer → create a task to search for it (the sample is not exhaustive).
+   - Prefer fewer, well-targeted tasks (typically 1-3). Do NOT over-decompose — narrow queries miss relevant document sections. Maximum {max_plan_tasks} tasks.
+
+5. SYNTHESIS INSTRUCTION: Describe how to combine all task answers into a final response. Leave empty ("") if scope_only=true or if there are no tasks.
+
+Rules:
+- Each task needs a question and a retrieval query (10-20 words using natural vocabulary likely in source documents).
+- For answer tasks (scope_only=false): the retrieval query MUST reference the same subject/entity as the question. For scope discovery tasks (scope_only=true): the query may be broader to explore what data exists.
+- Keep retrieval queries SHORT and NATURAL — use key entity names, time periods, and topic words. Avoid long formal document-title phrasing. Shorter queries with key terms match better in semantic search.
+- Documents may label the same concept differently — consider alternate terminology when writing queries.
+- If a requested metric is not directly available as a named entry, it may need to be derived from component values. Create tasks for the components.
+- Do not add tasks for information the query did not ask about.
+
+Output JSON only:
+{{"scope_only": true/false, "scope_resolution": "<what was resolved or needs discovery>", "resolved_query": "<resolved question>", "tasks": [{{"id": "<short_id>", "question": "<specific sub-question>", "query": "<10-20 word retrieval query>"}}], "synthesis_instruction": "<how to combine task answers; empty string if scope_only or no tasks>"}}"""
+
+PLANNER_USER_PROMPT = """User Question: {query}
+{scope_section}
+Initial Retrieval Results (this is a sample, not the full database):
+{initial_context}
+
+Create the retrieval plan:"""
+
+PLANNER_REPLAN_INSTRUCTION = """
+IMPORTANT — THIS IS PHASE 2 (REPLAN). You already ran scope discovery. The scope results above tell you what data actually exists in the database. Your job now is:
+1. Use the scope results to understand what data is available
+2. Set scope_only=false — discovery is done, do NOT create more discovery tasks
+3. Create targeted tasks for data that is missing from the initial context. Synthesis only receives the initial context and task answers — it does NOT see scope results. So if scope discovery found useful data that is not in the initial context, you MUST create a task to retrieve it. Tasks can only be empty if the initial context alone already fully answers the question.
+4. If scope results show certain data is missing from the database, do not create tasks to search for it again — accept that it is not available
+5. Provide a synthesis_instruction explaining how to combine the available information into a final response"""
+
+
+# =============================================================================
+# 2. TASK ANSWER PROMPT
+# =============================================================================
+
+TASK_ANSWER_SYSTEM_PROMPT = """You are a precise question-answering assistant. Answer the specific question using the provided documents. Your answer will be combined with other answers to form a complete response, so be precise and focused.
+
+Rules:
+1. Answer the specific question asked using the provided documents, any dependency results shown above the documents, and any prior partial data embedded in the question. Do not use external knowledge beyond these inputs. Do not add information beyond what the question requires.
+2. REPORT VALUES AS STATED: reproduce specific numbers, percentages, dates, and names exactly as they appear in the documents, in the SAME format the document uses. If a value is stated as an absolute amount, report the absolute amount. If stated as a percentage, report the percentage. Do not convert between formats. When reading values from tables or charts, carefully match BOTH the row label (entity/item) AND the column header (metric/attribute) to the question before extracting a value.
+3. When a metric term could mean either an absolute value or a percentage, report whichever form the document uses. If BOTH forms are available, provide both.
+4. If the documents contain no information relevant to answering this question — including when they are entirely about a different subject — respond with completeness "none". If the documents cover the right subject but a different scope, period, or level of detail, respond with completeness "partial".
+5. For simple factual lookups (a name, a date, a single value), keep the answer brief. For analysis or multi-part questions, provide the detail needed.
+6. Do not include document names, citations, or source references.
+7. Start the answer directly — no preamble like "Based on" or "According to".
+8. When the documents contain data at multiple scope levels, use the figure whose scope matches the question. If the question asks about data "as reported in" a specific document, use the primary figure shown in that document. If the scope choice is ambiguous or non-obvious, state which scope you are using.
+9. Documents may use different labels than the question for the same concept. Match the closest concept and use the value from the documents.
+10. BEFORE answering, verify the documents are about the same entity and time period as the question. Apply the completeness definitions from Rule 4: entirely different subject → none; same subject but different scope, period, or level of detail → partial.
+11. CONDITIONAL COMPUTATION — ONLY calculate, compute, or derive values when the question EXPLICITLY asks you to (using words like "calculate", "compute", "derive", "what is the ratio", "what percentage change"), OR when the specific value is NOT directly stated in any form in the documents and must be derived from components. When computing, show the formula and steps.
+12. For yes/no questions that require comparing values across different periods or contexts, state the values for each period or context BEFORE your conclusion.
+13. For questions about trends or changes, include data from ALL relevant time periods found in the documents.
+
+OUTPUT FORMAT — You MUST respond with JSON only:
+- "complete": You fully answered the question from the documents.
+  {{"completeness": "complete", "answer": "<your answer>", "missing": ""}}
+- "partial": You found some relevant data but could not fully answer the question. State what you found and what is still missing.
+  {{"completeness": "partial", "answer": "<answer with what you found>", "missing": "<what specific data is still needed>"}}
+- "none": The documents have NO relevant information at all.
+  {{"completeness": "none", "answer": "[NO DATA]", "missing": ""}}"""
+
+TASK_ANSWER_USER_PROMPT = """Question: {question}
+
+Documents:
+{documents}
+
+Answer (JSON):"""
+
+task_answer_prompt = ChatPromptTemplate(
+    [("system", TASK_ANSWER_SYSTEM_PROMPT), ("user", TASK_ANSWER_USER_PROMPT)]
+)
+
+
+# =============================================================================
+# 3. SEED QUERY GENERATOR PROMPT
+# =============================================================================
+
+SEED_GEN_SYSTEM_PROMPT = """You are a search query specialist. A previous retrieval attempt either failed to find data or found only PARTIAL data for a specific question. Your job is to generate a new query that targets the MISSING information, or decide to stop if the data does not exist.
+
+Before deciding, analyze what the previous queries returned and consider:
+- Documents may label the same concept with DIFFERENT terminology. A concept that seems absent may exist under an alternate name. Try alternate terms before concluding it is missing.
+- Data may be in a different section of the documents than expected. Try targeting different sections.
+- If all previous queries returned documents about the RIGHT subject and NONE contained the needed information across multiple different search angles, then the data likely does not exist. Stop.
+- If previous queries returned UNRELATED documents, the subject may not be in the database. Stop.
+
+Strategies for new queries:
+- Use synonyms or alternate terminology for the key concepts
+- Target a different section or part of the source documents
+- Broaden or narrow the scope (add or remove qualifiers)
+- Use an alternate name or identifier for the subject
+- Search for component values if the target metric might be derived
+- If partial data was found, target SPECIFICALLY what is missing — do NOT repeat queries for data already found
+
+IMPORTANT: Exhaust all genuinely different search angles before stopping — try at least 2-3 substantially different approaches. Do not stop after just one failed attempt. Each new query must use different vocabulary, not just minor rephrasing.
+
+Output JSON only:
+If trying again: {{"reasoning": "<what evidence suggests the missing data exists>", "seed_query": "<10-20 word query targeting the MISSING information>", "stop": false}}
+If stopping: {{"reasoning": "<why the data likely does not exist based on what retrieval returned>", "seed_query": null, "stop": true}}"""
+
+SEED_GEN_USER_PROMPT = """Original question: {question}
+
+Previously tried queries and what happened:
+{tried_queries}
+
+Generate a new retrieval query or decide to stop:"""
+
+seed_gen_prompt = ChatPromptTemplate(
+    [("system", SEED_GEN_SYSTEM_PROMPT), ("user", SEED_GEN_USER_PROMPT)]
+)
+
+
+# =============================================================================
+# 4. SYNTHESIS PROMPT
+# =============================================================================
+
+SYNTHESIS_SYSTEM_PROMPT = """You are a direct question-answering assistant. You receive sub-answers addressing parts of the user's question, and may also receive supplementary context from an initial document retrieval. Combine all available information into a single coherent response.
+
+Rules:
+1. Use ONLY the information from the sub-answers and supplementary context. Do not add external knowledge.
+2. Start directly with the answer. No preamble, no "Based on the data" or similar phrases. NEVER start with "Based on", "According to", "The data shows", "Here is", or similar.
+3. If the question asks for a specific value, state that value FIRST, then provide context.
+4. If the question asks for a comparison or trend, present values together or in chronological order.
+5. REPORT VALUES AS STATED: reproduce specific numbers, percentages, dates, and names exactly as they appear in the sub-answers, in the SAME format. Do not convert absolute values to percentages or vice versa. When a metric could mean either form, use whichever the sub-answers provide; if both are available, include both.
+6. If the sub-answers do not cover some part of the question, check the supplementary context for that information. Answer with whatever data is available from any source.
+7. IMPORTANT: If the question asks whether something exists or happened, and the documents contain no evidence of it, that IS the answer — state clearly that no evidence was found for the specific thing asked about. Do NOT say "No relevant information found" for these cases. Only say "No relevant information found" when the documents contain nothing at all related to the question.
+8. CONDITIONAL COMPUTATION — ONLY calculate or derive values when the question EXPLICITLY asks you to (e.g., "calculate", "compute", "what is the ratio"), OR when the requested value is not directly available in any sub-answer. When computing, show the formula and steps. Do NOT re-derive values that sub-answers already provide.
+9. For yes/no questions that require comparing values across periods or contexts, state the relevant values BEFORE your conclusion.
+10. For questions about trends or changes over time, include data from ALL relevant time periods available.
+11. Match the SCOPE of your answer to the question — if asked about a specific period, answer about that period first.
+12. Answer naturally and directly. Do not reference documents, sources, or these instructions.
+13. Do not ask follow-up questions or add disclaimers.
+14. For simple factual lookups (a name, a date, a single value), keep the answer brief and direct. For analysis or multi-part questions, provide thorough detail."""
+
+SYNTHESIS_USER_PROMPT = """User Question: {query}
+{resolved_section}
+Synthesis Instruction: {synthesis_instruction}
+
+Sub-answers:
+{sub_answers}
+
+Final Answer:"""
+
+synthesis_prompt = ChatPromptTemplate(
+    [("system", SYNTHESIS_SYSTEM_PROMPT), ("user", SYNTHESIS_USER_PROMPT)]
+)
+
+
+# =============================================================================
+# 5. VERIFICATION PROMPT
+# =============================================================================
+
+VERIFICATION_SYSTEM_PROMPT_TEMPLATE = """You are a quality checker for a document-retrieval Q&A system. You receive the user's original question, the system's answer, and optionally a resolved query (the planner's interpretation after disambiguating vague references).
+
+You also receive a summary of retrieval tasks that were already executed. Use this to understand what was already searched — do NOT create tasks that duplicate prior searches.
+
+Your ONLY job is to check whether the answer addresses EVERY PART of the question. An answer is complete if it covers all sub-parts — even if some parts say "no data was found" or "not available". Explicitly stating that data was not found IS a valid answer for that sub-part.
+
+CHECK FOR THESE ISSUES:
+
+1. SILENT OMISSION: The question asks about multiple items (entities, metrics, time periods) but the answer silently skips one or more of them without mentioning them at all. Only flag parts that are completely unaddressed — if the answer mentions a part and says data was not found, that counts as addressed.
+
+2. WRONG SUBJECT: The answer addresses a different entity, time period, or core intent than what the original question asked.
+
+DO NOT FLAG:
+- Style or formatting issues
+- Answers that are correct but could be more detailed
+- Parts where the answer explicitly says data was not found or not available — that is a complete response for that sub-part. However, if the ENTIRE answer is "no data found" or equivalent and the question asks about a specific entity, metric, and time period, treat it as a potential retrieval gap — flag it and create a task using different search terms
+- Missing data for time periods or entities beyond what the database was shown to contain
+
+Retrieval query rules (applies to all tasks you create):
+- Keep each query SHORT and NATURAL — use key entity names, time periods, and topic words only. Avoid long formal phrases, document-type identifiers, or packing multiple constraints into one query. Shorter queries with key terms match better in semantic search.
+- Each query must target ONE specific piece of missing information — do not combine multiple search intents into one query.
+
+Output JSON only:
+If adequate: {{"status": "pass", "reasoning": "<brief explanation>"}}
+If gaps found: {{"status": "fail", "issues": ["<issue 1>", ...], "tasks": [{{"id": "<short_id>", "question": "<specific sub-question>", "query": "<8-15 word retrieval query>"}}]}}
+Maximum {max_verification_tasks} tasks. Only create tasks for parts of the question that were silently omitted."""
+
+VERIFICATION_USER_PROMPT = """Original Question: {query}
+{resolved_query_section}
+System's Answer:
+{answer}
+
+Tasks Already Executed:
+{task_summary}
+
+Check the answer quality and identify any retrieval gaps:"""
+
+
+# =============================================================================
+# BUILDER — inject config values into prompt templates
+# =============================================================================
+
+
+def build_prompts(
+    max_plan_tasks: int,
+    max_verification_tasks: int,
+) -> dict[str, ChatPromptTemplate | str]:
+    """Build all prompt templates with config values injected.
+
+    Returns a dict with keys: planner_prompt, task_answer_prompt, seed_gen_prompt,
+    synthesis_prompt, verification_prompt, planner_replan_instruction.
+    """
+    planner_system = PLANNER_SYSTEM_PROMPT_TEMPLATE.replace(
+        "{max_plan_tasks}",
+        str(max_plan_tasks),
+    )
+
+    verification_system = VERIFICATION_SYSTEM_PROMPT_TEMPLATE.replace(
+        "{max_verification_tasks}",
+        str(max_verification_tasks),
+    )
+
+    return {
+        "planner_prompt": ChatPromptTemplate(
+            [
+                ("system", planner_system),
+                ("user", PLANNER_USER_PROMPT),
+            ]
+        ),
+        "task_answer_prompt": task_answer_prompt,
+        "seed_gen_prompt": seed_gen_prompt,
+        "synthesis_prompt": synthesis_prompt,
+        "verification_prompt": ChatPromptTemplate(
+            [
+                ("system", verification_system),
+                ("user", VERIFICATION_USER_PROMPT),
+            ]
+        ),
+        "planner_replan_instruction": PLANNER_REPLAN_INSTRUCTION,
+    }

--- a/src/nvidia_rag/rag_server/agentic_rag/runner.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/runner.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agentic RAG pipeline runner.
+
+Executes a pre-built AgenticRag graph for a single request and wraps
+the final answer in a streaming RAGResponse so downstream code (server.py
+StreamingResponse) works without modification.
+
+Usage (called from NvidiaRAG._agentic_chain):
+    from nvidia_rag.rag_server.agentic_rag.runner import run_agentic_pipeline
+    rag_response = await run_agentic_pipeline(
+        agent=agent,
+        graph=graph,
+        query=rewritten_query,
+        cfg=self.config.agentic_rag,
+        search_params=AgenticSearchParams(...),
+        ...
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import OrderedDict
+from typing import TYPE_CHECKING, Any
+
+from nvidia_rag.rag_server.agentic_rag.agentic_rag import AgenticRAGGraphState
+from nvidia_rag.rag_server.agentic_rag.builder import (
+    AgenticSearchParams,
+    _agentic_all_citations,
+    _agentic_search_params,
+)
+from nvidia_rag.rag_server.agentic_rag.tracing import QueryTrace, _current_trace
+from nvidia_rag.rag_server.response_generator import (
+    Citations,
+    ErrorCodeMapping,
+    RAGResponse,
+    SourceResult,
+    generate_answer_async,
+)
+
+if TYPE_CHECKING:
+    from nvidia_rag.rag_server.agentic_rag.agentic_rag import AgenticRag
+    from nvidia_rag.utils.agentic_rag_config import AgenticRAGConfig
+    from nvidia_rag.utils.observability.otel_metrics import OtelMetrics
+
+logger = logging.getLogger(__name__)
+
+
+async def _aiter_single(text: str):
+    """Async generator that yields a single string — compatible with generate_answer_async."""
+    yield text
+
+
+async def run_agentic_pipeline(
+    *,
+    agent: "AgenticRag",
+    graph: Any,
+    query: str,
+    cfg: "AgenticRAGConfig",
+    search_params: AgenticSearchParams,
+    enable_citations: bool = True,
+    use_nrl_citations: bool = False,
+    model: str = "",
+    collection_names: list[str] | None = None,
+    rag_start_time_sec: float | None = None,
+    metrics: "OtelMetrics | None" = None,
+) -> RAGResponse:
+    """Run the compiled agentic RAG graph for one request and return a RAGResponse.
+
+    The agent graph runs to completion (non-streaming) inside an OTel root span.
+    The resulting ``final_answer`` string is wrapped in a single-chunk async
+    generator so the rest of the rag-server pipeline (generate_answer_async →
+    StreamingResponse) works unchanged.
+
+    ``_current_trace`` and ``_agentic_search_params`` ContextVars are set for
+    the duration of this call and reset in the ``finally`` block, making this
+    function safe for concurrent async requests.
+
+    Args:
+        agent:              Compiled AgenticRag (used for metrics bookkeeping).
+        graph:              Compiled LangGraph returned by AgenticRag.build_graph().
+        query:              User query; already rewritten if query rewriting is enabled.
+        cfg:                AgenticRAGConfig sub-config (recursion limit, etc.).
+        search_params:      All per-request NvidiaRAG.search() parameters.
+        enable_citations:   Forward to generate_answer_async.
+        use_nrl_citations:  Forward to generate_answer_async (NRL/LanceDB mode).
+        model:              LLM model name forwarded to generate_answer_async.
+        collection_names:   Used for citation metadata; first entry used as collection_name.
+        rag_start_time_sec: Request-start timestamp for end-to-end latency metrics.
+        metrics:            Optional OTel metrics client.
+    """
+    import opentelemetry.trace as otel_trace
+
+    tracer = otel_trace.get_tracer(__name__)
+
+    trace = QueryTrace(query_text=query)
+    trace_token = _current_trace.set(trace)
+    params_token = _agentic_search_params.set(search_params)
+    citations_acc: OrderedDict[str, list[SourceResult]] = OrderedDict()
+    citations_token = _agentic_all_citations.set(citations_acc)
+
+    try:
+        with tracer.start_as_current_span("agentic_rag_query") as root_span:
+            root_span.set_attribute("openinference.span.kind", "CHAIN")
+            root_span.set_attribute("input.value", query)
+
+            initial_state = AgenticRAGGraphState(user_query=query)
+            final_state = await graph.ainvoke(
+                initial_state,
+                config={"recursion_limit": cfg.recursion_limit},
+            )
+
+            answer = (
+                final_state.get("final_answer", "No answer generated.")
+                if isinstance(final_state, dict)
+                else (final_state.final_answer or "No answer generated.")
+            )
+
+            trace.final_answer = answer
+            trace.finalize()
+            agent.metrics.update(trace)
+
+            root_span.set_attribute("output.value", answer)
+            logger.info("[AGENTIC_RAG] Query done: %s", trace.one_line_summary())
+            agent.metrics.log_summary()
+
+        # Pick citations from the last stage that performed retrieval.
+        # The OrderedDict preserves insertion order, so the last value is always
+        # the most recently active stage — no stage names need to be hardcoded.
+        acc = _agentic_all_citations.get()
+        last_stage_results = next(reversed(acc.values()), [])
+        collated_citations = (
+            Citations(total_results=len(last_stage_results), results=last_stage_results)
+            if last_stage_results
+            else None
+        )
+
+        return RAGResponse(
+            generate_answer_async(
+                _aiter_single(answer),
+                [],
+                model=model,
+                collection_name=collection_names[0] if collection_names else "",
+                enable_citations=enable_citations,
+                use_nrl_citations=use_nrl_citations,
+                rag_start_time_sec=rag_start_time_sec,
+                otel_metrics_client=metrics,
+                citations=collated_citations,
+            ),
+            status_code=ErrorCodeMapping.SUCCESS,
+        )
+
+    except Exception as ex:
+        logger.exception("Agentic RAG pipeline failed: %s", ex)
+        trace.error = str(ex)[:500]
+        trace.finalize()
+        agent.metrics.update(trace)
+        logger.info("[AGENTIC_RAG] Query failed: %s", trace.one_line_summary())
+        agent.metrics.log_summary()
+
+        error_msg = (
+            "I encountered an error while processing your request via agentic RAG. "
+            "Please check the server logs for details."
+        )
+        return RAGResponse(
+            generate_answer_async(
+                _aiter_single(error_msg),
+                [],
+                model=model,
+                collection_name=collection_names[0] if collection_names else "",
+                enable_citations=enable_citations,
+                otel_metrics_client=metrics,
+            ),
+            status_code=ErrorCodeMapping.INTERNAL_SERVER_ERROR,
+        )
+
+    finally:
+        _current_trace.reset(trace_token)
+        _agentic_search_params.reset(params_token)
+        _agentic_all_citations.reset(citations_token)

--- a/src/nvidia_rag/rag_server/agentic_rag/tracing.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/tracing.py
@@ -1,0 +1,280 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-query tracing and cross-query aggregate metrics.
+
+Provides concurrency-safe per-query instrumentation via ``contextvars``.
+Each query gets its own ``QueryTrace`` object that records LLM calls,
+graph-node timings, and workflow metadata. Traces are then fed into
+``AgentMetrics`` for rolling min/max/avg statistics.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+import time
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_P = "[AGENTIC_RAG]"
+
+# ---------------------------------------------------------------------------
+# Context variable — one QueryTrace per asyncio task / query invocation
+# ---------------------------------------------------------------------------
+
+_current_trace: contextvars.ContextVar[QueryTrace | None] = contextvars.ContextVar(
+    "_current_trace", default=None
+)
+
+
+def get_current_trace() -> QueryTrace | None:
+    """Return the ``QueryTrace`` for the current asyncio task, or *None*."""
+    return _current_trace.get()
+
+
+# ---------------------------------------------------------------------------
+# Data records
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LLMCallRecord:
+    """Single LLM invocation record."""
+
+    step_name: str
+    input_tokens: int
+    output_tokens: int
+    duration_ms: float
+    attempt_number: int = 1
+
+
+@dataclass
+class NodeTiming:
+    """Wall-clock duration for one graph node execution."""
+
+    node_name: str
+    duration_ms: float
+
+
+# ---------------------------------------------------------------------------
+# QueryTrace — per-query collector
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class QueryTrace:
+    """Collects all instrumentation data for a single query."""
+
+    query_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    query_text: str = ""
+    start_time: float = field(default_factory=time.perf_counter)
+    start_wall: datetime = field(default_factory=lambda: datetime.now(UTC))
+    end_time: float | None = None
+
+    llm_calls: list[LLMCallRecord] = field(default_factory=list)
+    node_timings: list[NodeTiming] = field(default_factory=list)
+
+    retrieval_stats: dict[str, Any] = field(default_factory=dict)
+    plan_summary: dict[str, Any] = field(default_factory=dict)
+    task_results_summary: dict[str, Any] = field(default_factory=dict)
+    verification_outcome: dict[str, Any] = field(default_factory=dict)
+
+    final_answer: str = ""
+    error: str | None = None
+
+    # ---- recording helpers ------------------------------------------------
+
+    def record_llm_call(
+        self,
+        step_name: str,
+        input_tokens: int,
+        output_tokens: int,
+        duration_ms: float,
+        attempt_number: int = 1,
+    ) -> None:
+        self.llm_calls.append(
+            LLMCallRecord(
+                step_name=step_name,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                duration_ms=duration_ms,
+                attempt_number=attempt_number,
+            )
+        )
+
+    @contextmanager
+    def trace_node(self, node_name: str):
+        """Context manager that records wall-clock duration of a graph node."""
+        t0 = time.perf_counter()
+        try:
+            yield
+        finally:
+            elapsed_ms = (time.perf_counter() - t0) * 1000
+            self.node_timings.append(NodeTiming(node_name=node_name, duration_ms=elapsed_ms))
+
+    # ---- properties -------------------------------------------------------
+
+    @property
+    def total_llm_calls(self) -> int:
+        return len(self.llm_calls)
+
+    @property
+    def total_input_tokens(self) -> int:
+        return sum(c.input_tokens for c in self.llm_calls)
+
+    @property
+    def total_output_tokens(self) -> int:
+        return sum(c.output_tokens for c in self.llm_calls)
+
+    @property
+    def total_duration_ms(self) -> float:
+        if self.end_time is None:
+            return (time.perf_counter() - self.start_time) * 1000
+        return (self.end_time - self.start_time) * 1000
+
+    # ---- finalize / serialize --------------------------------------------
+
+    def finalize(self) -> None:
+        """Mark the trace as complete."""
+        self.end_time = time.perf_counter()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "query_id": self.query_id,
+            "query_text": self.query_text,
+            "start_time_iso": self.start_wall.isoformat(),
+            "total_duration_ms": round(self.total_duration_ms, 1),
+            "total_llm_calls": self.total_llm_calls,
+            "total_input_tokens": self.total_input_tokens,
+            "total_output_tokens": self.total_output_tokens,
+            "error": self.error,
+            "node_timings": [
+                {"node": nt.node_name, "duration_ms": round(nt.duration_ms, 1)}
+                for nt in self.node_timings
+            ],
+            "llm_calls": [
+                {
+                    "step": c.step_name,
+                    "input_tokens": c.input_tokens,
+                    "output_tokens": c.output_tokens,
+                    "duration_ms": round(c.duration_ms, 1),
+                    "attempt": c.attempt_number,
+                }
+                for c in self.llm_calls
+            ],
+            "retrieval_stats": self.retrieval_stats,
+            "plan_summary": self.plan_summary,
+            "task_results_summary": self.task_results_summary,
+            "verification": self.verification_outcome,
+            "final_answer": self.final_answer,
+        }
+
+    def one_line_summary(self) -> str:
+        dur = self.total_duration_ms / 1000
+        return (
+            f"query_id={self.query_id[:8]} "
+            f"llm_calls={self.total_llm_calls} "
+            f"tokens_in={self.total_input_tokens} "
+            f"tokens_out={self.total_output_tokens} "
+            f"duration={dur:.1f}s" + (f" ERROR={self.error[:80]}" if self.error else "")
+        )
+
+
+# ---------------------------------------------------------------------------
+# AgentMetrics — rolling aggregates across queries
+# ---------------------------------------------------------------------------
+
+
+class AgentMetrics:
+    """Accumulates per-query summaries and computes min/max/avg statistics."""
+
+    def __init__(self) -> None:
+        self._query_summaries: list[dict[str, Any]] = []
+
+    def update(self, trace: QueryTrace) -> None:
+        self._query_summaries.append(
+            {
+                "query_id": trace.query_id,
+                "llm_calls": trace.total_llm_calls,
+                "duration_ms": trace.total_duration_ms,
+                "input_tokens": trace.total_input_tokens,
+                "output_tokens": trace.total_output_tokens,
+                "error": trace.error is not None,
+            }
+        )
+
+    def reset(self) -> None:
+        self._query_summaries.clear()
+
+    @property
+    def total_queries(self) -> int:
+        return len(self._query_summaries)
+
+    def summary(self) -> dict[str, Any]:
+        n = len(self._query_summaries)
+        if n == 0:
+            return {"total_queries": 0}
+
+        def _stats(key: str) -> dict[str, float]:
+            vals = [s[key] for s in self._query_summaries]
+            return {
+                "min": round(min(vals), 1),
+                "max": round(max(vals), 1),
+                "avg": round(sum(vals) / len(vals), 1),
+            }
+
+        errors = sum(1 for s in self._query_summaries if s["error"])
+        return {
+            "total_queries": n,
+            "errors": errors,
+            "llm_calls": _stats("llm_calls"),
+            "duration_ms": _stats("duration_ms"),
+            "input_tokens": _stats("input_tokens"),
+            "output_tokens": _stats("output_tokens"),
+        }
+
+    def log_summary(self) -> None:
+        s = self.summary()
+        n = s["total_queries"]
+        if n == 0:
+            return
+        lc = s["llm_calls"]
+        dur = s["duration_ms"]
+        ti = s["input_tokens"]
+        to_ = s["output_tokens"]
+        logger.info(
+            "%s Metrics (%d queries): "
+            "LLM calls min=%g max=%g avg=%.1f | "
+            "Latency min=%.1fs max=%.1fs avg=%.1fs | "
+            "Tokens in avg=%.0f out avg=%.0f | "
+            "Errors: %d",
+            _P,
+            n,
+            lc["min"],
+            lc["max"],
+            lc["avg"],
+            dur["min"] / 1000,
+            dur["max"] / 1000,
+            dur["avg"] / 1000,
+            ti["avg"],
+            to_["avg"],
+            s["errors"],
+        )

--- a/src/nvidia_rag/rag_server/main.py
+++ b/src/nvidia_rag/rag_server/main.py
@@ -284,6 +284,10 @@ class NvidiaRAG:
             enable_thinking=self.config.llm.parameters.enable_thinking
         )
 
+        # Agentic RAG agent/graph — built lazily on the first agentic request.
+        self._agentic_agent: Any = None
+        self._agentic_graph: Any = None
+
         if self._init_errors:
             logger.warning(
                 "NvidiaRAG initialization completed with %d unavailable service(s): %s. "
@@ -442,6 +446,7 @@ class NvidiaRAG:
         confidence_threshold: float | None = None,
         fetch_full_page_context: bool | None = None,
         fetch_neighboring_pages: int | None = None,
+        agentic: bool | None = None,
         rag_start_time_sec: float | None = None,
         metrics: OtelMetrics | None = None,
     ) -> AsyncGenerator[str, None]:
@@ -487,7 +492,11 @@ class NvidiaRAG:
         logger.info("  - vdb_top_k: %s, reranker_top_k: %s", vdb_top_k, reranker_top_k)
         logger.info("  - temperature: %s, top_p: %s, max_tokens: %s", temperature, top_p, max_tokens)
         logger.info("  - model: %s", model)
+        logger.info("  - agentic: %s", agentic)
         logger.info("-" * 80)
+
+        # Resolve agentic flag: per-request value takes precedence over global config.
+        agentic = agentic if agentic is not None else self.config.enable_agentic_rag
 
         # Apply defaults from config for None values
         model_params = self.config.llm.get_model_parameters()
@@ -666,6 +675,30 @@ class NvidiaRAG:
         }
 
         if use_knowledge_base:
+            if agentic:
+                return await self._agentic_chain(
+                    query=query,
+                    chat_history=chat_history,
+                    collection_names=collection_names,
+                    enable_query_rewriting=enable_query_rewriting,
+                    enable_reranker=enable_reranker,
+                    reranker_top_k=reranker_top_k,
+                    reranker_model=reranker_model,
+                    reranker_endpoint=reranker_endpoint,
+                    vdb_top_k=vdb_top_k,
+                    vdb_endpoint=vdb_endpoint,
+                    vdb_auth_token=vdb_auth_token,
+                    embedding_model=embedding_model,
+                    embedding_endpoint=embedding_endpoint,
+                    enable_filter_generator=enable_filter_generator,
+                    filter_expr=filter_expr,
+                    confidence_threshold=confidence_threshold,
+                    enable_citations=enable_citations,
+                    model=model,
+                    vdb_op=vdb_op,
+                    rag_start_time_sec=rag_start_time_sec,
+                    metrics=metrics,
+                )
             logger.info("=" * 80)
             logger.info("PIPELINE MODE: RAG Chain (with knowledge base)")
             logger.info("=" * 80)
@@ -731,6 +764,7 @@ class NvidiaRAG:
         filter_expr: str | list[dict[str, Any]] = "",
         confidence_threshold: float | None = None,
         enable_citations: bool | None = None,
+        stage: str = "rag",
     ) -> Citations:
         """Search for the most relevant documents for the given search parameters.
         It's called when the `/search` API is invoked.
@@ -1241,7 +1275,10 @@ class NvidiaRAG:
                     logger.warning(
                         "Could not find sufficiently relevant context after maximum attempts"
                     )
-                return _citations_fn(retrieved_documents=docs, force_citations=True, enable_citations=enable_citations)
+                _cit = _citations_fn(retrieved_documents=docs, force_citations=True, enable_citations=enable_citations)
+                for _r in _cit.results:
+                    _r.stage = stage
+                return _cit
             else:
                 if local_ranker and enable_reranker and not is_image_query:
                     logger.info(
@@ -1322,9 +1359,12 @@ class NvidiaRAG:
                             confidence_threshold=confidence_threshold,
                         )
 
-                    return _citations_fn(
+                    _cit = _citations_fn(
                         retrieved_documents=docs, force_citations=True, enable_citations=enable_citations
                     )
+                    for _r in _cit.results:
+                        _r.stage = stage
+                    return _cit
                 else:
                     # Handle case where reranker is disabled or image query
                     if is_image_query:
@@ -1353,9 +1393,12 @@ class NvidiaRAG:
                             ),
                             otel_ctx=otel_ctx,
                         )
-                    return _citations_fn(
+                    _cit = _citations_fn(
                         retrieved_documents=docs, force_citations=True, enable_citations=enable_citations
                     )
+                    for _r in _cit.results:
+                        _r.stage = stage
+                    return _cit
 
         except APIError:
             # Re-raise APIError as-is to preserve status_code
@@ -2014,6 +2057,186 @@ class NvidiaRAG:
         else:
             # Fallback for any other content type
             return (str(content) if content is not None else ""), is_image_query
+
+    # =========================================================================
+    # AGENTIC RAG
+    # =========================================================================
+
+    async def _ensure_agentic_agent(self) -> tuple[Any, Any]:
+        """Lazily build and cache the AgenticRag and its compiled graph.
+
+        Thread-safe enough for async: concurrent requests that hit the None
+        check simultaneously will both build; the last write wins but both
+        produce equivalent agents so there is no correctness issue.
+        """
+        if self._agentic_agent is None:
+            from nvidia_rag.rag_server.agentic_rag.builder import build_agentic_rag_agent
+
+            logger.info("Building AgenticRag (first agentic request)…")
+            self._agentic_agent, self._agentic_graph = await build_agentic_rag_agent(self)
+        return self._agentic_agent, self._agentic_graph
+
+    async def _agentic_chain(
+        self,
+        query: str | list[dict[str, Any]],
+        chat_history: list[dict[str, Any]],
+        collection_names: list[str],
+        enable_query_rewriting: bool,
+        enable_reranker: bool,
+        reranker_top_k: int,
+        reranker_model: str,
+        reranker_endpoint: str | None,
+        vdb_top_k: int,
+        vdb_endpoint: str | None,
+        vdb_auth_token: str,
+        embedding_model: str | None,
+        embedding_endpoint: str | None,
+        enable_filter_generator: bool,
+        filter_expr: str | list[dict[str, Any]],
+        confidence_threshold: float | None,
+        enable_citations: bool,
+        model: str,
+        vdb_op: VDBRag,
+        rag_start_time_sec: float | None,
+        metrics: Any | None,
+    ) -> RAGResponse:
+        """Orchestrate one agentic RAG request.
+
+        Pre-processing steps (query rewriting, collection validation) match
+        ``_rag_chain`` so both pipelines behave consistently.  All retrieval
+        parameters are forwarded per-request via the ``_agentic_search_params``
+        ContextVar so the cached agent can serve concurrent requests safely.
+        """
+        from nvidia_rag.rag_server.agentic_rag.builder import AgenticSearchParams
+        from nvidia_rag.rag_server.agentic_rag.runner import run_agentic_pipeline
+
+        cfg = self.config.agentic_rag
+
+        # --- Collection validation -------------------------------------------
+        if not collection_names:
+            raise APIError(
+                "Collection names are not provided.", ErrorCodeMapping.BAD_REQUEST
+            )
+        self._validate_collections_exist(collection_names, vdb_op)
+
+        # --- Extract text query for the agent --------------------------------
+        retriever_query, _ = self._build_retriever_query_from_content(query)
+
+        # --- Query rewriting (mirrors _rag_chain logic) ----------------------
+        conversation_history_count = int(os.environ.get("CONVERSATION_HISTORY", 0))
+        if conversation_history_count == 0:
+            chat_history_for_rewrite = []
+            if enable_query_rewriting:
+                logger.warning(
+                    "Query rewriting enabled but CONVERSATION_HISTORY=0; "
+                    "skipping query rewriting for agentic pipeline."
+                )
+        else:
+            history_count = conversation_history_count * 2 * -1
+            chat_history_for_rewrite = chat_history[history_count:]
+
+        if chat_history_for_rewrite and enable_query_rewriting:
+            logger.info("=" * 60)
+            logger.info("AGENTIC STAGE: Query Rewriting")
+            logger.info("=" * 60)
+            if self.query_rewriter_llm is None:
+                raise APIError(
+                    "Query rewriting is enabled but the query rewriter NIM is unavailable. "
+                    f"Please verify the service is running at {self.config.query_rewriter.server_url}.",
+                    ErrorCodeMapping.SERVICE_UNAVAILABLE,
+                )
+
+            contextualize_q_system_prompt = (
+                "Given a chat history and the latest user question "
+                "which might reference context in the chat history, "
+                "formulate a standalone question which can be understood "
+                "without the chat history. Do NOT answer the question, "
+                "just reformulate it if needed and otherwise return it as is."
+            )
+            query_rewriter_prompt_config = self.prompts.get("query_rewriter_prompt", {})
+            system_prompt = query_rewriter_prompt_config.get(
+                "system", contextualize_q_system_prompt
+            )
+            human_prompt = query_rewriter_prompt_config.get("human", "{input}")
+
+            formatted_history = "\n".join(
+                f"{msg.get('role', 'user').capitalize()}: "
+                f"{self._extract_text_from_content(msg.get('content'))}"
+                for msg in chat_history_for_rewrite
+                if msg.get("role") in ("user", "assistant")
+            )
+
+            contextualize_q_prompt = ChatPromptTemplate.from_messages(
+                [("system", system_prompt), ("human", human_prompt)]
+            )
+            q_prompt = (
+                contextualize_q_prompt
+                | self.query_rewriter_llm
+                | self.StreamingFilterThinkParser
+                | StrOutputParser()
+            )
+
+            try:
+                with traced_span("agentic_rag.Query Rewriting.token_usage"):
+                    retriever_query = await q_prompt.ainvoke(
+                        {"input": retriever_query, "chat_history": formatted_history},
+                        config={"run_name": "agentic-query-rewriter"},
+                    )
+            except (ConnectionError, OSError, Exception) as e:
+                if isinstance(e, APIError):
+                    raise
+                query_rewriter_url = self.config.query_rewriter.server_url
+                endpoint_msg = f" at {query_rewriter_url}" if query_rewriter_url else ""
+                raise APIError(
+                    f"Query rewriter LLM NIM unavailable{endpoint_msg}. "
+                    "Please verify the service is running and accessible or disable query rewriting.",
+                    ErrorCodeMapping.SERVICE_UNAVAILABLE,
+                ) from e
+
+            logger.info("Agentic query rewriting: '%s' → '%s'", query, retriever_query)
+
+        # --- Build per-request search params ---------------------------------
+        search_params = AgenticSearchParams(
+            collection_names=collection_names,
+            vdb_top_k=vdb_top_k,
+            vdb_endpoint=vdb_endpoint,
+            vdb_auth_token=vdb_auth_token,
+            reranker_top_k=reranker_top_k,
+            reranker_model=reranker_model,
+            reranker_endpoint=reranker_endpoint,
+            enable_reranker=enable_reranker,
+            embedding_model=embedding_model,
+            embedding_endpoint=embedding_endpoint,
+            enable_query_rewriting=False,  # already done above
+            enable_filter_generator=enable_filter_generator,
+            filter_expr=filter_expr,
+            confidence_threshold=confidence_threshold,
+            enable_citations=enable_citations,
+        )
+
+        # --- Ensure agent is built -------------------------------------------
+        agent, graph = await self._ensure_agentic_agent()
+
+        logger.info("=" * 60)
+        logger.info("PIPELINE MODE: Agentic RAG (LangGraph plan-and-execute)")
+        logger.info("=" * 60)
+        logger.info("  - query: '%s'", retriever_query[:200])
+        logger.info("  - collections: %s", collection_names)
+        logger.info("  - enable_reranker: %s, reranker_top_k: %s", enable_reranker, reranker_top_k)
+
+        return await run_agentic_pipeline(
+            agent=agent,
+            graph=graph,
+            query=retriever_query,
+            cfg=cfg,
+            search_params=search_params,
+            enable_citations=enable_citations,
+            use_nrl_citations=self._is_nrl_mode,
+            model=model,
+            collection_names=collection_names,
+            rag_start_time_sec=rag_start_time_sec,
+            metrics=metrics,
+        )
 
     async def _rag_chain(
         self,

--- a/src/nvidia_rag/rag_server/response_generator.py
+++ b/src/nvidia_rag/rag_server/response_generator.py
@@ -223,6 +223,12 @@ class SourceResult(BaseModel):
         default="text", description="Type of document content"
     )
     score: float = Field(default=0.0, description="Relevance score of the document")
+    stage: str = Field(
+        default="rag",
+        max_length=100,
+        pattern=r"[\s\S]*",
+        description="Pipeline stage that produced this result (e.g. 'rag', 'initial_retrieval', 'execute', 'verify_execute')",
+    )
 
     metadata: SourceMetadata
 
@@ -263,7 +269,7 @@ class TextContent(BaseModel):
 
     type: Literal["text"] = Field(default="text", description="The type of content")
     text: str = Field(
-        description="The text content", max_length=131072, pattern=r"[\s\S]*"
+        description="The text content", max_length=128000, pattern=r"[\s\S]*"
     )
 
 
@@ -622,6 +628,7 @@ async def generate_answer_async(
     rag_start_time_sec: float | None = None,
     otel_metrics_client: OtelMetrics | None = None,
     token_usage: dict | None = None,
+    citations: Optional["Citations"] = None,
 ):
     """Generate and stream the response to the provided prompt asynchronously.
 
@@ -636,6 +643,9 @@ async def generate_answer_async(
         otel_metrics_client: Optional OpenTelemetry metrics client for updating latency histograms
         token_usage: Optional mutable dict (e.g. {}) that a callback may populate with
             prompt_tokens, completion_tokens, and total_tokens for the final chunk.
+        citations: Optional pre-built Citations object (used by agentic RAG to pass
+            stage-annotated citations collected across pipeline stages). When provided,
+            this takes precedence over building citations from ``contexts``.
     """
     # Choose the citations builder based on ingestion mode.
     # NRL (LanceDB backend) produces text-only flat metadata; nv-ingest
@@ -689,10 +699,13 @@ async def generate_answer_async(
                             "    == RAG Time to First Token (TTFT): %.2f ms ==",
                             rag_ttft_ms,
                         )
-                    chain_response.citations = _citations_fn(
-                        retrieved_documents=contexts,
-                        enable_citations=enable_citations,
-                    )
+                    if citations is not None:
+                        chain_response.citations = citations
+                    else:
+                        chain_response.citations = _citations_fn(
+                            retrieved_documents=contexts,
+                            enable_citations=enable_citations,
+                        )
                     first_chunk = False
                 logger.debug(response_choice)
                 # Send generator with tokens in ChainResponse format

--- a/src/nvidia_rag/rag_server/server.py
+++ b/src/nvidia_rag/rag_server/server.py
@@ -591,6 +591,14 @@ class Prompt(BaseModel):
         ge=0,
         le=10,
     )
+    agentic: bool | None = Field(
+        default=CONFIG.enable_agentic_rag,
+        description=(
+            "Route this request through the agentic RAG pipeline (LangGraph plan-and-execute). "
+            "When None (default), the server-level CONFIG.enable_agentic_rag config value is used. "
+            "Explicitly passing True or False overrides the server default for this request."
+        ),
+    )
 
     @model_validator(mode="after")
     def validate_confidence_threshold(cls, values):
@@ -1410,6 +1418,7 @@ async def generate_answer(request: Request, prompt: Prompt) -> StreamingResponse
         "vlm_max_total_images": prompt.vlm_max_total_images,
         "filter_expr": prompt.filter_expr,
         "confidence_threshold": prompt.confidence_threshold,
+        "agentic": prompt.agentic,
     }
     logger.info(
         f"📥 Incoming request to /generate endpoint:\n{json.dumps(request_data, indent=2)}"
@@ -1494,6 +1503,7 @@ async def generate_answer(request: Request, prompt: Prompt) -> StreamingResponse
             confidence_threshold=prompt.confidence_threshold,
             fetch_full_page_context=prompt.fetch_full_page_context,
             fetch_neighboring_pages=prompt.fetch_neighboring_pages,
+            agentic=prompt.agentic,
             rag_start_time_sec=generate_start_time,
             metrics=metrics,
         )

--- a/src/nvidia_rag/utils/agentic_rag_config.py
+++ b/src/nvidia_rag/utils/agentic_rag_config.py
@@ -1,0 +1,352 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agentic RAG configuration classes.
+
+Imported by nvidia_rag.utils.configuration and placed under
+NvidiaRAGConfig.agentic_rag.  Kept in a dedicated module to avoid
+bloating configuration.py.
+
+Import note
+-----------
+This module imports _ConfigBase and Field from nvidia_rag.utils.configuration.
+That creates a deliberate partial-module circular reference: configuration.py
+imports this file only after _ConfigBase and Field are fully defined, so
+Python's partial-module resolution finds them correctly.  Do not move the
+import in configuration.py above those definitions.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Union
+
+from pydantic import SecretStr, field_validator
+from pydantic import Field as PydanticField
+
+# _ConfigBase and Field are imported from configuration.py.
+# This works because configuration.py places its import of this module
+# after _ConfigBase and Field are already defined.
+from nvidia_rag.utils.configuration import _ConfigBase, Field
+
+
+# =============================================================================
+# AGENT BEHAVIOUR SUB-CONFIGS
+# =============================================================================
+
+
+class AgenticPlannerConfig(_ConfigBase):
+    """Planner sub-config for agentic RAG."""
+
+    max_plan_tasks: int = Field(
+        default=5,
+        env="AGENTIC_PLANNER_MAX_TASKS",
+        description="Hard cap on answer tasks per plan.",
+    )
+    max_scope_rounds: int = Field(
+        default=2,
+        env="AGENTIC_PLANNER_MAX_SCOPE_ROUNDS",
+        description="Scope discovery rounds before forcing answer phase.",
+    )
+    max_attempts: int = Field(
+        default=3,
+        env="AGENTIC_PLANNER_MAX_ATTEMPTS",
+        description="Planner JSON parse/retry attempts.",
+    )
+
+
+class AgenticTaskExecutionConfig(_ConfigBase):
+    """Task-execution sub-config for agentic RAG."""
+
+    scope_max_retries: int = Field(
+        default=1,
+        env="AGENTIC_TASK_SCOPE_MAX_RETRIES",
+        description="Retry budget for scope discovery tasks.",
+    )
+    answer_max_retries: int = Field(
+        default=3,
+        env="AGENTIC_TASK_ANSWER_MAX_RETRIES",
+        description="Retry budget for answer tasks.",
+    )
+
+
+class AgenticLLMTransportConfig(_ConfigBase):
+    """LLM transport sub-config for agentic RAG."""
+
+    call_timeout: int = Field(
+        default=300,
+        env="AGENTIC_LLM_CALL_TIMEOUT",
+        description="Per-call timeout in seconds.",
+    )
+    max_retries: int = Field(
+        default=4,
+        env="AGENTIC_LLM_MAX_RETRIES",
+        description="Transport-level retries on timeout/5xx.",
+    )
+
+
+class AgenticVerificationConfig(_ConfigBase):
+    """Verification sub-config for agentic RAG."""
+
+    enabled: bool = Field(
+        default=True,
+        env="AGENTIC_VERIFICATION_ENABLED",
+        description="Toggle verification pass on/off.",
+    )
+    max_tasks: int = Field(
+        default=3,
+        env="AGENTIC_VERIFICATION_MAX_TASKS",
+        description="Max verification follow-up tasks.",
+    )
+
+
+class AgenticContextConfig(_ConfigBase):
+    """Context sub-config for agentic RAG."""
+
+    max_tokens: int = Field(
+        default=100000,
+        env="AGENTIC_CONTEXT_MAX_TOKENS",
+        description="Token budget for chunk context in prompts.",
+    )
+
+
+# =============================================================================
+# PER-ROLE LLM CONFIGS
+# Each role gets its own env var prefix so every LLM can be configured
+# independently.  If a role's model_name is left empty the builder falls
+# back to the planner LLM config.
+#
+# Env var naming convention:
+#   AGENTIC_{ROLE}_LLM_SERVERURL
+#   AGENTIC_{ROLE}_LLM_MODEL
+#   AGENTIC_{ROLE}_LLM_APIKEY
+# =============================================================================
+
+
+class AgenticPlannerLLMConfig(_ConfigBase):
+    """LLM config for the planner role (scope resolution + task creation).
+
+    Env vars: AGENTIC_PLANNER_LLM_SERVERURL, AGENTIC_PLANNER_LLM_MODEL,
+              AGENTIC_PLANNER_LLM_APIKEY
+    """
+
+    server_url: str = Field(
+        default="",
+        env="AGENTIC_PLANNER_LLM_SERVERURL",
+        description="URL endpoint for the planner LLM service.",
+    )
+    model_name: str = Field(
+        default="",
+        env="AGENTIC_PLANNER_LLM_MODEL",
+        description="Model name for the planner LLM. Falls back to main LLM if empty.",
+    )
+    api_key: SecretStr | None = Field(
+        default=None,
+        env="AGENTIC_PLANNER_LLM_APIKEY",
+        description="API key for the planner LLM (overrides global NVIDIA_API_KEY).",
+    )
+
+    @field_validator("server_url", mode="before")
+    @classmethod
+    def normalize_url(cls, v: Any) -> Any:
+        if isinstance(v, str):
+            v = v.strip().strip('"').strip("'")
+            if v and not v.startswith(("http://", "https://")):
+                return f"http://{v}"
+        return v
+
+
+class AgenticTaskLLMConfig(_ConfigBase):
+    """LLM config for the task role (answering individual sub-questions).
+
+    Env vars: AGENTIC_TASK_LLM_SERVERURL, AGENTIC_TASK_LLM_MODEL,
+              AGENTIC_TASK_LLM_APIKEY
+    """
+
+    server_url: str = Field(
+        default="",
+        env="AGENTIC_TASK_LLM_SERVERURL",
+        description="URL endpoint for the task LLM service.",
+    )
+    model_name: str = Field(
+        default="",
+        env="AGENTIC_TASK_LLM_MODEL",
+        description="Model name for the task LLM. Falls back to planner LLM if empty.",
+    )
+    api_key: SecretStr | None = Field(
+        default=None,
+        env="AGENTIC_TASK_LLM_APIKEY",
+        description="API key for the task LLM (overrides global NVIDIA_API_KEY).",
+    )
+
+    @field_validator("server_url", mode="before")
+    @classmethod
+    def normalize_url(cls, v: Any) -> Any:
+        if isinstance(v, str):
+            v = v.strip().strip('"').strip("'")
+            if v and not v.startswith(("http://", "https://")):
+                return f"http://{v}"
+        return v
+
+
+class AgenticSeedGenLLMConfig(_ConfigBase):
+    """LLM config for the seed-gen role (retry seed query generation).
+
+    Env vars: AGENTIC_SEED_GEN_LLM_SERVERURL, AGENTIC_SEED_GEN_LLM_MODEL,
+              AGENTIC_SEED_GEN_LLM_APIKEY
+    """
+
+    server_url: str = Field(
+        default="",
+        env="AGENTIC_SEED_GEN_LLM_SERVERURL",
+        description="URL endpoint for the seed-gen LLM service.",
+    )
+    model_name: str = Field(
+        default="",
+        env="AGENTIC_SEED_GEN_LLM_MODEL",
+        description="Model name for the seed-gen LLM. Falls back to planner LLM if empty.",
+    )
+    api_key: SecretStr | None = Field(
+        default=None,
+        env="AGENTIC_SEED_GEN_LLM_APIKEY",
+        description="API key for the seed-gen LLM (overrides global NVIDIA_API_KEY).",
+    )
+
+    @field_validator("server_url", mode="before")
+    @classmethod
+    def normalize_url(cls, v: Any) -> Any:
+        if isinstance(v, str):
+            v = v.strip().strip('"').strip("'")
+            if v and not v.startswith(("http://", "https://")):
+                return f"http://{v}"
+        return v
+
+
+class AgenticSynthesisLLMConfig(_ConfigBase):
+    """LLM config for the synthesis role (final answer generation).
+
+    Env vars: AGENTIC_SYNTHESIS_LLM_SERVERURL, AGENTIC_SYNTHESIS_LLM_MODEL,
+              AGENTIC_SYNTHESIS_LLM_APIKEY
+    """
+
+    server_url: str = Field(
+        default="",
+        env="AGENTIC_SYNTHESIS_LLM_SERVERURL",
+        description="URL endpoint for the synthesis LLM service.",
+    )
+    model_name: str = Field(
+        default="",
+        env="AGENTIC_SYNTHESIS_LLM_MODEL",
+        description="Model name for the synthesis LLM. Falls back to planner LLM if empty.",
+    )
+    api_key: SecretStr | None = Field(
+        default=None,
+        env="AGENTIC_SYNTHESIS_LLM_APIKEY",
+        description="API key for the synthesis LLM (overrides global NVIDIA_API_KEY).",
+    )
+
+    @field_validator("server_url", mode="before")
+    @classmethod
+    def normalize_url(cls, v: Any) -> Any:
+        if isinstance(v, str):
+            v = v.strip().strip('"').strip("'")
+            if v and not v.startswith(("http://", "https://")):
+                return f"http://{v}"
+        return v
+
+
+# Union type used for type hints in builder.py.
+AgenticAnyLLMConfig = Union[
+    AgenticPlannerLLMConfig,
+    AgenticTaskLLMConfig,
+    AgenticSeedGenLLMConfig,
+    AgenticSynthesisLLMConfig,
+]
+
+
+# =============================================================================
+# TOP-LEVEL AGENTIC RAG CONFIG
+# =============================================================================
+
+
+class AgenticRAGConfig(_ConfigBase):
+    """Configuration for the agentic RAG flow (NvidiaRAG(agentic=True)).
+
+    Each LLM role has its own config class with its own env var prefix.
+    If a role's model_name is left empty the builder falls back to the
+    planner_llm config, so a minimal deployment only needs to set
+    AGENTIC_PLANNER_LLM_* variables.
+
+    Environment variable prefixes:
+        Planner LLM   — AGENTIC_PLANNER_LLM_*
+        Task LLM      — AGENTIC_TASK_LLM_*
+        Seed-gen LLM  — AGENTIC_SEED_GEN_LLM_*
+        Synthesis LLM — AGENTIC_SYNTHESIS_LLM_*
+        Agent tuning  — AGENTIC_PLANNER_*, AGENTIC_TASK_*, AGENTIC_LLM_*,
+                        AGENTIC_VERIFICATION_*, AGENTIC_CONTEXT_*
+        Behaviour     — AGENTIC_CONCURRENCY_LIMIT, AGENTIC_RECURSION_LIMIT,
+                        AGENTIC_LOG_LEVEL
+    """
+
+    # --- Per-role LLM configs -----------------------------------------------
+    planner_llm: AgenticPlannerLLMConfig = PydanticField(
+        default_factory=AgenticPlannerLLMConfig,
+        description="LLM for planning (scope resolution + task creation).",
+    )
+    task_llm: AgenticTaskLLMConfig = PydanticField(
+        default_factory=AgenticTaskLLMConfig,
+        description="LLM for answering sub-questions. Falls back to planner_llm if model_name is empty.",
+    )
+    seed_gen_llm: AgenticSeedGenLLMConfig = PydanticField(
+        default_factory=AgenticSeedGenLLMConfig,
+        description="LLM for generating retry seed queries. Falls back to planner_llm if model_name is empty.",
+    )
+    synthesis_llm: AgenticSynthesisLLMConfig = PydanticField(
+        default_factory=AgenticSynthesisLLMConfig,
+        description="LLM for final answer synthesis. Falls back to planner_llm if model_name is empty.",
+    )
+
+    # --- Agent behaviour ----------------------------------------------------
+    concurrency_limit: int = Field(
+        default=3,
+        env="AGENTIC_CONCURRENCY_LIMIT",
+        description="Max concurrent LLM/retrieval calls inside the agent.",
+    )
+    recursion_limit: int = Field(
+        default=50,
+        env="AGENTIC_RECURSION_LIMIT",
+        description="Max recursion depth for the LangGraph workflow.",
+    )
+    log_level: str = Field(
+        default="INFO",
+        env="AGENTIC_LOG_LEVEL",
+        description="Logging level for the agentic RAG agent (DEBUG/INFO/WARNING/ERROR).",
+    )
+
+    # --- Component sub-configs ----------------------------------------------
+    planner: AgenticPlannerConfig = PydanticField(
+        default_factory=AgenticPlannerConfig
+    )
+    task_execution: AgenticTaskExecutionConfig = PydanticField(
+        default_factory=AgenticTaskExecutionConfig
+    )
+    llm: AgenticLLMTransportConfig = PydanticField(
+        default_factory=AgenticLLMTransportConfig
+    )
+    verification: AgenticVerificationConfig = PydanticField(
+        default_factory=AgenticVerificationConfig
+    )
+    context: AgenticContextConfig = PydanticField(
+        default_factory=AgenticContextConfig
+    )

--- a/src/nvidia_rag/utils/configuration.py
+++ b/src/nvidia_rag/utils/configuration.py
@@ -1243,6 +1243,12 @@ class ReflectionConfig(_ConfigBase):
         return v
 
 
+# Agentic RAG config classes live in a dedicated module to avoid bloating
+# this file.  Import must happen after _ConfigBase and Field are defined above
+# (Python partial-module resolution handles the deliberate circular reference).
+from nvidia_rag.utils.agentic_rag_config import AgenticRAGConfig  # noqa: E402
+
+
 class NvidiaRAGConfig(_ConfigBase):
     """Main NVIDIA RAG configuration.
 
@@ -1278,8 +1284,19 @@ class NvidiaRAGConfig(_ConfigBase):
         default_factory=QueryDecompositionConfig
     )
     reflection: ReflectionConfig = PydanticField(default_factory=ReflectionConfig)
+    agentic_rag: AgenticRAGConfig = PydanticField(default_factory=AgenticRAGConfig)
 
     # Top-level flags
+    enable_agentic_rag: bool = Field(
+        default=False,
+        env="ENABLE_AGENTIC_RAG",
+        description=(
+            "Enable the agentic RAG pipeline for knowledge-base queries. "
+            "When True, requests with use_knowledge_base=True are routed through "
+            "the LangGraph plan-and-execute agent instead of the standard RAG chain. "
+            "Can be overridden per-request via the agentic parameter in the request body."
+        ),
+    )
     enable_guardrails: bool = Field(
         default=False,
         env="ENABLE_GUARDRAILS",

--- a/tests/integration/test_cases/rag_generation.py
+++ b/tests/integration/test_cases/rag_generation.py
@@ -168,6 +168,50 @@ class RAGGenerationModule(BaseTestModule):
             )
             return False
 
+    @test_case(115, "Basic Generate with Agentic")
+    async def _test_generate_with_agentic(self) -> bool:
+        """Test basic RAG generation with agentic mode enabled"""
+        logger.info("\n=== Test 115: Basic Generate with Agentic ===")
+        generate_agentic_start = time.time()
+        generate_agentic_success = await self.test_generate_with_agentic()
+        generate_agentic_time = time.time() - generate_agentic_start
+
+        if generate_agentic_success:
+            self.add_test_result(
+                self._test_generate_with_agentic.test_number,
+                self._test_generate_with_agentic.test_name,
+                f"Basic RAG generation with agentic mode enabled using /v1/generate. Collection: {self.collections['with_metadata']}. Includes response content verification for default files, streaming response handling, and citation document verification.",
+                ["POST /v1/generate"],
+                [
+                    "messages",
+                    "collection_names",
+                    "agentic",
+                    "enable_citations",
+                    "enable_reranker",
+                ],
+                generate_agentic_time,
+                TestStatus.SUCCESS,
+            )
+            return True
+        else:
+            self.add_test_result(
+                self._test_generate_with_agentic.test_number,
+                self._test_generate_with_agentic.test_name,
+                f"Basic RAG generation with agentic mode enabled using /v1/generate. Collection: {self.collections['with_metadata']}. Includes response content verification for default files, streaming response handling, and citation document verification.",
+                ["POST /v1/generate"],
+                [
+                    "messages",
+                    "collection_names",
+                    "agentic",
+                    "enable_citations",
+                    "enable_reranker",
+                ],
+                generate_agentic_time,
+                TestStatus.FAILURE,
+                "Basic generate with agentic test failed",
+            )
+            return False
+
     async def test_generate_with_filter(
         self, filter_expr: str | list[dict[str, Any]] | None = None
     ) -> bool:
@@ -572,6 +616,113 @@ class RAGGenerationModule(BaseTestModule):
                         return False
             except Exception as e:
                 logger.error(f"❌ Error in generate without reranker test: {e}")
+                return False
+
+    async def test_generate_with_agentic(self) -> bool:
+        """Test /generate endpoint with agentic=true."""
+        payload = {
+            "messages": [{"role": "user", "content": "Who is the author of poems?"}],
+            "use_knowledge_base": True,
+            "temperature": 0,
+            "top_p": 0.1,
+            "max_tokens": 32768,
+            "reranker_top_k": 2,
+            "vdb_top_k": 10,
+            "collection_names": [self.collections["with_metadata"]],
+            "enable_query_rewriting": False,
+            "enable_reranker": False,
+            "enable_citations": True,
+            "agentic": True,
+            "stop": [],
+        }
+
+        async with aiohttp.ClientSession() as session:
+            try:
+                logger.info("🤖 Generating response with agentic mode enabled")
+                logger.info(
+                    f"📋 Generate request payload:\n{json.dumps(payload, indent=2)}"
+                )
+
+                async with session.post(
+                    f"{self.rag_server_url}/v1/generate", json=payload
+                ) as response:
+                    result = await print_response(response)
+                    if response.status == 200:
+                        if result.get("streaming_response"):
+                            logger.info(
+                                "✅ Basic generate with agentic test passed (streaming response processed)"
+                            )
+                        else:
+                            logger.info("✅ Basic generate with agentic test passed")
+
+                        response_text = ""
+                        if result.get("streaming_response"):
+                            response_text = extract_streaming_text(result)
+                        else:
+                            choices = result.get("choices", [])
+                            if choices:
+                                response_text = (
+                                    choices[0].get("message", {}).get("content", "")
+                                )
+
+                        if response_text:
+                            expected_keywords = ["Robert Frost"]
+                            if verify_response_content(
+                                response_text, expected_keywords, min_matches=1
+                            ):
+                                logger.info(
+                                    "✅ Response content verification passed - found expected author information"
+                                )
+                            else:
+                                logger.error(
+                                    f"⚠️ Response content verification failed - expected keywords '{expected_keywords}' not found"
+                                )
+                                return False
+                        else:
+                            logger.error(
+                                "⚠️ No response text found for content verification"
+                            )
+                            return False
+
+                        if "citations" in result:
+                            citations = result["citations"]
+                            results = citations.get("results", [])
+                            expected_count = payload["vdb_top_k"]
+
+                            if len(results) == expected_count:
+                                logger.info(
+                                    f"✅ Citation count verified: {len(results)} results (expected: {expected_count})"
+                                )
+
+                                if await verify_citation_document_names(
+                                    results,
+                                    [self.collections["with_metadata"]],
+                                    self.ingestor_server_url,
+                                ):
+                                    logger.info("✅ Citation document names verified")
+                                else:
+                                    logger.error(
+                                        "❌ Citation document names verification failed"
+                                    )
+                                    return False
+                            else:
+                                logger.warning(
+                                    f"❌ Citation count mismatch: got {len(results)}, expected {expected_count}"
+                                )
+                                logger.info(
+                                    "TODO: Server should ensure correct citation count based on vdb_top_k and available documents"
+                                )
+                                return True
+                        else:
+                            logger.error("⚠️ No citations found in generate response")
+                            return False
+
+                        return True
+                    else:
+                        logger.error("❌ Basic generate with agentic test failed")
+                        return False
+            except Exception as e:
+                logger.error(f"❌ Error in basic generate with agentic test: {e}")
                 return False
 
     @test_case(35, "Generate with Confidence Threshold")

--- a/tests/integration/test_sequences.yaml
+++ b/tests/integration/test_sequences.yaml
@@ -2,7 +2,7 @@ sequences:
   basic:
     name: "Basic Integration Tests"
     description: "Core functionality tests excluding advanced features"
-    test_numbers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 33, 34, 35, 36, 37, 38, 39, 40, 50, 51, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 100, 101, 102, 103, 104, 105, 106, 107, 108, 99, 110, 111, 112, 113, 114]
+    test_numbers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 115, 13, 14, 15, 33, 34, 35, 36, 37, 38, 39, 40, 50, 51, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 100, 101, 102, 103, 104, 105, 106, 107, 108, 99, 110, 111, 112, 113, 114]
     pre_sequence: [18]  # Cleanup collection before basic tests
     post_sequence: [16, 17, 18, 19, 109]  # Cleanup tests after sequence
 

--- a/tests/unit/test_compose_helm_parity/test_compose_helm_parity.py
+++ b/tests/unit/test_compose_helm_parity/test_compose_helm_parity.py
@@ -240,6 +240,10 @@ def test_compose_helm_image_and_env_parity():
                     "APP_VLM_APIKEY",
                     "SUMMARY_LLM_APIKEY",
                     "REFLECTION_LLM_APIKEY",
+                    "AGENTIC_PLANNER_LLM_APIKEY",
+                    "AGENTIC_TASK_LLM_APIKEY",
+                    "AGENTIC_SEED_GEN_LLM_APIKEY",
+                    "AGENTIC_SYNTHESIS_LLM_APIKEY",
                 },
             },
             "rag-frontend": {

--- a/tests/unit/test_rag_server/test_agentic_rag.py
+++ b/tests/unit/test_rag_server/test_agentic_rag.py
@@ -1,0 +1,405 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for agentic RAG helpers (no live LLM or network)."""
+
+from __future__ import annotations
+
+import inspect
+import json
+from collections import OrderedDict
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import nvidia_rag.rag_server.agentic_rag as agentic_rag_pkg
+from nvidia_rag.rag_server.agentic_rag import (
+    AgenticRAGGraphState,
+    AgenticSearchParams,
+    build_agentic_rag_agent,
+    make_retriever_fn,
+    run_agentic_pipeline,
+)
+from nvidia_rag.rag_server.agentic_rag import runner as agentic_runner
+from nvidia_rag.rag_server.agentic_rag.agentic_rag import AgenticRag
+from nvidia_rag.rag_server.agentic_rag.builder import (
+    _agentic_all_citations,
+    _agentic_search_params,
+)
+from nvidia_rag.rag_server.agentic_rag.prompt import build_prompts
+from nvidia_rag.rag_server.agentic_rag.tracing import (
+    AgentMetrics,
+    LLMCallRecord,
+    QueryTrace,
+    get_current_trace,
+)
+from nvidia_rag.rag_server.response_generator import (
+    Citations,
+    ErrorCodeMapping,
+    SourceMetadata,
+    SourceResult,
+)
+from nvidia_rag.utils.agentic_rag_config import AgenticRAGConfig
+
+
+def _minimal_agent() -> AgenticRag:
+    return AgenticRag(
+        planner_llm=MagicMock(),
+        task_llm=MagicMock(),
+        seed_gen_llm=MagicMock(),
+        synthesis_llm=MagicMock(),
+        retriever_fn=AsyncMock(return_value=None),
+        log_level="WARNING",
+        concurrency_limit=2,
+    )
+
+
+class TestAgenticRagPackageExports:
+    def test_public_api_matches_all(self) -> None:
+        expected = {
+            "AgenticRag",
+            "AgenticRAGGraphState",
+            "AgenticSearchParams",
+            "_agentic_search_params",
+            "build_agentic_rag_agent",
+            "make_retriever_fn",
+            "run_agentic_pipeline",
+        }
+        assert set(agentic_rag_pkg.__all__) == expected
+        assert AgenticRag is agentic_rag_pkg.AgenticRag
+        assert run_agentic_pipeline is agentic_runner.run_agentic_pipeline
+
+
+class TestAgenticRAGGraphState:
+    def test_defaults(self) -> None:
+        state = AgenticRAGGraphState(user_query="hello")
+        assert state.user_query == "hello"
+        assert state.initial_context == []
+        assert state.retrieval_plan == {}
+        assert state.task_results == {}
+        assert state.final_answer == ""
+        assert state.verification_round == 0
+
+
+class TestAgenticSearchParams:
+    def test_dataclass_defaults(self) -> None:
+        p = AgenticSearchParams()
+        assert p.collection_names is None
+        assert p.vdb_top_k is None
+        assert p.vdb_auth_token == ""
+        assert p.filter_expr == ""
+
+
+class TestAgenticRagStaticHelpers:
+    def test_filter_think_tokens_no_tags(self) -> None:
+        text = '{"a": 1}'
+        assert AgenticRag._filter_think_tokens(text) is text
+
+    def test_filter_think_tokens_strips_closed_block(self) -> None:
+        raw = (
+            "<think>ignore</think>"
+            '{"scope_only": false}'
+        )
+        assert AgenticRag._filter_think_tokens(raw) == '{"scope_only": false}'
+
+    def test_filter_think_tokens_truncated_block(self) -> None:
+        assert AgenticRag._filter_think_tokens("<think>no close") == ""
+
+    def test_sanitize_json_string_escapes_newlines_in_strings(self) -> None:
+        dirty = '{"x": "line1\nline2"}'
+        clean = AgenticRag._sanitize_json_string(dirty)
+        assert "\n" not in clean.split('"x":')[1]
+        assert json.loads(clean)["x"] == "line1\nline2"
+
+    def test_rebuild_result_text_vs_chart(self) -> None:
+        text_chunk = {
+            "doc_name": "a.pdf",
+            "content": "body",
+            "score": 0.9,
+            "document_type": "text",
+        }
+        r_text = AgenticRag._rebuild_result(text_chunk)
+        assert r_text["document_name"] == "a.pdf"
+        assert r_text["content"] == "body"
+        assert "metadata" not in r_text
+
+        chart_chunk = {
+            "doc_name": "c.png",
+            "content": "chart desc",
+            "document_type": "chart",
+        }
+        r_chart = AgenticRag._rebuild_result(chart_chunk)
+        assert r_chart["metadata"]["description"] == "chart desc"
+
+    def test_get_text_content_uses_metadata_description_for_images(self) -> None:
+        desc = "  alt text  "
+        assert (
+            AgenticRag._get_text_content(
+                {
+                    "document_type": "image",
+                    "content": "",
+                    "metadata": {"description": desc},
+                }
+            )
+            == desc
+        )
+
+    def test_clean_answer_strips_markdown_headers(self) -> None:
+        out = AgenticRag._clean_answer("## Title\n\nplain")
+        assert "Title" in out
+        assert "##" not in out
+
+
+class TestAgenticRagInstanceHelpers:
+    def test_parse_json_response_direct_and_embedded(self) -> None:
+        agent = _minimal_agent()
+        assert agent._parse_json_response('{"k": 1}') == {"k": 1}
+        wrapped = 'prefix {"k": 2} suffix'
+        assert agent._parse_json_response(wrapped) == {"k": 2}
+
+    def test_parse_json_response_invalid_returns_error_dict(self) -> None:
+        agent = _minimal_agent()
+        out = agent._parse_json_response("not json at all")
+        assert out.get("error") == "Failed to parse JSON"
+
+    def test_extract_chunks_from_model_dump_shape(self) -> None:
+        agent = _minimal_agent()
+        dumped = {
+            "results": [
+                {
+                    "document_name": "doc.txt",
+                    "content": "hello world",
+                    "score": 0.5,
+                    "document_type": "text",
+                }
+            ],
+            "total_results": 1,
+        }
+        chunks = agent._extract_chunks(dumped)
+        assert len(chunks) == 1
+        assert chunks[0]["doc_name"] == "doc.txt"
+        assert chunks[0]["content"] == "hello world"
+
+    def test_extract_chunks_skips_empty_image_without_description(self) -> None:
+        agent = _minimal_agent()
+        dumped = {
+            "results": [
+                {
+                    "document_name": "x.png",
+                    "content": "   ",
+                    "document_type": "image",
+                    "metadata": {},
+                }
+            ],
+            "total_results": 1,
+        }
+        assert agent._extract_chunks(dumped) == []
+
+    def test_format_chunks_for_prompt_sorts_by_score(self) -> None:
+        agent = _minimal_agent()
+        chunks = [
+            {"doc_name": "low", "content": "b", "score": 0.1, "document_type": "text"},
+            {"doc_name": "high", "content": "a", "score": 0.9, "document_type": "text"},
+        ]
+        text = agent._format_chunks_for_prompt(chunks, max_tokens=100_000)
+        assert text.index("high") < text.index("low")
+
+    def test_parse_task_answer_json_and_plain(self) -> None:
+        agent = _minimal_agent()
+        j = '{"completeness": "partial", "answer": "**x**", "missing": "y"}'
+        parsed = agent._parse_task_answer(j)
+        assert parsed["completeness"] == "partial"
+        assert parsed["answer"] == "x"
+        assert parsed["missing"] == "y"
+
+        plain = agent._parse_task_answer("  direct answer  ")
+        assert plain["completeness"] == "complete"
+        assert plain["answer"] == "direct answer"
+
+    def test_build_execution_levels_adds_ids(self) -> None:
+        agent = _minimal_agent()
+        tasks = [{"question": "q1", "query": "r1"}]
+        levels = agent._build_execution_levels(tasks)
+        assert len(levels) == 1
+        assert levels[0][0]["id"] == "auto_1"
+
+
+class TestMakeRetrieverFn:
+    @pytest.mark.asyncio
+    async def test_forwards_search_kwargs_from_context(self) -> None:
+        mock_rag = MagicMock()
+        mock_rag.search = AsyncMock(
+            return_value=Citations(
+                total_results=0,
+                results=[],
+            )
+        )
+        retriever = make_retriever_fn(mock_rag, default_reranker_top_k=7)
+        params = AgenticSearchParams(
+            collection_names=["col_a"],
+            vdb_top_k=12,
+            reranker_top_k=None,
+        )
+        token = _agentic_search_params.set(params)
+        acc_token = _agentic_all_citations.set(OrderedDict())
+        try:
+            out = await retriever("search me", stage="execute")
+            assert out is not None
+            mock_rag.search.assert_awaited_once()
+            call_kw = mock_rag.search.await_args.kwargs
+            assert call_kw["query"] == "search me"
+            assert call_kw["collection_names"] == ["col_a"]
+            assert call_kw["vdb_top_k"] == 12
+            assert call_kw["reranker_top_k"] == 7
+            assert call_kw["stage"] == "execute"
+        finally:
+            _agentic_search_params.reset(token)
+            _agentic_all_citations.reset(acc_token)
+
+    @pytest.mark.asyncio
+    async def test_accumulates_citations_when_context_set(self) -> None:
+        mock_rag = MagicMock()
+        sr = SourceResult(
+            document_name="n",
+            content="c",
+            metadata=SourceMetadata(),
+            stage="execute",
+        )
+        mock_rag.search = AsyncMock(
+            return_value=Citations(total_results=1, results=[sr])
+        )
+        retriever = make_retriever_fn(mock_rag, default_reranker_top_k=5)
+        acc: OrderedDict[str, list[SourceResult]] = OrderedDict()
+        p_token = _agentic_search_params.set(AgenticSearchParams())
+        c_token = _agentic_all_citations.set(acc)
+        try:
+            await retriever("q", stage="execute")
+            assert "execute" in acc
+            assert len(acc["execute"]) == 1
+            assert acc["execute"][0].document_name == "n"
+        finally:
+            _agentic_search_params.reset(p_token)
+            _agentic_all_citations.reset(c_token)
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_search_exception(self) -> None:
+        mock_rag = MagicMock()
+        mock_rag.search = AsyncMock(side_effect=RuntimeError("boom"))
+        retriever = make_retriever_fn(mock_rag, default_reranker_top_k=3)
+        p_token = _agentic_search_params.set(AgenticSearchParams())
+        c_token = _agentic_all_citations.set(OrderedDict())
+        try:
+            assert await retriever("q") is None
+        finally:
+            _agentic_search_params.reset(p_token)
+            _agentic_all_citations.reset(c_token)
+
+
+class TestBuildPrompts:
+    def test_injects_limits_and_returns_expected_keys(self) -> None:
+        prompts = build_prompts(max_plan_tasks=4, max_verification_tasks=2)
+        assert set(prompts.keys()) == {
+            "planner_prompt",
+            "task_answer_prompt",
+            "seed_gen_prompt",
+            "synthesis_prompt",
+            "verification_prompt",
+            "planner_replan_instruction",
+        }
+        planner_msgs = prompts["planner_prompt"].messages
+        system_tpl = planner_msgs[0].prompt.template
+        assert "Maximum 4 tasks." in system_tpl
+        ver_msgs = prompts["verification_prompt"].messages
+        ver_system = ver_msgs[0].prompt.template
+        assert "Maximum 2 tasks." in ver_system
+
+
+class TestTracing:
+    def test_query_trace_record_and_totals(self) -> None:
+        t = QueryTrace(query_text="q")
+        t.record_llm_call("step", 10, 20, 5.0)
+        t.finalize()
+        assert t.total_llm_calls == 1
+        assert t.total_input_tokens == 10
+        assert t.total_output_tokens == 20
+        d = t.to_dict()
+        assert d["query_text"] == "q"
+        assert d["total_llm_calls"] == 1
+        assert "query_id=" in t.one_line_summary()
+
+    def test_agent_metrics_summary_empty_and_nonempty(self) -> None:
+        m = AgentMetrics()
+        assert m.summary() == {"total_queries": 0}
+        tr = QueryTrace(query_text="z")
+        tr.llm_calls.append(LLMCallRecord("a", 1, 1, 1.0))
+        tr.finalize()
+        m.update(tr)
+        s = m.summary()
+        assert s["total_queries"] == 1
+        assert "llm_calls" in s
+
+    def test_get_current_trace_default_none(self) -> None:
+        assert get_current_trace() is None
+
+
+class TestRunAgenticPipeline:
+    @pytest.mark.asyncio
+    async def test_success_wraps_final_answer(self) -> None:
+        graph = MagicMock()
+        graph.ainvoke = AsyncMock(return_value={"final_answer": "synthesized"})
+
+        class _Agent:
+            def __init__(self) -> None:
+                self.metrics = AgentMetrics()
+
+        cfg = AgenticRAGConfig()
+        resp = await run_agentic_pipeline(
+            agent=_Agent(),
+            graph=graph,
+            query="user q",
+            cfg=cfg,
+            search_params=AgenticSearchParams(),
+        )
+        assert resp.status_code == ErrorCodeMapping.SUCCESS
+        blob = "".join([c async for c in resp.generator])
+        assert "synthesized" in blob
+
+    @pytest.mark.asyncio
+    async def test_failure_returns_server_error_message(self) -> None:
+        graph = MagicMock()
+        graph.ainvoke = AsyncMock(side_effect=ValueError("graph broke"))
+
+        class _Agent:
+            def __init__(self) -> None:
+                self.metrics = AgentMetrics()
+
+        cfg = AgenticRAGConfig()
+        resp = await run_agentic_pipeline(
+            agent=_Agent(),
+            graph=graph,
+            query="q",
+            cfg=cfg,
+            search_params=AgenticSearchParams(),
+        )
+        assert resp.status_code == ErrorCodeMapping.INTERNAL_SERVER_ERROR
+        text = "".join([c async for c in resp.generator])
+        assert "error" in text.lower() or "encountered" in text.lower()
+
+
+class TestBuildAgenticRagAgentSignature:
+    """Ensure the factory remains awaitable (import-time contract)."""
+
+    def test_build_agentic_rag_agent_is_coroutine_function(self) -> None:
+        assert inspect.iscoroutinefunction(build_agentic_rag_agent)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -795,7 +795,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/cb/48e964c452ca2b92175a9b2dca037a553036cb053ba69e284650ce755f13/greenlet-3.3.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:e29f3018580e8412d6aaf5641bb7745d38c85228dacf51a73bd4e26ddf2a6a8e", size = 274908, upload-time = "2025-12-04T14:23:26.435Z" },
     { url = "https://files.pythonhosted.org/packages/28/da/38d7bff4d0277b594ec557f479d65272a893f1f2a716cad91efeb8680953/greenlet-3.3.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a687205fb22794e838f947e2194c0566d3812966b41c78709554aa883183fb62", size = 577113, upload-time = "2025-12-04T14:50:05.493Z" },
     { url = "https://files.pythonhosted.org/packages/3c/f2/89c5eb0faddc3ff014f1c04467d67dee0d1d334ab81fadbf3744847f8a8a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4243050a88ba61842186cb9e63c7dfa677ec146160b0efd73b855a3d9c7fcf32", size = 590338, upload-time = "2025-12-04T14:57:41.136Z" },
-    { url = "https://files.pythonhosted.org/packages/80/d7/db0a5085035d05134f8c089643da2b44cc9b80647c39e93129c5ef170d8f/greenlet-3.3.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:670d0f94cd302d81796e37299bcd04b95d62403883b24225c6b5271466612f45", size = 601098, upload-time = "2025-12-04T15:07:11.898Z" },
     { url = "https://files.pythonhosted.org/packages/dc/a6/e959a127b630a58e23529972dbc868c107f9d583b5a9f878fb858c46bc1a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6cb3a8ec3db4a3b0eb8a3c25436c2d49e3505821802074969db017b87bc6a948", size = 590206, upload-time = "2025-12-04T14:26:01.254Z" },
     { url = "https://files.pythonhosted.org/packages/48/60/29035719feb91798693023608447283b266b12efc576ed013dd9442364bb/greenlet-3.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2de5a0b09eab81fc6a382791b995b1ccf2b172a9fec934747a7a23d2ff291794", size = 1550668, upload-time = "2025-12-04T15:04:22.439Z" },
     { url = "https://files.pythonhosted.org/packages/0a/5f/783a23754b691bfa86bd72c3033aa107490deac9b2ef190837b860996c9f/greenlet-3.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4449a736606bd30f27f8e1ff4678ee193bc47f6ca810d705981cfffd6ce0d8c5", size = 1615483, upload-time = "2025-12-04T14:27:28.083Z" },
@@ -803,7 +802,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/0a/a3871375c7b9727edaeeea994bfff7c63ff7804c9829c19309ba2e058807/greenlet-3.3.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:b01548f6e0b9e9784a2c99c5651e5dc89ffcbe870bc5fb2e5ef864e9cc6b5dcb", size = 276379, upload-time = "2025-12-04T14:23:30.498Z" },
     { url = "https://files.pythonhosted.org/packages/43/ab/7ebfe34dce8b87be0d11dae91acbf76f7b8246bf9d6b319c741f99fa59c6/greenlet-3.3.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:349345b770dc88f81506c6861d22a6ccd422207829d2c854ae2af8025af303e3", size = 597294, upload-time = "2025-12-04T14:50:06.847Z" },
     { url = "https://files.pythonhosted.org/packages/a4/39/f1c8da50024feecd0793dbd5e08f526809b8ab5609224a2da40aad3a7641/greenlet-3.3.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e8e18ed6995e9e2c0b4ed264d2cf89260ab3ac7e13555b8032b25a74c6d18655", size = 607742, upload-time = "2025-12-04T14:57:42.349Z" },
-    { url = "https://files.pythonhosted.org/packages/77/cb/43692bcd5f7a0da6ec0ec6d58ee7cddb606d055ce94a62ac9b1aa481e969/greenlet-3.3.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c024b1e5696626890038e34f76140ed1daf858e37496d33f2af57f06189e70d7", size = 622297, upload-time = "2025-12-04T15:07:13.552Z" },
     { url = "https://files.pythonhosted.org/packages/75/b0/6bde0b1011a60782108c01de5913c588cf51a839174538d266de15e4bf4d/greenlet-3.3.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:047ab3df20ede6a57c35c14bf5200fcf04039d50f908270d3f9a7a82064f543b", size = 609885, upload-time = "2025-12-04T14:26:02.368Z" },
     { url = "https://files.pythonhosted.org/packages/49/0e/49b46ac39f931f59f987b7cd9f34bfec8ef81d2a1e6e00682f55be5de9f4/greenlet-3.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2d9ad37fc657b1102ec880e637cccf20191581f75c64087a549e66c57e1ceb53", size = 1567424, upload-time = "2025-12-04T15:04:23.757Z" },
     { url = "https://files.pythonhosted.org/packages/05/f5/49a9ac2dff7f10091935def9165c90236d8f175afb27cbed38fb1d61ab6b/greenlet-3.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83cd0e36932e0e7f36a64b732a6f60c2fc2df28c351bae79fbaf4f8092fe7614", size = 1636017, upload-time = "2025-12-04T14:27:29.688Z" },
@@ -811,7 +809,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/02/2f/28592176381b9ab2cafa12829ba7b472d177f3acc35d8fbcf3673d966fff/greenlet-3.3.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:a1e41a81c7e2825822f4e068c48cb2196002362619e2d70b148f20a831c00739", size = 275140, upload-time = "2025-12-04T14:23:01.282Z" },
     { url = "https://files.pythonhosted.org/packages/2c/80/fbe937bf81e9fca98c981fe499e59a3f45df2a04da0baa5c2be0dca0d329/greenlet-3.3.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f515a47d02da4d30caaa85b69474cec77b7929b2e936ff7fb853d42f4bf8808", size = 599219, upload-time = "2025-12-04T14:50:08.309Z" },
     { url = "https://files.pythonhosted.org/packages/c2/ff/7c985128f0514271b8268476af89aee6866df5eec04ac17dcfbc676213df/greenlet-3.3.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d2d9fd66bfadf230b385fdc90426fcd6eb64db54b40c495b72ac0feb5766c54", size = 610211, upload-time = "2025-12-04T14:57:43.968Z" },
-    { url = "https://files.pythonhosted.org/packages/79/07/c47a82d881319ec18a4510bb30463ed6891f2ad2c1901ed5ec23d3de351f/greenlet-3.3.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:30a6e28487a790417d036088b3bcb3f3ac7d8babaa7d0139edbaddebf3af9492", size = 624311, upload-time = "2025-12-04T15:07:14.697Z" },
     { url = "https://files.pythonhosted.org/packages/fd/8e/424b8c6e78bd9837d14ff7df01a9829fc883ba2ab4ea787d4f848435f23f/greenlet-3.3.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:087ea5e004437321508a8d6f20efc4cfec5e3c30118e1417ea96ed1d93950527", size = 612833, upload-time = "2025-12-04T14:26:03.669Z" },
     { url = "https://files.pythonhosted.org/packages/b5/ba/56699ff9b7c76ca12f1cdc27a886d0f81f2189c3455ff9f65246780f713d/greenlet-3.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ab97cf74045343f6c60a39913fa59710e4bd26a536ce7ab2397adf8b27e67c39", size = 1567256, upload-time = "2025-12-04T15:04:25.276Z" },
     { url = "https://files.pythonhosted.org/packages/1e/37/f31136132967982d698c71a281a8901daf1a8fbab935dce7c0cf15f942cc/greenlet-3.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5375d2e23184629112ca1ea89a53389dddbffcf417dad40125713d88eb5f96e8", size = 1636483, upload-time = "2025-12-04T14:27:30.804Z" },
@@ -1740,6 +1737,7 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langchain-milvus" },
     { name = "langchain-nvidia-ai-endpoints" },
+    { name = "langgraph" },
     { name = "lark" },
     { name = "minio" },
     { name = "pdfplumber" },
@@ -1813,6 +1811,7 @@ rag = [
     { name = "opentelemetry-sdk-extension-prometheus-multiprocess" },
     { name = "prometheus-client" },
     { name = "pyarrow" },
+    { name = "tiktoken" },
 ]
 
 [package.dev-dependencies]
@@ -1852,6 +1851,7 @@ requires-dist = [
     { name = "langchain-openai", marker = "extra == 'all'", specifier = ">=0.2,<1.1.9" },
     { name = "langchain-openai", marker = "extra == 'ingest'", specifier = ">=0.2,<1.1.9" },
     { name = "langchain-openai", marker = "extra == 'rag'", specifier = ">=0.2,<1.1.9" },
+    { name = "langgraph", specifier = ">=0.2" },
     { name = "lark", specifier = ">=1.2.2" },
     { name = "minio", specifier = ">=7.2,<8.0" },
     { name = "nv-ingest-api", marker = "extra == 'all'", specifier = "==26.3.0" },
@@ -1899,6 +1899,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0,<7.0" },
     { name = "redis", specifier = ">=4.3.4" },
     { name = "setuptools", marker = "extra == 'ingest'", specifier = ">=80.10.2" },
+    { name = "tiktoken", marker = "extra == 'rag'", specifier = ">=0.7" },
     { name = "tqdm", marker = "extra == 'all'", specifier = ">=4.67,<5.0" },
     { name = "tqdm", marker = "extra == 'ingest'", specifier = ">=4.67,<5.0" },
     { name = "tritonclient", marker = "extra == 'all'", specifier = "==2.57.0" },


### PR DESCRIPTION
# Agentic RAG onboarding

- Adds an optional **LangGraph plan-and-execute** agentic RAG path for knowledge-base queries (`agentic_rag/` package: graph, builder, runner, prompts, tracing).
- Wires **NvidiaRAG** to route KB traffic through the agentic pipeline when enabled; supports a per-request **`agentic`** flag and lazy graph initialization.
- Introduces **`agentic_rag_config`** plus global config plumbing; extends **search/citations** with a **`stage`** field for agentic retrieval steps.
- **Deploy**: Docker Compose (`docker-compose-rag-server.yaml`), **`nvdev.env`** agentic LLM/behavior knobs, Helm chart (deployment, secrets, values), and **Workbench** `compose.yaml` updates.
- **Tests**: new unit tests (`test_agentic_rag.py`), integration coverage in `rag_generation.py`, sequence tweak, compose/helm parity test touch-up; **`pyproject.toml` / `uv.lock`** dependency updates.


## Checklist
- [X] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [X] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [X] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.