### PR TITLE
Migrate VLM to Nemotron Omni as default VLM

### DIFF
--- a/deploy/compose/docker-compose-ingestor-server.yaml
+++ b/deploy/compose/docker-compose-ingestor-server.yaml
@@ -108,7 +108,7 @@ services:
       APP_NVINGEST_SEGMENTAUDIO: ${APP_NVINGEST_SEGMENTAUDIO:-False} # Enable audio segmentation for NV Ingest
 
       ##===NV-Ingest Caption Model configurations====
-      APP_NVINGEST_CAPTIONMODELNAME: ${APP_NVINGEST_CAPTIONMODELNAME:-"nvidia/nemotron-nano-12b-v2-vl"}
+      APP_NVINGEST_CAPTIONMODELNAME: ${APP_NVINGEST_CAPTIONMODELNAME:-"nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"}
       # Incase of nvidia-hosted caption model, use the endpoint url as - https://integrate.api.nvidia.com/v1
       APP_NVINGEST_CAPTIONENDPOINTURL: ${APP_NVINGEST_CAPTIONENDPOINTURL:-"http://vlm-ms:8000/v1/chat/completions"}
 
@@ -260,7 +260,7 @@ services:
       - YOLOX_TABLE_STRUCTURE_INFER_PROTOCOL=${YOLOX_TABLE_STRUCTURE_INFER_PROTOCOL:-grpc}
       # Incase of nvidia-hosted caption model, use the endpoint url as - https://integrate.api.nvidia.com/v1/chat/completions
       - VLM_CAPTION_ENDPOINT=${VLM_CAPTION_ENDPOINT:-http://vlm-ms:8000/v1/chat/completions}
-      - VLM_CAPTION_MODEL_NAME=${VLM_CAPTION_MODEL_NAME:-nvidia/nemotron-nano-12b-v2-vl}
+      - VLM_CAPTION_MODEL_NAME=${VLM_CAPTION_MODEL_NAME:-nvidia/nemotron-3-nano-omni-30b-a3b-reasoning}
       - MODEL_PREDOWNLOAD_PATH=${MODEL_PREDOWNLOAD_PATH:-/workspace/models/}
       - COMPONENTS_TO_READY_CHECK=ALL
     healthcheck:

--- a/deploy/compose/docker-compose-rag-server.yaml
+++ b/deploy/compose/docker-compose-rag-server.yaml
@@ -69,7 +69,7 @@ services:
 
       # Fetch full page context: when True, fetches ALL chunks for retrieved pages and organizes by page
       # Useful for PDFs where we have page numbers in file
-      APP_FETCH_FULL_PAGE_CONTEXT: ${APP_FETCH_FULL_PAGE_CONTEXT:-false}
+      APP_FETCH_FULL_PAGE_CONTEXT: ${APP_FETCH_FULL_PAGE_CONTEXT:-False}
       # N pages before/after each retrieved page (0=disabled, 1=+/-1 page). Requires APP_FETCH_FULL_PAGE_CONTEXT=true
       APP_FETCH_NEIGHBORING_PAGES: ${APP_FETCH_NEIGHBORING_PAGES:-0}
 
@@ -126,14 +126,20 @@ services:
       VLM_TO_LLM_FALLBACK: ${VLM_TO_LLM_FALLBACK:-False}
       # Max images sent to VLM per request (query + context)
       APP_VLM_MAX_TOTAL_IMAGES: ${APP_VLM_MAX_TOTAL_IMAGES:-5}
+      # Whether to filter out reasoning tokens from VLM responses (stream only content, not reasoning)
+      VLM_FILTER_THINK_TOKENS: ${VLM_FILTER_THINK_TOKENS:-true}
+      # Enable reasoning mode for Nemotron 3 nano omni reasoning model
+      APP_VLM_ENABLE_THINKING: ${APP_VLM_ENABLE_THINKING:-true}
+      # Max reasoning tokens for VLM (0 = no cap); only applied when enable_thinking is true
+      APP_VLM_THINKING_TOKEN_BUDGET: ${APP_VLM_THINKING_TOKEN_BUDGET:-16384}
       # VLM generation parameters
-      APP_VLM_MAX_TOKENS: ${APP_VLM_MAX_TOKENS:-8192}
-      APP_VLM_TEMPERATURE: ${APP_VLM_TEMPERATURE:-0.1}
-      APP_VLM_TOP_P: ${APP_VLM_TOP_P:-1.0}
+      APP_VLM_MAX_TOKENS: ${APP_VLM_MAX_TOKENS:-32768}
+      APP_VLM_TEMPERATURE: ${APP_VLM_TEMPERATURE:-0.6}
+      APP_VLM_TOP_P: ${APP_VLM_TOP_P:-0.95}
       # VLM server URL
       APP_VLM_SERVERURL: ${APP_VLM_SERVERURL-"http://vlm-ms:8000/v1"}
       # VLM model name
-      APP_VLM_MODELNAME: ${APP_VLM_MODELNAME:-"nvidia/nemotron-nano-12b-v2-vl"}
+      APP_VLM_MODELNAME: ${APP_VLM_MODELNAME:-"nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"}
 
       NVIDIA_API_KEY: ${NGC_API_KEY:?"NGC_API_KEY is required"}
 

--- a/deploy/compose/nims.yaml
+++ b/deploy/compose/nims.yaml
@@ -330,8 +330,8 @@ services:
     profiles: ["audio"]
 
   vlm-ms:
-    container_name: nemo-vlm-microservice
-    image: nvcr.io/nim/nvidia/nemotron-nano-12b-v2-vl:1.6.0
+    container_name: nemotron-3-nano-omni-30b-a3b-reasoning
+    image: nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:1.7.0-variant
     volumes:
     - ${MODEL_DIRECTORY:-./}:/opt/nim/.cache
     ports:
@@ -349,7 +349,7 @@ services:
       interval: 10s
       timeout: 20s
       retries: 100
-    shm_size: 16GB
+    shm_size: 32GB
     deploy:
       resources:
         reservations:

--- a/deploy/compose/nvdev.env
+++ b/deploy/compose/nvdev.env
@@ -77,11 +77,11 @@ export NV_INGEST_MAX_UTIL=8
 
 # VLM generation feature
 export APP_VLM_SERVERURL="https://integrate.api.nvidia.com/v1"
-export APP_VLM_MODELNAME="nvidia/nemotron-nano-12b-v2-vl"
+export APP_VLM_MODELNAME="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
 # export ENABLE_VLM_INFERENCE="true" # Uncomment to use VLM generation
 
 # Image captioning feature
-export APP_NVINGEST_CAPTIONMODELNAME="nvidia/nemotron-nano-12b-v2-vl"
+export APP_NVINGEST_CAPTIONMODELNAME="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
 export APP_NVINGEST_CAPTIONENDPOINTURL="https://integrate.api.nvidia.com/v1/chat/completions"
 # export APP_NVINGEST_EXTRACTIMAGES="True" # Uncomment to use image captioning
 

--- a/deploy/helm/nvidia-blueprint-rag/files/prompt.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/files/prompt.yaml
@@ -176,20 +176,41 @@ iterative_summary_prompt:
 
 vlm_template:
   system: |
-    You are a multimodal AI assistant. Answer using only the provided context and images.
+    You are a multimodal AI assistant. Answer using the provided context and images.
 
     <instructions>
-    1. Use ONLY the information in the textual context below and the attached images.
-    2. Do not use external knowledge or assumptions beyond the provided inputs.
-    3. Do not describe images unless needed to answer; focus on the answer.
-    4. Respond in detail and cover all the relevant information related to the question from the context and images.
-    5. Keep the response neutral and factually accurate.
+    1. Use the textual context and attached images as your primary source of information.
+       Do not fabricate facts, numbers, or claims not present in the inputs.
+       If the context provides partial information, answer with what is available and
+       note what is missing — do not refuse simply because coverage is incomplete.
+    2. If the context or images contain ANY information relevant to the question — even
+       partial — you MUST provide an answer using that information. Only reply that you
+       cannot answer if the context and images have no connection to the question at all.
+    3. Preserve exact values: reproduce specific numbers, percentages, dates, names, and
+       URLs exactly as they appear in the context or images.
+    4. When extracting a value from a table or list, identify the exact row/column label
+       matching the question before extracting its value. When the question specifies a
+       time period, confirm that exact period in the context before answering — do not
+       use data from an adjacent period. If the exact value cannot be unambiguously
+       identified in the context, say what related information is available rather than
+       guessing a value.
+    5. When a page image is provided alongside the text, cross-reference the image to
+       verify values in tables and charts. The image is the authoritative source for
+       exact cell values when text and image disagree.
+    6. When the question asks for multiple distinct values or differences between several
+       categories, provide ALL values separately. Do not stop after the first one.
+    7. When a question asks "how much" as a count or amount, give the absolute value.
+       Provide a percentage only when the question explicitly asks for a rate or percentage.
+    8. For yes/no questions, state your answer (Yes or No) first, then cite the specific
+       evidence from the context that supports it.
+    9. When asked to calculate a ratio, margin, or rate, extract the relevant numbers from
+       the context first, then compute and state the final result.
+    10. Respond in detail and cover all relevant information from the context and images.
     </instructions>
 
-    Context:
+  human: |
     {context}
 
-    User Question:
     {question}
 
 # Reasoning templates deprecated and removed

--- a/deploy/helm/nvidia-blueprint-rag/values.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/values.yaml
@@ -161,7 +161,7 @@ envVars:
 
   # Fetch full page context: when True, fetches ALL chunks for retrieved pages and organizes by page
   # Useful for PDFs where we have page numbers in file
-  APP_FETCH_FULL_PAGE_CONTEXT: "false"
+  APP_FETCH_FULL_PAGE_CONTEXT: "False"
   # N pages before/after each retrieved page (0=disabled, 1=+/-1 page). Requires APP_FETCH_FULL_PAGE_CONTEXT=true
   APP_FETCH_NEIGHBORING_PAGES: "0"
 
@@ -209,14 +209,20 @@ envVars:
   VLM_TO_LLM_FALLBACK: "False"
   # Max images sent to VLM per request (query + context)
   APP_VLM_MAX_TOTAL_IMAGES: "5"
+  # Whether to filter out reasoning tokens from VLM responses (stream only content, not reasoning)
+  VLM_FILTER_THINK_TOKENS: "true"
+  # Enable Nemotron Omni reasoning mode (separates chain-of-thought into a `reasoning` delta)
+  APP_VLM_ENABLE_THINKING: "true"
+  # Max reasoning tokens for VLM (0 = no cap); only applied when enable_thinking is true
+  APP_VLM_THINKING_TOKEN_BUDGET: "16384"
   # VLM generation parameters
-  APP_VLM_MAX_TOKENS: "8192"
-  APP_VLM_TEMPERATURE: "0.1"
-  APP_VLM_TOP_P: "1.0"
+  APP_VLM_MAX_TOKENS: "32768"
+  APP_VLM_TEMPERATURE: "0.6"
+  APP_VLM_TOP_P: "0.95"
   # VLM server URL
   APP_VLM_SERVERURL: "http://nim-vlm:8000/v1"
   # VLM model name
-  APP_VLM_MODELNAME: "nvidia/nemotron-nano-12b-v2-vl"
+  APP_VLM_MODELNAME: "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
 
   # === Text Splitter ===
   APP_TEXTSPLITTER_CHUNKSIZE: "2000"
@@ -418,7 +424,7 @@ ingestor-server:
     APP_NVINGEST_TEXTDEPTH: "page"  # Extract text by "page" or "document"
 
     # === NV-Ingest caption configurations ===
-    APP_NVINGEST_CAPTIONMODELNAME: "nvidia/nemotron-nano-12b-v2-vl"  # Model name for captioning
+    APP_NVINGEST_CAPTIONMODELNAME: "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"  # Model name for captioning
     APP_NVINGEST_CAPTIONENDPOINTURL: ""  # Endpoint URL for captioning model
 
     # NeMo Retriever invoke URLs (HTTP) for local NIMs (see rag-nv-ingest YOLOX_*_HTTP_ENDPOINT)
@@ -1026,8 +1032,8 @@ nimOperator:
     service:
       name: "nim-vlm"
     image:
-      repository: nvcr.io/nim/nvidia/nemotron-nano-12b-v2-vl
-      tag: "1.6.0"
+      repository: nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning
+      tag: "1.7.0-variant"
       pullPolicy: IfNotPresent
     resources:
       limits:
@@ -1137,7 +1143,7 @@ nv-ingest:
     YOLOX_TABLE_STRUCTURE_INFER_PROTOCOL: grpc
 
     # Captioning
-    VLM_CAPTION_MODEL_NAME: nvidia/nemotron-nano-12b-v2-vl
+    VLM_CAPTION_MODEL_NAME: nvidia/nemotron-3-nano-omni-30b-a3b-reasoning
     VLM_CAPTION_ENDPOINT: http://nim-vlm:8000/v1/chat/completions
 
     # Audio service

--- a/docs/change-model.md
+++ b/docs/change-model.md
@@ -315,11 +315,13 @@ The default VLM for this blueprint is **Nemotron Omni** (`nvidia/nemotron-3-nano
      image: nvcr.io/nim/nvidia/nemotron-nano-12b-v2-vl:1.6.0
    ```
 
-2. Set the model name environment variables before starting services:
+2. Set the model name and disable Omni-specific reasoning knobs before starting services:
 
    ```bash
    export APP_VLM_MODELNAME="nvidia/nemotron-nano-12b-v2-vl"
    export APP_NVINGEST_CAPTIONMODELNAME="nvidia/nemotron-nano-12b-v2-vl"
+   export APP_VLM_ENABLE_THINKING=false
+   export APP_VLM_THINKING_TOKEN_BUDGET=0
    ```
 
 3. Restart the affected services:
@@ -343,6 +345,8 @@ The default VLM for this blueprint is **Nemotron Omni** (`nvidia/nemotron-3-nano
 
    envVars:
      APP_VLM_MODELNAME: "nvidia/nemotron-nano-12b-v2-vl"
+     APP_VLM_ENABLE_THINKING: "false"
+     APP_VLM_THINKING_TOKEN_BUDGET: "0"
 
    ingestor-server:
      envVars:

--- a/docs/change-model.md
+++ b/docs/change-model.md
@@ -302,6 +302,63 @@ Use this procedure to change models when you are running self-hosted NVIDIA NIM 
 
 
 
+## Switch Back to Nemotron Nano 12B VLM
+
+The default VLM for this blueprint is **Nemotron Omni** (`nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`). If you want to revert to the previous **Nemotron Nano 12B** (`nvidia/nemotron-nano-12b-v2-vl`) model, follow the steps below.
+
+### Docker Compose
+
+1. In `deploy/compose/nims.yaml`, update the `vlm-ms` service image:
+
+   ```yaml
+   vlm-ms:
+     image: nvcr.io/nim/nvidia/nemotron-nano-12b-v2-vl:1.6.0
+   ```
+
+2. Set the model name environment variables before starting services:
+
+   ```bash
+   export APP_VLM_MODELNAME="nvidia/nemotron-nano-12b-v2-vl"
+   export APP_NVINGEST_CAPTIONMODELNAME="nvidia/nemotron-nano-12b-v2-vl"
+   ```
+
+3. Restart the affected services:
+
+   ```bash
+   docker compose -f deploy/compose/nims.yaml --profile vlm-generation up -d
+   docker compose -f deploy/compose/docker-compose-rag-server.yaml up -d
+   docker compose -f deploy/compose/docker-compose-ingestor-server.yaml up -d
+   ```
+
+### Helm
+
+1. In `deploy/helm/nvidia-blueprint-rag/values.yaml`, update the VLM NIM image and model names:
+
+   ```yaml
+   nimOperator:
+     nim-vlm:
+       image:
+         repository: nvcr.io/nim/nvidia/nemotron-nano-12b-v2-vl
+         tag: "1.6.0"
+
+   envVars:
+     APP_VLM_MODELNAME: "nvidia/nemotron-nano-12b-v2-vl"
+
+   ingestor-server:
+     envVars:
+       APP_NVINGEST_CAPTIONMODELNAME: "nvidia/nemotron-nano-12b-v2-vl"
+
+   nv-ingest:
+     envVars:
+       VLM_CAPTION_MODEL_NAME: nvidia/nemotron-nano-12b-v2-vl
+   ```
+
+2. Apply the changes as described in [Change a Deployment](deploy-helm.md#change-a-deployment).
+
+:::{note}
+Nemotron Nano 12B requires 1x H100 GPU for VLM inference. Ensure `APP_VLM_SERVERURL` points to the correct NIM endpoint after switching.
+:::
+
 ## Related Topics
 
 - [Best Practices for Common Settings](accuracy_perf.md).

--- a/docs/image_captioning.md
+++ b/docs/image_captioning.md
@@ -27,14 +27,14 @@ For this feature, use H100 or A100 GPUs instead.
 
 2. Make sure the vlm container is up and running
    ```bash
-   docker ps --filter "name=nemo-vlm-microservice" --format "table {{.ID}}\t{{.Names}}\t{{.Status}}"
+   docker ps --filter "name=nemotron-3-nano-omni-30b-a3b-reasoning" --format "table {{.ID}}\t{{.Names}}\t{{.Status}}"
    ```
 
    *Example Output*
 
    ```output
-   NAMES                                   STATUS
-   nemo-vlm-microservice                   Up 5 minutes (healthy)
+   NAMES                                                STATUS
+   nemotron-3-nano-omni-30b-a3b-reasoning               Up 5 minutes (healthy)
    ```
 
 3. Enable image captioning
@@ -49,7 +49,7 @@ For this feature, use H100 or A100 GPUs instead.
 1. Set caption endpoint and model to API catalog
    ```bash
    export APP_NVINGEST_CAPTIONENDPOINTURL="https://integrate.api.nvidia.com/v1/chat/completions"
-   export APP_NVINGEST_CAPTIONMODELNAME="nvidia/nemotron-nano-12b-v2-vl"
+   export APP_NVINGEST_CAPTIONMODELNAME="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
    ```
 
 2. Enable image captioning
@@ -87,7 +87,7 @@ To enable image captioning in Helm-based deployments by using an on-prem VLM mod
        # === Image Captioning ===
        APP_NVINGEST_EXTRACTIMAGES: "True"
        APP_NVINGEST_CAPTIONENDPOINTURL: "http://nim-vlm:8000/v1/chat/completions"
-       APP_NVINGEST_CAPTIONMODELNAME: "nvidia/nemotron-nano-12b-v2-vl"
+       APP_NVINGEST_CAPTIONMODELNAME: "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
    ```
 
 2. Apply the updated Helm chart:

--- a/docs/multimodal-query.md
+++ b/docs/multimodal-query.md
@@ -12,7 +12,7 @@ The multimodal query feature in the [NVIDIA RAG Blueprint](readme.md) enables yo
 
 This feature combines:
 - **VLM Embeddings**: `nvidia/llama-nemotron-embed-vl-1b-v2` for creating multimodal embeddings that understand both text and images
-- **Vision-Language Model**: `nvidia/nemotron-nano-12b-v2-vl` for generating intelligent responses based on visual and textual context
+- **Vision-Language Model**: `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` for generating intelligent responses based on visual and textual context
 
 
 
@@ -81,7 +81,7 @@ Set the model names and service URLs for the RAG pipeline:
 
 ```bash
 # VLM (Vision-Language Model) configuration
-export APP_VLM_MODELNAME="nvidia/nemotron-nano-12b-v2-vl"
+export APP_VLM_MODELNAME="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
 export APP_VLM_SERVERURL="http://vlm-ms:8000/v1"
 export APP_LLM_SERVERURL=""
 
@@ -169,7 +169,7 @@ Then set the VLM configuration:
 
 ```bash
 # VLM (Vision-Language Model) configuration - cloud hosted
-export APP_VLM_MODELNAME="nvidia/nemotron-nano-12b-v2-vl"
+export APP_VLM_MODELNAME="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
 export APP_VLM_SERVERURL="https://integrate.api.nvidia.com"
 export APP_LLM_SERVERURL=""
 
@@ -274,7 +274,7 @@ envVars:
   # VLM inference settings
   ENABLE_VLM_INFERENCE: "true"
   VLM_TO_LLM_FALLBACK: "false"
-  APP_VLM_MODELNAME: "nvidia/nemotron-nano-12b-v2-vl"
+  APP_VLM_MODELNAME: "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
   APP_VLM_SERVERURL: "http://nim-vlm:8000/v1"
 
   # VLM embedding settings

--- a/docs/service-port-gpu-reference.md
+++ b/docs/service-port-gpu-reference.md
@@ -23,7 +23,7 @@ The following table provides a comprehensive reference of all services, their po
 | Embedding | `nemotron-embedding-ms` | 9080 | 8000 | 0 | `EMBEDDING_MS_GPU_ID` | Text embeddings |
 | VLM Embedding | `nemotron-vlm-embedding-ms` | 9081 | 8000 | 0 | `VLM_EMBEDDING_MS_GPU_ID` | Vision-language embeddings (opt-in, profile: vlm-embed) |
 | Ranking | `nemotron-ranking-ms` | 1976 | 8000 | 0 | `RANKING_MS_GPU_ID` | Reranking model |
-| VLM | `nemo-vlm-microservice` | 1977 | 8000 | 5 | `VLM_MS_GPU_ID` | Vision-language model (opt-in, profile: vlm-only, vlm-generation) |
+| VLM | `nemotron-3-nano-omni-30b-a3b-reasoning` | 1977 | 8000 | 5 | `VLM_MS_GPU_ID` | Vision-language model (opt-in, profile: vlm-only, vlm-generation) |
 | Nemotron Parse | `compose-nemotron-parse-1` | 8015, 8016, 8017 | 8000, 8001, 8002 | 1 | `NEMOTRON_PARSE_MS_GPU_ID` | PDF parsing (opt-in, profile: nemotron-parse) |
 | RIVA ASR | `compose-audio-1` | 8021, 8022 | 50051, 9000 | 0 | `AUDIO_MS_GPU_ID` | Audio speech recognition (opt-in, profile: audio) |
 | Page Elements | `compose-page-elements-1` | 8000, 8001, 8002 | 8000, 8001, 8002 | 0 | `YOLOX_MS_GPU_ID` | Object detection for pages |
@@ -46,7 +46,7 @@ The following table provides a comprehensive reference of all services, their po
 
 The following NIM services are opt-in and require explicit Docker Compose profile activation:
 - **VLM Embedding** (`nemotron-vlm-embedding-ms`): Use profile `vlm-embed` for vision-language embeddings
-- **VLM** (`nemo-vlm-microservice`): Use profile `vlm-only` or `vlm-generation` for vision-language model
+- **VLM** (`nemotron-3-nano-omni-30b-a3b-reasoning`): Use profile `vlm-only` or `vlm-generation` for vision-language model
 - **Nemotron Parse** (`compose-nemotron-parse-1`): Use profile `nemotron-parse` for advanced PDF parsing
 - **RIVA ASR** (`compose-audio-1`): Use profile `audio` for audio speech recognition
 

--- a/docs/vlm.md
+++ b/docs/vlm.md
@@ -49,10 +49,10 @@ When VLM inference is enabled, the **VLM replaces the traditional LLM** in the R
 
 The VLM feature uses predefined prompts that can be customized in [`src/nvidia_rag/rag_server/prompt.yaml`](../src/nvidia_rag/rag_server/prompt.yaml) under the `vlm_template` section. The `vlm_template` controls how the question, textual context, and cited images are presented to the VLM.
 
-**VLM reasoning vs. non-reasoning mode**: The VLM supports two modes controlled via the `vlm_template`:
+**VLM reasoning vs. non-reasoning mode**: Nemotron Omni supports two modes controlled by the `APP_VLM_ENABLE_THINKING` environment variable:
 
-- **Non-reasoning mode (default)**: Template path ends with `/no_think`. Default parameters: `APP_VLM_TEMPERATURE=0.1`, `APP_VLM_TOP_P=1.0`, `APP_VLM_MAX_TOKENS=8192`.
-- **Reasoning mode (chain-of-thought)**: Change the route in `vlm_template` from `/no_think` to `/think`. Recommended: `APP_VLM_TEMPERATURE=0.3`, `APP_VLM_TOP_P=0.91`, `APP_VLM_MAX_TOKENS=8192`.
+- **Reasoning mode (default)**: `APP_VLM_ENABLE_THINKING=true`. The model produces a chain-of-thought trace before the final answer. Default parameters: `APP_VLM_TEMPERATURE=0.6`, `APP_VLM_TOP_P=0.95`, `APP_VLM_MAX_TOKENS=32768`, `APP_VLM_THINKING_TOKEN_BUDGET=16384`.
+- **Non-reasoning mode**: `APP_VLM_ENABLE_THINKING=false`. The model skips the reasoning trace and returns only the final answer.
 
 Set these parameters via environment variables in your deployment configuration (for example in `docker-compose-rag-server.yaml` or Helm `values.yaml`).
 

--- a/docs/vlm.md
+++ b/docs/vlm.md
@@ -58,7 +58,7 @@ Set these parameters via environment variables in your deployment configuration 
 
 ## Enable VLM with Docker Compose
 
-NVIDIA RAG uses the [**nemotron-nano-12b-v2-vl**](https://build.nvidia.com/nvidia/nemotron-nano-12b-v2-vl) Vision-Language Model by default, provided as the `vlm-ms` service in `deploy/compose/nims.yaml`.
+NVIDIA RAG uses the **Nemotron Omni** (`nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`) Vision-Language Model by default, provided as the `vlm-ms` service in `deploy/compose/nims.yaml`.
 
 The `vlm-generation` profile in `deploy/compose/nims.yaml` is designed for VLM-based generation on **2xH100 GPUs**. It skips the NIM LLM deployment (VLM replaces LLM), deploys the VLM service (`vlm-ms`), and deploys embedding and reranker microservices.
 
@@ -82,7 +82,7 @@ The `vlm-generation` profile in `deploy/compose/nims.yaml` is designed for VLM-b
    USERID=$(id -u) docker compose -f deploy/compose/nims.yaml --profile vlm-generation up -d
    ```
 
-2. Enable image extraction and captioning for ingestion. In `deploy/compose/docker-compose-ingestor-server.yaml`, under the `ingestor-server` service, ensure `APP_NVINGEST_EXTRACTIMAGES` is set to `True` so images are extracted and stored. Image captioning is enabled by default: `APP_NVINGEST_CAPTIONMODELNAME` is set to `nvidia/nemotron-nano-12b-v2-vl` and `APP_NVINGEST_CAPTIONENDPOINTURL` points to the `vlm-ms` service. Override via environment variables if needed:
+2. Enable image extraction and captioning for ingestion. In `deploy/compose/docker-compose-ingestor-server.yaml`, under the `ingestor-server` service, set `APP_NVINGEST_EXTRACTIMAGES` to `True` so images are extracted and stored (disabled by default). Image captioning is enabled by default: `APP_NVINGEST_CAPTIONMODELNAME` is set to `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` and `APP_NVINGEST_CAPTIONENDPOINTURL` points to the `vlm-ms` service. Override via environment variables if needed:
 
    ```bash
    export APP_NVINGEST_EXTRACTIMAGES=True
@@ -93,7 +93,7 @@ The `vlm-generation` profile in `deploy/compose/nims.yaml` is designed for VLM-b
 
    ```bash
    export ENABLE_VLM_INFERENCE="true"
-   export APP_VLM_MODELNAME="nvidia/nemotron-nano-12b-v2-vl"
+   export APP_VLM_MODELNAME="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
    export APP_VLM_SERVERURL="http://vlm-ms:8000/v1"
    docker compose -f deploy/compose/docker-compose-rag-server.yaml up -d
    ```
@@ -114,7 +114,7 @@ To use a remote NVIDIA-hosted NIM for VLM inference, set `APP_VLM_SERVERURL` to 
 
 ```bash
 export ENABLE_VLM_INFERENCE="true"
-export APP_VLM_MODELNAME="nvidia/nemotron-nano-12b-v2-vl"
+export APP_VLM_MODELNAME="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
 export APP_VLM_SERVERURL="https://integrate.api.nvidia.com/v1/"
 docker compose -f deploy/compose/docker-compose-rag-server.yaml up -d
 ```
@@ -131,7 +131,7 @@ Continue with [Deploy with Docker (NVIDIA-Hosted Models)](deploy-docker-nvidia-h
 
    ```yaml
    ENABLE_VLM_INFERENCE: "true"
-   APP_VLM_MODELNAME: "nvidia/nemotron-nano-12b-v2-vl"
+   APP_VLM_MODELNAME: "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
    APP_VLM_SERVERURL: "http://nim-vlm:8000/v1"
    ```
 
@@ -197,7 +197,7 @@ USERID=$(id -u) docker compose -f deploy/compose/nims.yaml up -d
 
 export ENABLE_VLM_INFERENCE="true"
 export VLM_TO_LLM_FALLBACK="true"
-export APP_VLM_MODELNAME="nvidia/nemotron-nano-12b-v2-vl"
+export APP_VLM_MODELNAME="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
 export APP_VLM_SERVERURL="http://vlm-ms:8000/v1"
 docker compose -f deploy/compose/docker-compose-rag-server.yaml up -d
 ```
@@ -212,7 +212,7 @@ Do not use the `vlm-generation` profile when fallback is enabled; it skips the L
 envVars:
   ENABLE_VLM_INFERENCE: "true"
   VLM_TO_LLM_FALLBACK: "true"
-  APP_VLM_MODELNAME: "nvidia/nemotron-nano-12b-v2-vl"
+  APP_VLM_MODELNAME: "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
   APP_VLM_SERVERURL: "http://nim-vlm:8000/v1"
 
 nimOperator:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
 [project.optional-dependencies]
 rag = [
     "langchain-openai>=0.2,<1.1.9",
+    "openai>=1.0,<2.0",
     "opentelemetry-api>=1.29,<2.0",
     "opentelemetry-exporter-otlp>=1.29,<2.0",
     "opentelemetry-exporter-prometheus>=0.50b0,<1.0",
@@ -65,6 +66,7 @@ ingest = [
     "tritonclient==2.57.0",
     # Other ingest dependencies
     "langchain-openai>=0.2,<1.1.9",
+    "openai>=1.0,<2.0",
     "overrides>=7.7,<8.0",
     "tqdm>=4.67,<5.0",
     "opentelemetry-api>=1.29,<2.0",
@@ -87,6 +89,7 @@ all = [
     "tritonclient==2.57.0",
     # RAG + Ingest dependencies
     "langchain-openai>=0.2,<1.1.9",
+    "openai>=1.0,<2.0",
     "overrides>=7.7,<8.0",
     "tqdm>=4.67,<5.0",
     "opentelemetry-api>=1.29,<2.0",

--- a/src/nvidia_rag/rag_server/main.py
+++ b/src/nvidia_rag/rag_server/main.py
@@ -443,6 +443,9 @@ class NvidiaRAG:
         vlm_top_p: float | None = None,
         vlm_max_tokens: int | None = None,
         vlm_max_total_images: int | None = None,
+        vlm_enable_thinking: bool | None = None,
+        vlm_thinking_token_budget: int | None = None,
+        vlm_filter_thinking_tokens: bool | None = None,
         filter_expr: str | list[dict[str, Any]] = "",
         enable_query_decomposition: bool | None = None,
         confidence_threshold: float | None = None,
@@ -684,6 +687,10 @@ class NvidiaRAG:
             "vlm_top_p": vlm_top_p,
             "vlm_max_tokens": vlm_max_tokens,
             "vlm_max_total_images": vlm_max_total_images,
+            # Reasoning controls — None means "use server-side default".
+            "vlm_enable_thinking": vlm_enable_thinking,
+            "vlm_thinking_token_budget": vlm_thinking_token_budget,
+            "vlm_filter_thinking_tokens": vlm_filter_thinking_tokens,
         }
 
         if use_knowledge_base:
@@ -1809,6 +1816,14 @@ class NvidiaRAG:
                 vlm_settings.get("vlm_max_total_images")
                 or self.config.vlm.max_total_images
             )
+            # Per-request reasoning controls (None → server-side default in vlm.py).
+            vlm_enable_thinking_req = vlm_settings.get("vlm_enable_thinking")
+            vlm_thinking_token_budget_req = vlm_settings.get(
+                "vlm_thinking_token_budget"
+            )
+            vlm_filter_thinking_tokens_req = vlm_settings.get(
+                "vlm_filter_thinking_tokens"
+            )
 
             # Extract text from query for logging
             query_text = self._extract_text_from_content(query)
@@ -1851,6 +1866,7 @@ class NvidiaRAG:
             ]
 
             # Stream VLM response (no context documents in direct mode)
+            vlm_token_usage: dict[str, Any] = {}
             vlm_generator = vlm.stream_with_messages(
                 docs=[],  # No context documents
                 messages=vlm_messages,
@@ -1860,6 +1876,10 @@ class NvidiaRAG:
                 top_p=vlm_top_p_cfg,
                 max_tokens=vlm_max_tokens_cfg,
                 max_total_images=vlm_max_total_images_cfg,
+                token_usage=vlm_token_usage,
+                enable_thinking=vlm_enable_thinking_req,
+                thinking_token_budget=vlm_thinking_token_budget_req,
+                filter_think_tokens=vlm_filter_thinking_tokens_req,
             )
 
             # Eagerly prefetch first chunk to catch errors early
@@ -1876,6 +1896,7 @@ class NvidiaRAG:
                     collection_name="",
                     enable_citations=enable_citations,
                     otel_metrics_client=metrics,
+                    token_usage=vlm_token_usage,
                 ),
                 status_code=ErrorCodeMapping.SUCCESS,
             )
@@ -3313,6 +3334,19 @@ class NvidiaRAG:
                             vlm_settings.get("vlm_max_total_images")
                             or self.config.vlm.max_total_images
                         )
+                        # None passes through to vlm.stream_with_messages where
+                        # it falls back to the per-config defaults; using
+                        # `is not None` here so explicit False / 0 from clients
+                        # is preserved.
+                        vlm_enable_thinking_req = vlm_settings.get(
+                            "vlm_enable_thinking"
+                        )
+                        vlm_thinking_token_budget_req = vlm_settings.get(
+                            "vlm_thinking_token_budget"
+                        )
+                        vlm_filter_thinking_tokens_req = vlm_settings.get(
+                            "vlm_filter_thinking_tokens"
+                        )
 
                         logger.info("=" * 80)
                         logger.info("STAGE: VLM Generation (Vision Language Model)")
@@ -3370,6 +3404,7 @@ class NvidiaRAG:
                         )
                         # Always stream VLM response directly using async streaming (reasoning gate deprecated)
                         logger.info("Streaming VLM response directly (async).")
+                        vlm_token_usage: dict[str, Any] = {}
                         vlm_generator = vlm.stream_with_messages(
                             docs=context_to_show,
                             messages=vlm_messages,
@@ -3381,6 +3416,10 @@ class NvidiaRAG:
                             max_tokens=vlm_max_tokens_cfg,
                             max_total_images=vlm_max_total_images_cfg,
                             nrl_mode=self._is_nrl_mode,
+                            token_usage=vlm_token_usage,
+                            enable_thinking=vlm_enable_thinking_req,
+                            thinking_token_budget=vlm_thinking_token_budget_req,
+                            filter_think_tokens=vlm_filter_thinking_tokens_req,
                         )
                         # Eagerly prefetch first chunk to trigger any errors before creating RAGResponse
                         # ensures connection errors are caught early
@@ -3397,12 +3436,13 @@ class NvidiaRAG:
                             generate_answer_async(
                                 prefetched_vlm_stream,
                                 docs_for_citations,
-                                model=model,
+                                model=vlm_model_cfg,
                                 collection_name=validated_collections[0]
                                 if validated_collections
                                 else "",
                                 enable_citations=enable_citations,
                                 use_nrl_citations=self._is_nrl_mode,
+                                token_usage=vlm_token_usage,
                             ),
                             status_code=ErrorCodeMapping.SUCCESS,
                         )

--- a/src/nvidia_rag/rag_server/prompt.yaml
+++ b/src/nvidia_rag/rag_server/prompt.yaml
@@ -176,20 +176,41 @@ iterative_summary_prompt:
 
 vlm_template:
   system: |
-    You are a multimodal AI assistant. Answer using only the provided context and images.
+    You are a multimodal AI assistant. Answer using the provided context and images.
 
     <instructions>
-    1. Use ONLY the information in the textual context below and the attached images.
-    2. Do not use external knowledge or assumptions beyond the provided inputs.
-    3. Do not describe images unless needed to answer; focus on the answer.
-    4. Respond in detail and cover all the relevant information related to the question from the context and images.
-    5. Keep the response neutral and factually accurate.
+    1. Use the textual context and attached images as your primary source of information.
+       Do not fabricate facts, numbers, or claims not present in the inputs.
+       If the context provides partial information, answer with what is available and
+       note what is missing — do not refuse simply because coverage is incomplete.
+    2. If the context or images contain ANY information relevant to the question — even
+       partial — you MUST provide an answer using that information. Only reply that you
+       cannot answer if the context and images have no connection to the question at all.
+    3. Preserve exact values: reproduce specific numbers, percentages, dates, names, and
+       URLs exactly as they appear in the context or images.
+    4. When extracting a value from a table or list, identify the exact row/column label
+       matching the question before extracting its value. When the question specifies a
+       time period, confirm that exact period in the context before answering — do not
+       use data from an adjacent period. If the exact value cannot be unambiguously
+       identified in the context, say what related information is available rather than
+       guessing a value.
+    5. When a page image is provided alongside the text, cross-reference the image to
+       verify values in tables and charts. The image is the authoritative source for
+       exact cell values when text and image disagree.
+    6. When the question asks for multiple distinct values or differences between several
+       categories, provide ALL values separately. Do not stop after the first one.
+    7. When a question asks "how much" as a count or amount, give the absolute value.
+       Provide a percentage only when the question explicitly asks for a rate or percentage.
+    8. For yes/no questions, state your answer (Yes or No) first, then cite the specific
+       evidence from the context that supports it.
+    9. When asked to calculate a ratio, margin, or rate, extract the relevant numbers from
+       the context first, then compute and state the final result.
+    10. Respond in detail and cover all relevant information from the context and images.
     </instructions>
 
-    Context:
+  human: |
     {context}
 
-    User Question:
     {question}
 
 # Reasoning templates deprecated and removed

--- a/src/nvidia_rag/rag_server/server.py
+++ b/src/nvidia_rag/rag_server/server.py
@@ -554,6 +554,37 @@ class Prompt(BaseModel):
         le=64,
         format="int64",
     )
+    vlm_enable_thinking: bool | None = Field(
+        default=None,
+        description=(
+            "Enable VLM chain-of-thought reasoning for this request. "
+            "When omitted, falls back to the server-side default "
+            "(APP_VLM_ENABLE_THINKING). Independent of the LLM-side "
+            "thinking knobs (min_thinking_tokens / max_thinking_tokens)."
+        ),
+    )
+    vlm_thinking_token_budget: int | None = Field(
+        default=None,
+        description=(
+            "Maximum tokens the VLM may spend on reasoning (0 = unbounded). "
+            "Only applied when vlm_enable_thinking is True. When omitted, "
+            "falls back to the server-side default (APP_VLM_THINKING_TOKEN_BUDGET)."
+        ),
+        ge=0,
+        le=65536,
+        format="int64",
+    )
+    vlm_filter_thinking_tokens: bool | None = Field(
+        default=None,
+        description=(
+            "When True the VLM's reasoning trace is suppressed and only the "
+            "final answer is streamed. When False the reasoning trace is "
+            "streamed first, wrapped in [reasoning]...[/reasoning] sentinels, "
+            "followed by the answer. When omitted, falls back to the "
+            "server-side default (VLM_FILTER_THINK_TOKENS). No-op if "
+            "vlm_enable_thinking is False (nothing to filter)."
+        ),
+    )
 
     # seed: int = Field(42, description="If specified, our system will make a best effort to sample deterministically,
     #       such that repeated requests with the same seed and parameters should return the same result.")
@@ -1427,6 +1458,9 @@ async def generate_answer(request: Request, prompt: Prompt) -> StreamingResponse
         "vlm_temperature": prompt.vlm_temperature,
         "vlm_top_p": prompt.vlm_top_p,
         "vlm_max_tokens": prompt.vlm_max_tokens,
+        "vlm_enable_thinking": prompt.vlm_enable_thinking,
+        "vlm_thinking_token_budget": prompt.vlm_thinking_token_budget,
+        "vlm_filter_thinking_tokens": prompt.vlm_filter_thinking_tokens,
         "vlm_max_total_images": prompt.vlm_max_total_images,
         "filter_expr": prompt.filter_expr,
         "confidence_threshold": prompt.confidence_threshold,
@@ -1510,6 +1544,9 @@ async def generate_answer(request: Request, prompt: Prompt) -> StreamingResponse
             vlm_temperature=prompt.vlm_temperature,
             vlm_top_p=prompt.vlm_top_p,
             vlm_max_tokens=prompt.vlm_max_tokens,
+            vlm_enable_thinking=prompt.vlm_enable_thinking,
+            vlm_thinking_token_budget=prompt.vlm_thinking_token_budget,
+            vlm_filter_thinking_tokens=prompt.vlm_filter_thinking_tokens,
             vlm_max_total_images=prompt.vlm_max_total_images,
             filter_expr=prompt.filter_expr,
             confidence_threshold=prompt.confidence_threshold,

--- a/src/nvidia_rag/rag_server/vlm.py
+++ b/src/nvidia_rag/rag_server/vlm.py
@@ -870,6 +870,10 @@ class VLM:
         max_total_images: int | None = None,
         organize_by_page: bool = False,
         nrl_mode: bool = False,
+        token_usage: dict[str, Any] | None = None,
+        enable_thinking: bool | None = None,
+        thinking_token_budget: int | None = None,
+        filter_think_tokens: bool | None = None,
         **_: Any,
     ) -> AsyncGenerator[str, None]:
         """
@@ -912,9 +916,25 @@ class VLM:
                     self.invoke_url,
                     api_key=self.config.vlm.get_api_key(),
                 )
+                # Resolve reasoning controls: per-request override > config default.
+                eff_enable_thinking = (
+                    enable_thinking
+                    if enable_thinking is not None
+                    else self.config.vlm.enable_thinking
+                )
+                eff_thinking_token_budget = (
+                    thinking_token_budget
+                    if thinking_token_budget is not None
+                    else self.config.vlm.thinking_token_budget
+                )
+                eff_filter_think_tokens = (
+                    filter_think_tokens
+                    if filter_think_tokens is not None
+                    else self.config.vlm.filter_think_tokens
+                )
                 extra_body = self._build_extra_body(
-                    self.config.vlm.enable_thinking,
-                    self.config.vlm.thinking_token_budget,
+                    eff_enable_thinking,
+                    eff_thinking_token_budget,
                 )
 
                 (
@@ -948,12 +968,10 @@ class VLM:
                     "VLM final streaming prompt (images redacted): %s", safe_prompt
                 )
 
-                filter_enabled = (
-                    os.getenv("VLM_FILTER_THINK_TOKENS", "true").lower() == "true"
-                )
+                filter_enabled = eff_filter_think_tokens
                 logger.info(
                     "VLM reasoning streaming: enable_thinking=%s filter=%s",
-                    self.config.vlm.enable_thinking,
+                    eff_enable_thinking,
                     filter_enabled,
                 )
 
@@ -964,12 +982,30 @@ class VLM:
                     top_p=eff_top_p,
                     max_tokens=eff_max_tokens,
                     stream=True,
+                    stream_options={"include_usage": True},
                     extra_body=extra_body,
                 )
 
                 chunk_count = 0
+                # When filter_enabled=False, wrap each reasoning span with
+                # [reasoning]...[/reasoning] sentinels so clients can structurally
+                # separate chain-of-thought from the final answer. Nemotron Omni
+                # emits reasoning in a separate delta field rather than inline
+                # tags, so without a wrapper the streamed text would have no
+                # boundary between deliberation and answer. Square-bracket markers
+                # are used (instead of HTML-style <reasoning>) because the rag
+                # server's response model sanitises Message.content via bleach,
+                # which strips angle-bracket tags.
+                in_reasoning = False
                 async for chunk in stream:
                     try:
+                        # OpenAI emits a final chunk with empty choices and a populated `usage`
+                        # field when stream_options.include_usage=True. Capture it once we see it.
+                        chunk_usage = getattr(chunk, "usage", None)
+                        if chunk_usage is not None and token_usage is not None:
+                            token_usage["prompt_tokens"] = getattr(chunk_usage, "prompt_tokens", 0) or 0
+                            token_usage["completion_tokens"] = getattr(chunk_usage, "completion_tokens", 0) or 0
+                            token_usage["total_tokens"] = getattr(chunk_usage, "total_tokens", 0) or 0
                         if not chunk.choices:
                             chunk_count += 1
                             continue
@@ -988,10 +1024,17 @@ class VLM:
                             if content:
                                 yield content
                         else:
-                            # Both reasoning trace and final answer reach the client
+                            # Both reasoning trace and final answer reach the client,
+                            # with reasoning wrapped in [reasoning]...[/reasoning].
                             if reasoning:
+                                if not in_reasoning:
+                                    yield "[reasoning]"
+                                    in_reasoning = True
                                 yield reasoning
                             if content:
+                                if in_reasoning:
+                                    yield "[/reasoning]"
+                                    in_reasoning = False
                                 yield content
                     except Exception as e:
                         logger.debug(
@@ -1002,6 +1045,13 @@ class VLM:
                             exc_info=True,
                         )
                     chunk_count += 1
+
+                # Close any unterminated reasoning span if the stream ended
+                # before any content delta arrived (e.g. token cap exhausted
+                # while the model was still deliberating).
+                if in_reasoning:
+                    yield "[/reasoning]"
+                    in_reasoning = False
 
                 logger.info("VLM streaming processed %d chunks", chunk_count)
             except Exception as e:

--- a/src/nvidia_rag/rag_server/vlm.py
+++ b/src/nvidia_rag/rag_server/vlm.py
@@ -18,7 +18,8 @@ This module defines the VLM (Vision-Language Model) utilities for NVIDIA RAG pip
 
 Main functionalities:
 - Analyze images using a VLM given user messages and full chat/context.
-- Use an LLM to reason about the VLM's response and decide if it should be used.
+- Stream tokens from a VLM, including the reasoning trace emitted by
+  ``nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`` when ``enable_thinking`` is set.
 
 Intended for use in NVIDIA's Retrieval-Augmented Generation (RAG) systems, compatible with LangChain and OpenAI-compatible VLM APIs.
 
@@ -138,10 +139,21 @@ class VLM:
 
     @staticmethod
     def init_model(
-        model: str, endpoint: str, api_key: str | None = None, **kwargs: Any
+        model: str,
+        endpoint: str,
+        api_key: str | None = None,
+        enable_thinking: bool = True,
+        thinking_token_budget: int = 0,
+        **kwargs: Any,
     ) -> ChatOpenAI:
         """
         Initialize and return the VLM ChatOpenAI model instance.
+
+        For ``nvidia/nemotron-3-nano-omni-30b-a3b-reasoning``, reasoning is
+        controlled via ``chat_template_kwargs`` in the request body.  When
+        ``enable_thinking=True`` the model separates chain-of-thought into a
+        ``reasoning`` delta field and the final answer into ``content``.
+        An optional ``thinking_token_budget`` caps the reasoning trace length.
 
         Note
         ----
@@ -149,11 +161,18 @@ class VLM:
         limits are enforced earlier when assembling the messages that will be
         sent to the model.
         """
+        extra_body: dict[str, Any] = {
+            "chat_template_kwargs": {"enable_thinking": enable_thinking},
+        }
+        if enable_thinking and thinking_token_budget > 0:
+            extra_body["thinking_token_budget"] = thinking_token_budget
+
         return ChatOpenAI(
             model=model,
             openai_api_key=api_key,
             openai_api_base=endpoint,
             default_headers=NVIDIA_API_DEFAULT_HEADERS,
+            model_kwargs={"extra_body": extra_body},
             **kwargs,
         )
 
@@ -743,6 +762,7 @@ class VLM:
         top_p: float | None = None,
         max_tokens: int | None = None,
         max_total_images: int | None = None,
+        organize_by_page: bool = False,
         nrl_mode: bool = False,
         **_: Any,
     ) -> str:
@@ -779,7 +799,11 @@ class VLM:
         )
 
         vlm = self.init_model(
-            self.model_name, self.invoke_url, api_key=self.config.vlm.get_api_key()
+            self.model_name,
+            self.invoke_url,
+            api_key=self.config.vlm.get_api_key(),
+            enable_thinking=self.config.vlm.enable_thinking,
+            thinking_token_budget=self.config.vlm.thinking_token_budget,
         )
 
         (
@@ -793,6 +817,7 @@ class VLM:
             context_text,
             question_text,
             max_total_images=eff_max_total_images,
+            organize_by_page=organize_by_page,
             nrl_mode=nrl_mode,
         )
 
@@ -848,6 +873,15 @@ class VLM:
         """
         Stream tokens from the VLM asynchronously given full conversation and retrieved context.
         Yields incremental text chunks as they arrive.
+
+        For ``nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`` with
+        ``enable_thinking=True``, each streaming delta carries either a
+        ``reasoning`` / ``reasoning_content`` field (chain-of-thought) and/or a
+        ``content`` field (final answer). ``VLM_FILTER_THINK_TOKENS`` controls
+        what reaches the client:
+
+        - ``true``  (default): forward only ``content`` (reasoning hidden)
+        - ``false``: forward reasoning first, then ``content``
         """
         if not isinstance(messages, list) or len(messages) == 0:
             logger.warning("No messages provided for VLM streaming.")
@@ -867,7 +901,11 @@ class VLM:
             )
 
             vlm = self.init_model(
-                self.model_name, self.invoke_url, api_key=self.config.vlm.get_api_key()
+                self.model_name,
+                self.invoke_url,
+                api_key=self.config.vlm.get_api_key(),
+                enable_thinking=self.config.vlm.enable_thinking,
+                thinking_token_budget=self.config.vlm.thinking_token_budget,
             )
 
             (
@@ -897,8 +935,24 @@ class VLM:
             safe_prompt = self._redact_messages_for_logging(lc_messages)
             logger.info("VLM final streaming prompt (images redacted): %s", safe_prompt)
 
-            # Stream response chunks asynchronously
-            idx = 0
+            # Stream response chunks.
+            #
+            # nvidia/nemotron-3-nano-30b-a3b-omni-reasoning separates its output
+            # into two delta fields per chunk:
+            #   • chunk.additional_kwargs["reasoning"] — chain-of-thought tokens
+            #   • chunk.content                        — final answer tokens
+            #
+            # VLM_FILTER_THINK_TOKENS controls what reaches the client:
+            #   true  → forward only content (reasoning hidden, default)
+            #   false → forward reasoning first, then content (both visible)
+            filter_enabled = os.getenv("VLM_FILTER_THINK_TOKENS", "true").lower() == "true"
+            logger.info(
+                "VLM reasoning streaming: enable_thinking=%s filter=%s",
+                self.config.vlm.enable_thinking,
+                filter_enabled,
+            )
+
+            chunk_count = 0
             async for chunk in vlm.astream(
                 lc_messages,
                 temperature=eff_temperature,
@@ -906,19 +960,32 @@ class VLM:
                 max_tokens=eff_max_tokens,
             ):
                 try:
-                    content = getattr(chunk, "content", None)
-                    if isinstance(content, str) and content:
-                        yield content
+                    reasoning: str = (
+                        getattr(chunk, "additional_kwargs", {}).get("reasoning", "") or ""
+                    )
+                    content: str = getattr(chunk, "content", "") or ""
+
+                    if filter_enabled:
+                        # Only the final answer reaches the client
+                        if content:
+                            yield content
+                    else:
+                        # Both reasoning trace and final answer reach the client
+                        if reasoning:
+                            yield reasoning
+                        if content:
+                            yield content
                 except Exception as e:
-                    # Best-effort streaming; log and skip malformed chunks
                     logger.debug(
                         "Skipping malformed VLM stream chunk at index %s: %r; error: %s",
-                        idx,
+                        chunk_count,
                         chunk,
                         e,
                         exc_info=True,
                     )
-                idx += 1
+                chunk_count += 1
+
+            logger.info("VLM streaming processed %d chunks", chunk_count)
         except Exception as e:
             error_type = type(e).__name__
             if (

--- a/src/nvidia_rag/rag_server/vlm.py
+++ b/src/nvidia_rag/rag_server/vlm.py
@@ -21,7 +21,10 @@ Main functionalities:
 - Stream tokens from a VLM, including the reasoning trace emitted by
   ``nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`` when ``enable_thinking`` is set.
 
-Intended for use in NVIDIA's Retrieval-Augmented Generation (RAG) systems, compatible with LangChain and OpenAI-compatible VLM APIs.
+The implementation talks directly to OpenAI-compatible endpoints via the
+``openai`` Python SDK; there is no LangChain abstraction layer, so reasoning
+delta fields (``reasoning`` / ``reasoning_content``) are read straight off the
+streaming chunks.
 
 Class:
     VLM: Provides methods for image analysis via messages and VLM/LLM reasoning.
@@ -35,8 +38,7 @@ from collections.abc import AsyncGenerator
 from logging import getLogger
 from typing import Any
 
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
-from langchain_openai import ChatOpenAI
+from openai import AsyncOpenAI
 from PIL import Image as PILImage
 
 from nvidia_rag.rag_server.response_generator import APIError, ErrorCodeMapping
@@ -44,8 +46,12 @@ from nvidia_rag.utils.common import NVIDIA_API_DEFAULT_HEADERS
 from nvidia_rag.utils.configuration import NvidiaRAGConfig
 from nvidia_rag.utils.llm import get_prompts
 from nvidia_rag.utils.object_store import get_object_store_operator
+from nvidia_rag.utils.observability.tracing import trace_function, traced_span
 
 logger = getLogger(__name__)
+
+# OpenAI Chat Completions message dict: {"role": str, "content": str | list[dict]}.
+MessageDict = dict[str, Any]
 
 
 class VLM:
@@ -66,9 +72,6 @@ class VLM:
     - ``0``: prevents **additional** images from being added from retrieved
       documents; user-supplied images already present in the messages are
       passed through unchanged.
-
-    The limit is applied when assembling the LangChain messages, after
-    normalizing incoming messages and skipping non-image document types.
 
     Methods
     -------
@@ -98,20 +101,6 @@ class VLM:
             prompts:
                 Optional prompts dictionary.
 
-        Image budget semantics
-        ----------------------
-        The image budget is read from ``config.vlm.max_total_images`` and
-        interpreted as:
-
-        - ``None``: no explicit limit applied by this helper.
-        - Integer ``N > 0``: at most ``N`` images (combined from user messages
-          and retrieved context) are included in the VLM prompt.
-        - ``0``: no **additional** images are taken from retrieved documents;
-          any images already present in user/chat messages are left intact.
-
-        This limit is enforced while building the prompt messages, after
-        normalizing message content and skipping non-image document types.
-
         Raises
         ------
         EnvironmentError
@@ -138,51 +127,47 @@ class VLM:
         logger.info(f"VLM Server URL: {self.invoke_url}")
 
     @staticmethod
-    def init_model(
-        model: str,
+    def _create_async_client(
         endpoint: str,
         api_key: str | None = None,
-        enable_thinking: bool = True,
-        thinking_token_budget: int = 0,
-        **kwargs: Any,
-    ) -> ChatOpenAI:
-        """
-        Initialize and return the VLM ChatOpenAI model instance.
+    ) -> AsyncOpenAI:
+        """Build an OpenAI-compatible async client targeting the VLM endpoint."""
+        return AsyncOpenAI(
+            base_url=endpoint,
+            # OpenAI SDK requires a non-empty api_key string even for self-hosted NIMs.
+            api_key=api_key or "not-required",
+            default_headers=NVIDIA_API_DEFAULT_HEADERS,
+        )
+
+    @staticmethod
+    def _build_extra_body(
+        enable_thinking: bool,
+        thinking_token_budget: int,
+    ) -> dict[str, Any]:
+        """Build the ``extra_body`` payload for Nemotron Omni reasoning controls.
 
         For ``nvidia/nemotron-3-nano-omni-30b-a3b-reasoning``, reasoning is
         controlled via ``chat_template_kwargs`` in the request body.  When
         ``enable_thinking=True`` the model separates chain-of-thought into a
-        ``reasoning`` delta field and the final answer into ``content``.
-        An optional ``thinking_token_budget`` caps the reasoning trace length.
-
-        Note
-        ----
-        This helper does **not** apply any image-count limits itself; those
-        limits are enforced earlier when assembling the messages that will be
-        sent to the model.
+        ``reasoning`` (or ``reasoning_content``) delta and the final answer
+        into ``content``. An optional ``thinking_token_budget`` caps the
+        reasoning trace length.
         """
         extra_body: dict[str, Any] = {
             "chat_template_kwargs": {"enable_thinking": enable_thinking},
         }
         if enable_thinking and thinking_token_budget > 0:
             extra_body["thinking_token_budget"] = thinking_token_budget
-
-        return ChatOpenAI(
-            model=model,
-            openai_api_key=api_key,
-            openai_api_base=endpoint,
-            default_headers=NVIDIA_API_DEFAULT_HEADERS,
-            model_kwargs={"extra_body": extra_body},
-            **kwargs,
-        )
+        return extra_body
 
     @staticmethod
+    @trace_function("vlm.normalize_messages")
     def _normalize_messages(
         raw_messages: list[dict[str, Any]],
-    ) -> tuple[list[HumanMessage | AIMessage | SystemMessage], int, str]:
-        """Normalize raw messages; return (messages_without_system, last_human_idx, incoming_system_text)."""
-        lc_messages: list[HumanMessage | AIMessage | SystemMessage] = []
-        last_human_idx: int | None = None
+    ) -> tuple[list[MessageDict], int, str]:
+        """Normalize raw messages; return (messages_without_system, last_user_idx, incoming_system_text)."""
+        normalized_messages: list[MessageDict] = []
+        last_user_idx: int | None = None
         system_accum_text: str = ""
 
         def ensure_list_content(raw_content: Any) -> list[dict[str, Any]]:
@@ -237,7 +222,7 @@ class VLM:
                 if system_text:
                     system_accum_text = (system_accum_text + " " + system_text).strip()
             elif role == "assistant":
-                # Assistant content should be a plain string
+                # Assistant content should be a plain string per OpenAI Chat schema.
                 assistant_text = "".join(
                     [
                         (
@@ -248,18 +233,23 @@ class VLM:
                         for part in content
                     ]
                 )
-                lc_messages.append(AIMessage(content=assistant_text))
+                normalized_messages.append(
+                    {"role": "assistant", "content": assistant_text}
+                )
             else:
                 # User content can be multimodal list
-                lc_messages.append(HumanMessage(content=content))
-                last_human_idx = len(lc_messages) - 1
+                normalized_messages.append({"role": "user", "content": content})
+                last_user_idx = len(normalized_messages) - 1
 
-        if last_human_idx is None:
-            lc_messages.append(HumanMessage(content=[{"type": "text", "text": ""}]))
-            last_human_idx = len(lc_messages) - 1
+        if last_user_idx is None:
+            normalized_messages.append(
+                {"role": "user", "content": [{"type": "text", "text": ""}]}
+            )
+            last_user_idx = len(normalized_messages) - 1
 
-        return lc_messages, last_human_idx, system_accum_text
+        return normalized_messages, last_user_idx, system_accum_text
 
+    @trace_function("vlm.extract_and_process_messages")
     def extract_and_process_messages(
         self,
         vlm_template: dict[str, Any],
@@ -270,12 +260,10 @@ class VLM:
         max_total_images: int | None = None,
         organize_by_page: bool = False,
         nrl_mode: bool = False,
-    ) -> tuple[
-        SystemMessage, HumanMessage, list[HumanMessage | AIMessage | SystemMessage]
-    ]:
+    ) -> tuple[MessageDict, MessageDict, list[MessageDict]]:
         """
         Build system and user messages from template, normalize chat history, and
-        extract any query/context images to be attached to the last human message.
+        extract any query/context images to be attached to the last user message.
         When organize_by_page=True, interleaves text and images per page.
         When nrl_mode=True, uses NRL metadata layout (stored_image_uri) instead of
         nv-ingest nested content_metadata.
@@ -293,13 +281,13 @@ class VLM:
         system_text = (vlm_template.get("system") or "").strip()
         if incoming_system_text:
             system_text = (system_text + " " + incoming_system_text).strip()
-        system_message = SystemMessage(content=system_text)
+        system_message: MessageDict = {"role": "system", "content": system_text}
 
         # Count images already present in chat history to respect overall image budget
         existing_image_count = 0
         try:
             for msg in chat_history_messages:
-                parts = msg.content if isinstance(msg.content, list) else []
+                parts = msg["content"] if isinstance(msg.get("content"), list) else []
                 for p in parts:
                     if isinstance(p, dict) and p.get("type") == "image_url":
                         existing_image_count += 1
@@ -335,7 +323,10 @@ class VLM:
                     self._extract_images_from_docs(docs, remaining_image_budget)
                 )
 
-        citations_instruct_user_message = HumanMessage(content=content_parts)
+        citations_instruct_user_message: MessageDict = {
+            "role": "user",
+            "content": content_parts,
+        }
         return (system_message, citations_instruct_user_message, chat_history_messages)
 
     @staticmethod
@@ -360,7 +351,7 @@ class VLM:
                     one_line += "…"
                 snippet = one_line.replace('"', "'") if one_line else "(empty)"
                 logger.info(
-                    "  [VLM prompt structure] part %d: text(%d chars) \"%s\"",
+                    '  [VLM prompt structure] part %d: text(%d chars) "%s"',
                     i + 1,
                     n,
                     snippet,
@@ -370,6 +361,7 @@ class VLM:
             else:
                 logger.info("  [VLM prompt structure] part %d: ?", i + 1)
 
+    @trace_function("vlm.extract_images_from_docs")
     def _extract_images_from_docs(
         self,
         docs: list[Any],
@@ -389,19 +381,26 @@ class VLM:
             source_meta = metadata.get("source", {}) or {}
             source_id = (
                 source_meta.get("source_id", "")
-                or (source_meta.get("source_name", "") if isinstance(source_meta, dict) else "")
+                or (
+                    source_meta.get("source_name", "")
+                    if isinstance(source_meta, dict)
+                    else ""
+                )
                 if isinstance(source_meta, dict)
                 else ""
             )
             file_name = os.path.basename(str(source_id)) if source_id else ""
             page_number = content_md.get("page_number")
             location = content_md.get("location")
-            if not (collection_name and file_name and page_number is not None and location is not None):
+            if not (
+                collection_name
+                and file_name
+                and page_number is not None
+                and location is not None
+            ):
                 continue
             try:
-                source_location = doc.metadata.get("source").get(
-                            "source_location"
-                        )
+                source_location = doc.metadata.get("source").get("source_location")
                 if source_location:
                     raw_content = get_object_store_operator().get_object_from_uri(
                         source_location
@@ -412,16 +411,19 @@ class VLM:
                 if not content_b64:
                     continue
                 png_b64 = VLM._convert_image_url_to_png_b64(content_b64)
-                parts.append({
-                    "type": "image_url",
-                    "image_url": {"url": f"data:image/png;base64,{png_b64}"},
-                })
+                parts.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{png_b64}"},
+                    }
+                )
                 if remaining_image_budget is not None:
                     remaining_image_budget -= 1
             except Exception:
                 continue
         return parts
 
+    @trace_function("vlm.extract_images_from_docs_nrl")
     def _extract_images_from_docs_nrl(
         self,
         docs: list[Any],
@@ -449,10 +451,12 @@ class VLM:
                 if not content_b64:
                     continue
                 png_b64 = VLM._convert_image_url_to_png_b64(content_b64)
-                parts.append({
-                    "type": "image_url",
-                    "image_url": {"url": f"data:image/png;base64,{png_b64}"},
-                })
+                parts.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{png_b64}"},
+                    }
+                )
                 if remaining_image_budget is not None:
                     remaining_image_budget -= 1
             except Exception:
@@ -504,7 +508,9 @@ class VLM:
                 page_num = content_md.get("page_number")
                 source = meta.get("source", {})
                 source_path = (
-                    source.get("source_name", "") if isinstance(source, dict) else source
+                    source.get("source_name", "")
+                    if isinstance(source, dict)
+                    else source
                 )
                 source_key = str(source_path) if source_path else ""
 
@@ -520,7 +526,7 @@ class VLM:
                 grouped[k] = []
             grouped[k].append(doc)
 
-        for (source_key, page_num) in sorted(grouped.keys(), key=lambda x: (x[0], x[1])):
+        for source_key, page_num in sorted(grouped.keys(), key=lambda x: (x[0], x[1])):
             doc_list = grouped[(source_key, page_num)]
             text_parts: list[str] = []
             image_docs: list[Any] = []
@@ -534,23 +540,35 @@ class VLM:
                     if d_meta.get("stored_image_uri"):
                         image_docs.append(d)
                 else:
-                    content_md = (getattr(d, "metadata", {}) or {}).get("content_metadata", {}) or {}
+                    content_md = (getattr(d, "metadata", {}) or {}).get(
+                        "content_metadata", {}
+                    ) or {}
                     if content_md.get("type") in ["image", "structured"]:
                         image_docs.append(d)
                     else:
                         text_parts.append(getattr(d, "page_content", "") or "")
 
-            filename = os.path.splitext(os.path.basename(source_key))[0] if source_key else "unknown"
-            page_text = f"=== Page {page_num} ({filename}) ===\n" + "\n\n".join(p for p in text_parts if p)
+            filename = (
+                os.path.splitext(os.path.basename(source_key))[0]
+                if source_key
+                else "unknown"
+            )
+            page_text = f"=== Page {page_num} ({filename}) ===\n" + "\n\n".join(
+                p for p in text_parts if p
+            )
             if page_text.strip():
                 content_parts.append({"type": "text", "text": page_text})
             for img_doc in image_docs:
                 if remaining_image_budget is not None and remaining_image_budget <= 0:
                     break
                 if nrl_mode:
-                    img_parts = self._extract_images_from_docs_nrl([img_doc], remaining_image_budget)
+                    img_parts = self._extract_images_from_docs_nrl(
+                        [img_doc], remaining_image_budget
+                    )
                 else:
-                    img_parts = self._extract_images_from_docs([img_doc], remaining_image_budget)
+                    img_parts = self._extract_images_from_docs(
+                        [img_doc], remaining_image_budget
+                    )
                 content_parts.extend(img_parts)
                 if remaining_image_budget is not None and img_parts:
                     remaining_image_budget -= len(img_parts)
@@ -558,60 +576,56 @@ class VLM:
         if no_page:
             add_text = self._format_docs_text(no_page)
             if add_text.strip():
-                content_parts.append({
-                    "type": "text",
-                    "text": "=== Additional context ===\n" + add_text,
-                })
+                content_parts.append(
+                    {
+                        "type": "text",
+                        "text": "=== Additional context ===\n" + add_text,
+                    }
+                )
 
-        content_parts.append({
-            "type": "text",
-            "text": "\n\nUser Question:\n" + (question_text or "").strip(),
-        })
+        content_parts.append(
+            {
+                "type": "text",
+                "text": "\n\nUser Question:\n" + (question_text or "").strip(),
+            }
+        )
         return content_parts
 
     @staticmethod
     def assemble_messages(
-        system_message: SystemMessage,
-        citations_instruct_user_message: HumanMessage,
-        chat_history_messages: list[HumanMessage | AIMessage | SystemMessage],
-    ) -> list[HumanMessage | AIMessage | SystemMessage]:
+        system_message: MessageDict,
+        citations_instruct_user_message: MessageDict,
+        chat_history_messages: list[MessageDict],
+    ) -> list[MessageDict]:
         """Assemble final message list as [system] + [citations user] + chat history."""
         return [system_message, citations_instruct_user_message, *chat_history_messages]
 
     @staticmethod
+    @trace_function("vlm.invoke_model_async")
     async def invoke_model_async(
-        model: ChatOpenAI,
-        messages: list[HumanMessage | AIMessage | SystemMessage],
+        client: AsyncOpenAI,
+        model: str,
+        messages: list[MessageDict],
         *,
         temperature: float,
         top_p: float,
         max_tokens: int,
+        extra_body: dict[str, Any] | None = None,
     ) -> str:
         """Invoke the VLM model asynchronously and return the complete response string."""
         logger.info(
             f"Invoking VLM async with temperature={temperature}, top_p={top_p}, max_tokens={max_tokens}"
         )
-        result = await model.ainvoke(
-            messages, temperature=temperature, top_p=top_p, max_tokens=max_tokens
+        response = await client.chat.completions.create(
+            model=model,
+            messages=messages,
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_tokens,
+            extra_body=extra_body,
         )
-        return result.content.strip()
-
-    @staticmethod
-    def invoke_model(
-        model: ChatOpenAI,
-        messages: list[HumanMessage | AIMessage | SystemMessage],
-        *,
-        temperature: float,
-        top_p: float,
-        max_tokens: int,
-    ):
-        """Invoke the VLM model and return the complete response string."""
-        logger.info(
-            f"Invoking VLM with temperature={temperature}, top_p={top_p}, max_tokens={max_tokens}"
-        )
-        return model.invoke(
-            messages, temperature=temperature, top_p=top_p, max_tokens=max_tokens
-        ).content.strip()
+        content = response.choices[0].message.content if response.choices else ""
+        return (content or "").strip()
 
     @staticmethod
     def _convert_image_url_to_png_b64(image_url: str) -> str:
@@ -662,7 +676,7 @@ class VLM:
             return image_url
 
     def _redact_messages_for_logging(
-        self, messages: list[HumanMessage | AIMessage | SystemMessage]
+        self, messages: list[MessageDict]
     ) -> list[dict[str, Any]]:
         """
         Create a redacted, log-safe representation of the messages where any
@@ -670,18 +684,17 @@ class VLM:
         """
         safe: list[dict[str, Any]] = []
         for m in messages:
-            if isinstance(m, SystemMessage):
-                role = "system"
-            elif isinstance(m, AIMessage):
-                role = "assistant"
-            else:
-                role = "user"
-
-            raw_content = m.content
+            role = m.get("role", "user")
+            raw_content = m.get("content")
             parts = (
                 raw_content
                 if isinstance(raw_content, list)
-                else [{"type": "text", "text": str(raw_content)}]
+                else [
+                    {
+                        "type": "text",
+                        "text": str(raw_content) if raw_content is not None else "",
+                    }
+                ]
             )
 
             safe_parts: list[dict[str, Any]] = []
@@ -751,6 +764,7 @@ class VLM:
                     parts.append(content)
         return "\n\n".join(parts)
 
+    @trace_function("vlm.analyze_with_messages")
     async def analyze_with_messages(
         self,
         docs: list[Any],
@@ -770,21 +784,6 @@ class VLM:
         Send the full conversation messages to the VLM asynchronously, appending any relevant images
         from user messages and retrieved context. Ensures images are provided as
         base64 PNG data URLs.
-
-        Parameters
-        ----------
-        docs : List[Any]
-            Retrieved documents that may contain image thumbnails in storage.
-            Each item is expected to behave like a LangChain ``Document``
-            (i.e., exposing ``page_content`` and ``metadata`` attributes).
-        messages : List[dict]
-            Full conversation messages with roles and content. Content can be
-            a string or multimodal list with items of shape {type: text|image_url}.
-
-        Returns
-        -------
-        str
-            The VLM's response as a string, or an empty string on error.
         """
         if not isinstance(messages, list) or len(messages) == 0:
             logger.warning("No messages provided for VLM analysis.")
@@ -798,12 +797,13 @@ class VLM:
             max_total_images if max_total_images is not None else self.max_total_images
         )
 
-        vlm = self.init_model(
-            self.model_name,
+        client = self._create_async_client(
             self.invoke_url,
             api_key=self.config.vlm.get_api_key(),
-            enable_thinking=self.config.vlm.enable_thinking,
-            thinking_token_budget=self.config.vlm.thinking_token_budget,
+        )
+        extra_body = self._build_extra_body(
+            self.config.vlm.enable_thinking,
+            self.config.vlm.thinking_token_budget,
         )
 
         (
@@ -821,21 +821,23 @@ class VLM:
             nrl_mode=nrl_mode,
         )
 
-        lc_messages = self.assemble_messages(
+        all_messages = self.assemble_messages(
             system_message, citations_instruct_user_message, chat_history_messages
         )
 
         # Log final prompt with images redacted
-        safe_prompt = self._redact_messages_for_logging(lc_messages)
+        safe_prompt = self._redact_messages_for_logging(all_messages)
         logger.info("VLM final prompt (images redacted): %s", safe_prompt)
 
         try:
             vlm_response = await self.invoke_model_async(
-                vlm,
-                lc_messages,
+                client,
+                self.model_name,
+                all_messages,
                 temperature=eff_temperature,
                 top_p=eff_top_p,
                 max_tokens=eff_max_tokens,
+                extra_body=extra_body,
             )
             logger.info(f"VLM Response: {vlm_response}")
             return str(vlm_response or "")
@@ -887,117 +889,136 @@ class VLM:
             logger.warning("No messages provided for VLM streaming.")
             return
 
-        try:
-            # Resolve effective settings (function overrides > instance defaults)
-            eff_temperature = (
-                temperature if temperature is not None else self.temperature
-            )
-            eff_top_p = top_p if top_p is not None else self.top_p
-            eff_max_tokens = max_tokens if max_tokens is not None else self.max_tokens
-            eff_max_total_images = (
-                max_total_images
-                if max_total_images is not None
-                else self.max_total_images
-            )
+        # Wrap the entire streaming lifecycle in a single span; the `with`
+        # block stays open across `yield` points until the async generator is
+        # exhausted or closed by the caller.
+        with traced_span("vlm.stream_with_messages"):
+            try:
+                # Resolve effective settings (function overrides > instance defaults)
+                eff_temperature = (
+                    temperature if temperature is not None else self.temperature
+                )
+                eff_top_p = top_p if top_p is not None else self.top_p
+                eff_max_tokens = (
+                    max_tokens if max_tokens is not None else self.max_tokens
+                )
+                eff_max_total_images = (
+                    max_total_images
+                    if max_total_images is not None
+                    else self.max_total_images
+                )
 
-            vlm = self.init_model(
-                self.model_name,
-                self.invoke_url,
-                api_key=self.config.vlm.get_api_key(),
-                enable_thinking=self.config.vlm.enable_thinking,
-                thinking_token_budget=self.config.vlm.thinking_token_budget,
-            )
+                client = self._create_async_client(
+                    self.invoke_url,
+                    api_key=self.config.vlm.get_api_key(),
+                )
+                extra_body = self._build_extra_body(
+                    self.config.vlm.enable_thinking,
+                    self.config.vlm.thinking_token_budget,
+                )
 
-            (
-                system_message,
-                citations_instruct_user_message,
-                chat_history_messages,
-            ) = self.extract_and_process_messages(
-                self.vlm_template,
-                docs,
-                messages,
-                context_text,
-                question_text,
-                max_total_images=eff_max_total_images,
-                organize_by_page=organize_by_page,
-                nrl_mode=nrl_mode,
-            )
+                (
+                    system_message,
+                    citations_instruct_user_message,
+                    chat_history_messages,
+                ) = self.extract_and_process_messages(
+                    self.vlm_template,
+                    docs,
+                    messages,
+                    context_text,
+                    question_text,
+                    max_total_images=eff_max_total_images,
+                    organize_by_page=organize_by_page,
+                    nrl_mode=nrl_mode,
+                )
 
-            lc_messages = self.assemble_messages(
-                system_message, citations_instruct_user_message, chat_history_messages
-            )
+                all_messages = self.assemble_messages(
+                    system_message,
+                    citations_instruct_user_message,
+                    chat_history_messages,
+                )
 
-            # Log compact structure of what we send to VLM (no full text/images)
-            user_content = getattr(citations_instruct_user_message, "content", None)
-            if isinstance(user_content, list):
-                self._log_content_parts_structure(user_content)
-            # Log final prompt with images redacted
-            safe_prompt = self._redact_messages_for_logging(lc_messages)
-            logger.info("VLM final streaming prompt (images redacted): %s", safe_prompt)
+                # Log compact structure of what we send to VLM (no full text/images)
+                user_content = citations_instruct_user_message.get("content")
+                if isinstance(user_content, list):
+                    self._log_content_parts_structure(user_content)
+                # Log final prompt with images redacted
+                safe_prompt = self._redact_messages_for_logging(all_messages)
+                logger.info(
+                    "VLM final streaming prompt (images redacted): %s", safe_prompt
+                )
 
-            # Stream response chunks.
-            #
-            # nvidia/nemotron-3-nano-30b-a3b-omni-reasoning separates its output
-            # into two delta fields per chunk:
-            #   • chunk.additional_kwargs["reasoning"] — chain-of-thought tokens
-            #   • chunk.content                        — final answer tokens
-            #
-            # VLM_FILTER_THINK_TOKENS controls what reaches the client:
-            #   true  → forward only content (reasoning hidden, default)
-            #   false → forward reasoning first, then content (both visible)
-            filter_enabled = os.getenv("VLM_FILTER_THINK_TOKENS", "true").lower() == "true"
-            logger.info(
-                "VLM reasoning streaming: enable_thinking=%s filter=%s",
-                self.config.vlm.enable_thinking,
-                filter_enabled,
-            )
+                filter_enabled = (
+                    os.getenv("VLM_FILTER_THINK_TOKENS", "true").lower() == "true"
+                )
+                logger.info(
+                    "VLM reasoning streaming: enable_thinking=%s filter=%s",
+                    self.config.vlm.enable_thinking,
+                    filter_enabled,
+                )
 
-            chunk_count = 0
-            async for chunk in vlm.astream(
-                lc_messages,
-                temperature=eff_temperature,
-                top_p=eff_top_p,
-                max_tokens=eff_max_tokens,
-            ):
-                try:
-                    reasoning: str = (
-                        getattr(chunk, "additional_kwargs", {}).get("reasoning", "") or ""
-                    )
-                    content: str = getattr(chunk, "content", "") or ""
+                stream = await client.chat.completions.create(
+                    model=self.model_name,
+                    messages=all_messages,
+                    temperature=eff_temperature,
+                    top_p=eff_top_p,
+                    max_tokens=eff_max_tokens,
+                    stream=True,
+                    extra_body=extra_body,
+                )
 
-                    if filter_enabled:
-                        # Only the final answer reaches the client
-                        if content:
-                            yield content
-                    else:
-                        # Both reasoning trace and final answer reach the client
-                        if reasoning:
-                            yield reasoning
-                        if content:
-                            yield content
-                except Exception as e:
-                    logger.debug(
-                        "Skipping malformed VLM stream chunk at index %s: %r; error: %s",
-                        chunk_count,
-                        chunk,
-                        e,
-                        exc_info=True,
-                    )
-                chunk_count += 1
+                chunk_count = 0
+                async for chunk in stream:
+                    try:
+                        if not chunk.choices:
+                            chunk_count += 1
+                            continue
+                        delta = chunk.choices[0].delta
+                        # Different OpenAI-compatible reasoning models emit the
+                        # chain-of-thought under different keys. Read both.
+                        reasoning: str = (
+                            getattr(delta, "reasoning", None)
+                            or getattr(delta, "reasoning_content", None)
+                            or ""
+                        )
+                        content: str = getattr(delta, "content", None) or ""
 
-            logger.info("VLM streaming processed %d chunks", chunk_count)
-        except Exception as e:
-            error_type = type(e).__name__
-            if (
-                "Connection" in error_type
-                or "Connect" in error_type
-                or isinstance(e, ConnectionError | OSError)
-            ):
-                vlm_url = self.invoke_url or "VLM service"
-                error_msg = f"VLM NIM unavailable at {vlm_url}. Please verify the service is running and accessible."
-                logger.exception("Connection error in VLM streaming: %s", e)
-                raise APIError(error_msg, ErrorCodeMapping.SERVICE_UNAVAILABLE) from e
-            logger.warning(
-                f"Exception during VLM streaming call with messages: {e}", exc_info=True
-            )
-            return
+                        if filter_enabled:
+                            # Only the final answer reaches the client
+                            if content:
+                                yield content
+                        else:
+                            # Both reasoning trace and final answer reach the client
+                            if reasoning:
+                                yield reasoning
+                            if content:
+                                yield content
+                    except Exception as e:
+                        logger.debug(
+                            "Skipping malformed VLM stream chunk at index %s: %r; error: %s",
+                            chunk_count,
+                            chunk,
+                            e,
+                            exc_info=True,
+                        )
+                    chunk_count += 1
+
+                logger.info("VLM streaming processed %d chunks", chunk_count)
+            except Exception as e:
+                error_type = type(e).__name__
+                if (
+                    "Connection" in error_type
+                    or "Connect" in error_type
+                    or isinstance(e, ConnectionError | OSError)
+                ):
+                    vlm_url = self.invoke_url or "VLM service"
+                    error_msg = f"VLM NIM unavailable at {vlm_url}. Please verify the service is running and accessible."
+                    logger.exception("Connection error in VLM streaming: %s", e)
+                    raise APIError(
+                        error_msg, ErrorCodeMapping.SERVICE_UNAVAILABLE
+                    ) from e
+                logger.warning(
+                    f"Exception during VLM streaming call with messages: {e}",
+                    exc_info=True,
+                )
+                return

--- a/src/nvidia_rag/utils/configuration.py
+++ b/src/nvidia_rag/utils/configuration.py
@@ -372,7 +372,7 @@ class NvIngestConfig(_ConfigBase):
         description="Number of overlapping tokens between chunks",
     )
     caption_model_name: str = Field(
-        default="nvidia/nemotron-nano-12b-v2-vl",
+        default="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
         env="APP_NVINGEST_CAPTIONMODELNAME",
         description="Model name for generating image captions",
     )
@@ -953,7 +953,7 @@ class VLMConfig(_ConfigBase):
         description="URL endpoint for Vision-Language Model service",
     )
     model_name: str = Field(
-        default="nvidia/nemotron-nano-12b-v2-vl",
+        default="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
         env="APP_VLM_MODELNAME",
         description="Vision-Language Model for processing images and text",
     )
@@ -976,6 +976,23 @@ class VLMConfig(_ConfigBase):
         default=5,
         env="APP_VLM_MAX_TOTAL_IMAGES",
         description="Maximum total images sent to VLM per request (query + context)",
+    )
+    enable_thinking: bool = Field(
+        default=True,
+        env="APP_VLM_ENABLE_THINKING",
+        description=(
+            "Enable reasoning mode for the VLM (nvidia/nemotron-3-nano-omni-30b-a3b-reasoning). "
+            "When True the model separates chain-of-thought into the 'reasoning' field and the "
+            "final answer into 'content'. Set False to skip reasoning entirely."
+        ),
+    )
+    thinking_token_budget: int = Field(
+        default=0,
+        env="APP_VLM_THINKING_TOKEN_BUDGET",
+        description=(
+            "Maximum tokens the VLM may use for reasoning (0 = no budget cap). "
+            "Only applied when enable_thinking is True."
+        ),
     )
     api_key: SecretStr | None = Field(
         default=None,

--- a/src/nvidia_rag/utils/configuration.py
+++ b/src/nvidia_rag/utils/configuration.py
@@ -994,6 +994,16 @@ class VLMConfig(_ConfigBase):
             "Only applied when enable_thinking is True."
         ),
     )
+    filter_think_tokens: bool = Field(
+        default=True,
+        env="VLM_FILTER_THINK_TOKENS",
+        description=(
+            "When True (default) the rag-server forwards only the final answer "
+            "to the client; the VLM's reasoning trace is suppressed. When False, "
+            "reasoning is streamed first wrapped in [reasoning]...[/reasoning] "
+            "sentinels, followed by the answer."
+        ),
+    )
     api_key: SecretStr | None = Field(
         default=None,
         env="APP_VLM_APIKEY",

--- a/tests/unit/test_rag_server/test_vlm.py
+++ b/tests/unit/test_rag_server/test_vlm.py
@@ -303,9 +303,8 @@ class TestVLM:
 
     @pytest.mark.asyncio
     async def test_stream_with_messages_yields_content_only_when_filter_enabled(
-        self, monkeypatch
+        self,
     ):
-        monkeypatch.setenv("VLM_FILTER_THINK_TOKENS", "true")
         system_message = {"role": "system", "content": "sys"}
         user_message = {"role": "user", "content": [{"type": "text", "text": "ctx"}]}
 
@@ -361,6 +360,7 @@ class TestVLM:
         ):
             self.mock_config.vlm.enable_thinking = True
             self.mock_config.vlm.thinking_token_budget = 0
+            self.mock_config.vlm.filter_think_tokens = True
             self.mock_config.vlm.get_api_key.return_value = None
 
             chunks = []
@@ -375,9 +375,8 @@ class TestVLM:
 
     @pytest.mark.asyncio
     async def test_stream_with_messages_yields_reasoning_when_filter_disabled(
-        self, monkeypatch
+        self,
     ):
-        monkeypatch.setenv("VLM_FILTER_THINK_TOKENS", "false")
         system_message = {"role": "system", "content": "sys"}
         user_message = {"role": "user", "content": [{"type": "text", "text": "ctx"}]}
 
@@ -421,6 +420,7 @@ class TestVLM:
         ):
             self.mock_config.vlm.enable_thinking = True
             self.mock_config.vlm.thinking_token_budget = 0
+            self.mock_config.vlm.filter_think_tokens = False
             self.mock_config.vlm.get_api_key.return_value = None
 
             chunks = []
@@ -430,7 +430,9 @@ class TestVLM:
             ):
                 chunks.append(chunk)
 
-        assert chunks == ["step1", "answer"]
+        # Reasoning is wrapped in [reasoning]...[/reasoning] sentinels so clients
+        # can structurally separate chain-of-thought from the final answer.
+        assert chunks == ["[reasoning]", "step1", "[/reasoning]", "answer"]
 
     @pytest.mark.asyncio
     async def test_stream_with_messages_returns_early_without_messages(self):

--- a/tests/unit/test_rag_server/test_vlm.py
+++ b/tests/unit/test_rag_server/test_vlm.py
@@ -19,14 +19,12 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
-from PIL import Image as PILImage
-
 from nvidia_rag.rag_server.vlm import VLM
+from PIL import Image as PILImage
 
 
 class TestVLM:
-    """Unit tests for the updated VLM helper."""
+    """Unit tests for the VLM helper (native OpenAI SDK implementation)."""
 
     def setup_method(self):
         self.vlm_model = "test-model"
@@ -73,6 +71,21 @@ class TestVLM:
         ):
             VLM("", self.vlm_endpoint, config=self.mock_config)
 
+    def test_build_extra_body_includes_thinking_budget_when_enabled(self):
+        body = VLM._build_extra_body(enable_thinking=True, thinking_token_budget=128)
+        assert body == {
+            "chat_template_kwargs": {"enable_thinking": True},
+            "thinking_token_budget": 128,
+        }
+
+    def test_build_extra_body_omits_thinking_budget_when_disabled(self):
+        body = VLM._build_extra_body(enable_thinking=False, thinking_token_budget=512)
+        assert body == {"chat_template_kwargs": {"enable_thinking": False}}
+
+    def test_build_extra_body_omits_zero_budget(self):
+        body = VLM._build_extra_body(enable_thinking=True, thinking_token_budget=0)
+        assert body == {"chat_template_kwargs": {"enable_thinking": True}}
+
     def test_normalize_messages_converts_images_and_accumulates_system_text(self):
         with patch.object(
             VLM, "_convert_image_url_to_png_b64", return_value="converted"
@@ -91,12 +104,13 @@ class TestVLM:
                 ]
             )
 
-        assert isinstance(messages[0], HumanMessage)
+        assert messages[0]["role"] == "user"
         assert last_idx == 0
         assert system_text == "sys notice"
-        image_part = messages[0].content[1]
+        image_part = messages[0]["content"][1]
         assert image_part["type"] == "image_url"
         assert image_part["image_url"]["url"] == "data:image/png;base64,converted"
+        assert messages[1] == {"role": "assistant", "content": "hi"}
 
     def test_extract_and_process_messages_attaches_doc_images(self):
         mock_object_store = MagicMock()
@@ -130,10 +144,11 @@ class TestVLM:
                 max_total_images=4,
             )
 
-        assert isinstance(system_msg, SystemMessage)
+        assert system_msg["role"] == "system"
         assert history
-        assert len(user_msg.content) == 2
-        assert user_msg.content[1]["type"] == "image_url"
+        assert user_msg["role"] == "user"
+        assert len(user_msg["content"]) == 2
+        assert user_msg["content"][1]["type"] == "image_url"
 
     def test_extract_and_process_messages_respects_image_budget(self):
         existing_image = {
@@ -157,24 +172,26 @@ class TestVLM:
             max_total_images=1,
         )
 
-        assert isinstance(system_msg, SystemMessage)
-        assert len(user_msg.content) == 1  # only text; no room for doc images
+        assert system_msg["role"] == "system"
+        assert len(user_msg["content"]) == 1  # only text; no room for doc images
 
     @pytest.mark.asyncio
     async def test_analyze_with_messages_invokes_model(self):
-        system_message = SystemMessage(content="sys")
-        user_message = HumanMessage(content=[{"type": "text", "text": "ctx"}])
-        history = [HumanMessage(content=[{"type": "text", "text": "prev"}])]
+        system_message = {"role": "system", "content": "sys"}
+        user_message = {"role": "user", "content": [{"type": "text", "text": "ctx"}]}
+        history = [{"role": "user", "content": [{"type": "text", "text": "prev"}]}]
 
         with (
-            patch.object(VLM, "init_model") as mock_init_model,
+            patch.object(VLM, "_create_async_client") as mock_create_client,
             patch.object(
                 VLM,
                 "extract_and_process_messages",
                 return_value=(system_message, user_message, history),
             ),
             patch.object(
-                VLM, "assemble_messages", return_value=[system_message, user_message]
+                VLM,
+                "assemble_messages",
+                return_value=[system_message, user_message],
             ) as mock_assemble,
             patch.object(VLM, "_redact_messages_for_logging"),
             patch.object(
@@ -184,6 +201,10 @@ class TestVLM:
                 return_value="final-response",
             ) as mock_invoke,
         ):
+            self.mock_config.vlm.enable_thinking = True
+            self.mock_config.vlm.thinking_token_budget = 0
+            self.mock_config.vlm.get_api_key.return_value = None
+
             response = await self.vlm.analyze_with_messages(
                 docs=[],
                 messages=[{"role": "user", "content": "question"}],
@@ -193,38 +214,42 @@ class TestVLM:
             )
 
         assert response == "final-response"
-        mock_init_model.assert_called_once()
+        mock_create_client.assert_called_once()
         mock_assemble.assert_called_once()
         mock_invoke.assert_called_once_with(
-            mock_init_model.return_value,
+            mock_create_client.return_value,
+            self.vlm_model,
             [system_message, user_message],
             temperature=0.2,
             top_p=0.9,
             max_tokens=128,
+            extra_body={"chat_template_kwargs": {"enable_thinking": True}},
         )
 
     @pytest.mark.asyncio
     async def test_analyze_with_messages_returns_empty_without_messages(self):
-        with patch.object(VLM, "init_model") as mock_init_model:
+        with patch.object(VLM, "_create_async_client") as mock_create_client:
             response = await self.vlm.analyze_with_messages(docs=[], messages=[])
 
         assert response == ""
-        mock_init_model.assert_not_called()
+        mock_create_client.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_analyze_with_messages_logs_exception_and_returns_empty(self):
-        system_message = SystemMessage(content="sys")
-        user_message = HumanMessage(content=[{"type": "text", "text": "ctx"}])
+        system_message = {"role": "system", "content": "sys"}
+        user_message = {"role": "user", "content": [{"type": "text", "text": "ctx"}]}
 
         with (
-            patch.object(VLM, "init_model"),
+            patch.object(VLM, "_create_async_client"),
             patch.object(
                 VLM,
                 "extract_and_process_messages",
                 return_value=(system_message, user_message, []),
             ),
             patch.object(
-                VLM, "assemble_messages", return_value=[system_message, user_message]
+                VLM,
+                "assemble_messages",
+                return_value=[system_message, user_message],
             ),
             patch.object(VLM, "_redact_messages_for_logging"),
             patch.object(
@@ -234,6 +259,10 @@ class TestVLM:
                 side_effect=RuntimeError("boom"),
             ),
         ):
+            self.mock_config.vlm.enable_thinking = False
+            self.mock_config.vlm.thinking_token_budget = 0
+            self.mock_config.vlm.get_api_key.return_value = None
+
             response = await self.vlm.analyze_with_messages(
                 docs=[], messages=[{"role": "user", "content": "hi"}]
             )
@@ -241,47 +270,177 @@ class TestVLM:
         assert response == ""
 
     @pytest.mark.asyncio
-    async def test_stream_with_messages_yields_chunks(self):
-        system_message = SystemMessage(content="sys")
-        user_message = HumanMessage(content=[{"type": "text", "text": "ctx"}])
-        mock_model = Mock()
+    async def test_invoke_model_async_returns_stripped_content(self):
+        mock_client = MagicMock()
+        completion = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="  hello  "))]
+        )
+        mock_client.chat = SimpleNamespace(
+            completions=SimpleNamespace(
+                create=AsyncMock(return_value=completion),
+            )
+        )
 
-        async def mock_astream(*args, **kwargs):
-            yield SimpleNamespace(content="Hello")
-            yield SimpleNamespace(content="")
-            yield SimpleNamespace(content="World")
+        result = await VLM.invoke_model_async(
+            mock_client,
+            "test-model",
+            [{"role": "user", "content": "hi"}],
+            temperature=0.1,
+            top_p=0.9,
+            max_tokens=64,
+            extra_body={"chat_template_kwargs": {"enable_thinking": True}},
+        )
 
-        mock_model.astream = mock_astream
+        assert result == "hello"
+        mock_client.chat.completions.create.assert_awaited_once_with(
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=0.1,
+            top_p=0.9,
+            max_tokens=64,
+            extra_body={"chat_template_kwargs": {"enable_thinking": True}},
+        )
+
+    @pytest.mark.asyncio
+    async def test_stream_with_messages_yields_content_only_when_filter_enabled(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("VLM_FILTER_THINK_TOKENS", "true")
+        system_message = {"role": "system", "content": "sys"}
+        user_message = {"role": "user", "content": [{"type": "text", "text": "ctx"}]}
+
+        async def fake_stream():
+            # Reasoning-only chunk should be hidden when filter is on.
+            yield SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content=None, reasoning="thinking…")
+                    )
+                ]
+            )
+            yield SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content="Hello", reasoning=None)
+                    )
+                ]
+            )
+            yield SimpleNamespace(
+                choices=[
+                    SimpleNamespace(delta=SimpleNamespace(content="", reasoning=None))
+                ]
+            )
+            yield SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content="World", reasoning=None)
+                    )
+                ]
+            )
+
+        mock_client = MagicMock()
+        mock_client.chat = SimpleNamespace(
+            completions=SimpleNamespace(
+                create=AsyncMock(return_value=fake_stream()),
+            )
+        )
 
         with (
-            patch.object(VLM, "init_model", return_value=mock_model),
+            patch.object(VLM, "_create_async_client", return_value=mock_client),
             patch.object(
                 VLM,
                 "extract_and_process_messages",
                 return_value=(system_message, user_message, []),
             ),
             patch.object(
-                VLM, "assemble_messages", return_value=[system_message, user_message]
+                VLM,
+                "assemble_messages",
+                return_value=[system_message, user_message],
             ),
             patch.object(VLM, "_redact_messages_for_logging"),
         ):
+            self.mock_config.vlm.enable_thinking = True
+            self.mock_config.vlm.thinking_token_budget = 0
+            self.mock_config.vlm.get_api_key.return_value = None
+
             chunks = []
             async for chunk in self.vlm.stream_with_messages(
-                docs=[], messages=[{"role": "user", "content": "hi"}], temperature=0.1
+                docs=[],
+                messages=[{"role": "user", "content": "hi"}],
+                temperature=0.1,
             ):
                 chunks.append(chunk)
 
         assert chunks == ["Hello", "World"]
 
     @pytest.mark.asyncio
+    async def test_stream_with_messages_yields_reasoning_when_filter_disabled(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("VLM_FILTER_THINK_TOKENS", "false")
+        system_message = {"role": "system", "content": "sys"}
+        user_message = {"role": "user", "content": [{"type": "text", "text": "ctx"}]}
+
+        async def fake_stream():
+            # Use reasoning_content (alternate field name) to confirm fallback.
+            yield SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content=None, reasoning_content="step1")
+                    )
+                ]
+            )
+            yield SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content="answer", reasoning_content=None)
+                    )
+                ]
+            )
+
+        mock_client = MagicMock()
+        mock_client.chat = SimpleNamespace(
+            completions=SimpleNamespace(
+                create=AsyncMock(return_value=fake_stream()),
+            )
+        )
+
+        with (
+            patch.object(VLM, "_create_async_client", return_value=mock_client),
+            patch.object(
+                VLM,
+                "extract_and_process_messages",
+                return_value=(system_message, user_message, []),
+            ),
+            patch.object(
+                VLM,
+                "assemble_messages",
+                return_value=[system_message, user_message],
+            ),
+            patch.object(VLM, "_redact_messages_for_logging"),
+        ):
+            self.mock_config.vlm.enable_thinking = True
+            self.mock_config.vlm.thinking_token_budget = 0
+            self.mock_config.vlm.get_api_key.return_value = None
+
+            chunks = []
+            async for chunk in self.vlm.stream_with_messages(
+                docs=[],
+                messages=[{"role": "user", "content": "hi"}],
+            ):
+                chunks.append(chunk)
+
+        assert chunks == ["step1", "answer"]
+
+    @pytest.mark.asyncio
     async def test_stream_with_messages_returns_early_without_messages(self):
-        with patch.object(VLM, "init_model") as mock_init_model:
+        with patch.object(VLM, "_create_async_client") as mock_create_client:
             chunks = []
             async for chunk in self.vlm.stream_with_messages(docs=[], messages=[]):
                 chunks.append(chunk)
 
         assert chunks == []
-        mock_init_model.assert_not_called()
+        mock_create_client.assert_not_called()
 
     def test_convert_image_url_to_png_b64_data_url(self):
         test_image = self.create_test_image_b64()
@@ -297,18 +456,19 @@ class TestVLM:
 
     def test_redact_messages_for_logging_masks_base64(self):
         messages = [
-            SystemMessage(content="sys"),
-            HumanMessage(
-                content=[
+            {"role": "system", "content": "sys"},
+            {
+                "role": "user",
+                "content": [
                     {
                         "type": "image_url",
                         "image_url": {
                             "url": f"data:image/png;base64,{self.create_test_image_b64()}"
                         },
                     }
-                ]
-            ),
-            AIMessage(content="done"),
+                ],
+            },
+            {"role": "assistant", "content": "done"},
         ]
 
         redacted = self.vlm._redact_messages_for_logging(messages)

--- a/tests/unit/test_utils/test_configuration.py
+++ b/tests/unit/test_utils/test_configuration.py
@@ -362,7 +362,7 @@ class TestNvIngestConfig:
         assert config.tokenizer == "intfloat/e5-large-unsupervised"
         assert config.chunk_size == 1024
         assert config.chunk_overlap == 150
-        assert config.caption_model_name == "nvidia/nemotron-nano-12b-v2-vl"
+        assert config.caption_model_name == "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
         assert (
             config.caption_endpoint_url
             == "https://integrate.api.nvidia.com/v1/chat/completions"

--- a/uv.lock
+++ b/uv.lock
@@ -1760,6 +1760,7 @@ all = [
     { name = "langchain-openai" },
     { name = "nv-ingest-api" },
     { name = "nv-ingest-client" },
+    { name = "openai" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-exporter-prometheus" },
@@ -1782,6 +1783,7 @@ ingest = [
     { name = "langchain-openai" },
     { name = "nv-ingest-api" },
     { name = "nv-ingest-client" },
+    { name = "openai" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-exporter-prometheus" },
@@ -1800,6 +1802,7 @@ rag = [
     { name = "azure-core" },
     { name = "azure-storage-blob" },
     { name = "langchain-openai" },
+    { name = "openai" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-exporter-prometheus" },
@@ -1858,6 +1861,9 @@ requires-dist = [
     { name = "nv-ingest-api", marker = "extra == 'ingest'", specifier = "==26.3.0" },
     { name = "nv-ingest-client", marker = "extra == 'all'", specifier = "==26.3.0" },
     { name = "nv-ingest-client", marker = "extra == 'ingest'", specifier = "==26.3.0" },
+    { name = "openai", marker = "extra == 'all'", specifier = ">=1.0,<2.0" },
+    { name = "openai", marker = "extra == 'ingest'", specifier = ">=1.0,<2.0" },
+    { name = "openai", marker = "extra == 'rag'", specifier = ">=1.0,<2.0" },
     { name = "opentelemetry-api", marker = "extra == 'all'", specifier = ">=1.29,<2.0" },
     { name = "opentelemetry-api", marker = "extra == 'ingest'", specifier = ">=1.29,<2.0" },
     { name = "opentelemetry-api", marker = "extra == 'rag'", specifier = ">=1.29,<2.0" },
@@ -1967,7 +1973,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.15.0"
+version = "1.109.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1979,9 +1985,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/94/f4/4690ecb5d70023ce6bfcfeabfe717020f654bde59a775058ec6ac4692463/openai-2.15.0.tar.gz", hash = "sha256:42eb8cbb407d84770633f31bf727d4ffb4138711c670565a41663d9439174fba", size = 627383, upload-time = "2026-01-09T22:10:08.603Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/a1/a303104dc55fc546a3f6914c842d3da471c64eec92043aef8f652eb6c524/openai-1.109.1.tar.gz", hash = "sha256:d173ed8dbca665892a6db099b4a2dfac624f94d20a93f46eb0b56aae940ed869", size = 564133, upload-time = "2025-09-24T13:00:53.075Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/df/c306f7375d42bafb379934c2df4c2fa3964656c8c782bac75ee10c102818/openai-2.15.0-py3-none-any.whl", hash = "sha256:6ae23b932cd7230f7244e52954daa6602716d6b9bf235401a107af731baea6c3", size = 1067879, upload-time = "2026-01-09T22:10:06.446Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/2a/7dd3d207ec669cacc1f186fd856a0f61dbc255d24f6fdc1a6715d6051b0f/openai-1.109.1-py3-none-any.whl", hash = "sha256:6bcaf57086cf59159b8e27447e4e7dd019db5d29a438072fbd49c290c7e65315", size = 948627, upload-time = "2025-09-24T13:00:50.754Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Switch VLM from nemotron-nano-12b-v2-vl to Nemotron Omni GA image (nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:1.7.0-variant)
- Update all documentation references from nemotron-nano-12b-v2-vl to Nemotron Omni; add section in change-model.md for switching back to Nemotron Nano 12B VLM
- Update Helm values.yaml with Nemotron Omni image and model names


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded default Vision‑Language Model to a reasoning-capable Nemotron variant.
  * Added thinking-mode controls: enable/disable thinking, token budget, and reasoning-token filtering.

* **Behavior Changes**
  * VLM generation defaults adjusted (max tokens, temperature, top-p) and memory use increased for the VLM service.
  * Multimodal answer behavior tightened to prefer input evidence and avoid fabrication.

* **Documentation**
  * Updated VLM, image-captioning, and multimodal query guides; added rollback instructions.

* **Tests / Chores**
  * Unit tests aligned to new VLM message format; dependency pins updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->