### PR TITLE
Added Streaming support in Agentic RAG

### DIFF
--- a/docs/api_reference/openapi_schema_rag_server.json
+++ b/docs/api_reference/openapi_schema_rag_server.json
@@ -372,6 +372,30 @@
             ],
             "description": "Latency metrics associated with the request",
             "default": {}
+          },
+          "event_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Event Type",
+            "description": "Type of streaming chunk. None for non-streaming and for the regular (non-agentic) path's content chunks. Set for agentic-RAG streaming chunks; see ``nvidia_rag.rag_server.agentic_rag.streaming.EventType`` for the enumerated values (e.g. ``stage_start``, ``stage_end``, ``intermediate_reasoning``, ``intermediate_output``, ``final_reasoning``, ``final_answer``, ``agent_event``, ``error``)."
+          },
+          "stage": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage",
+            "description": "Name of the agentic-RAG graph node that produced this chunk (e.g. ``initial_retrieval``, ``plan``, ``execute``, ``synthesize``, ``verify``, ``verify_execute``). Pairs with ``event_type`` so clients can group reasoning by pipeline stage without parsing event_type. None for non-agentic responses."
           }
         },
         "type": "object",
@@ -870,6 +894,18 @@
             "title": "Content",
             "description": "The input query/prompt to the pipeline. Can be a string for text-only messages, or an array of content objects for multimodal messages containing text and/or images.",
             "default": "Hello! What can you help me with?"
+          },
+          "reasoning_content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reasoning Content",
+            "description": "Reasoning trace or intermediate output from the agentic RAG pipeline. Populated for streamed chunks whose ``event_type`` indicates a reasoning/intermediate event (stage announcements, intermediate-stage reasoning or output tokens, final-stage reasoning tokens). The user-facing answer is always streamed via ``content`` — this field is purely supplementary."
           }
         },
         "type": "object",
@@ -911,6 +947,18 @@
             "title": "Content",
             "description": "The input query/prompt to the pipeline. Can be a string for text-only messages, or an array of content objects for multimodal messages containing text and/or images.",
             "default": "Hello! What can you help me with?"
+          },
+          "reasoning_content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reasoning Content",
+            "description": "Reasoning trace or intermediate output from the agentic RAG pipeline. Populated for streamed chunks whose ``event_type`` indicates a reasoning/intermediate event (stage announcements, intermediate-stage reasoning or output tokens, final-stage reasoning tokens). The user-facing answer is always streamed via ``content`` — this field is purely supplementary."
           }
         },
         "type": "object",
@@ -1120,19 +1168,33 @@
             "default": true
           },
           "temperature": {
-            "type": "number",
-            "maximum": 1,
-            "minimum": 0,
+            "anyOf": [
+              {
+                "type": "number",
+                "maximum": 1,
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Temperature",
-            "description": "The sampling temperature to use for text generation. The higher the temperature value is, the less deterministic the output text will be. It is not recommended to modify both temperature and top_p in the same call.",
+            "description": "The sampling temperature to use for text generation. The higher the temperature value is, the less deterministic the output text will be. If unset, the model/provider default is used. It is not recommended to modify both temperature and top_p in the same call.",
             "default": 0
           },
           "top_p": {
-            "type": "number",
-            "maximum": 1,
-            "minimum": 0.1,
+            "anyOf": [
+              {
+                "type": "number",
+                "maximum": 1,
+                "minimum": 0.1
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Top P",
-            "description": "The top-p sampling mass used for text generation. The top-p value determines the probability mass that is sampled at sampling time. For example, if top_p = 0.2, only the most likely tokens (summing to 0.2 cumulative probability) will be sampled. It is not recommended to modify both temperature and top_p in the same call.",
+            "description": "The top-p sampling mass used for text generation. The top-p value determines the probability mass that is sampled at sampling time. For example, if top_p = 0.2, only the most likely tokens (summing to 0.2 cumulative probability) will be sampled. If unset, the model/provider default is used. It is not recommended to modify both temperature and top_p in the same call.",
             "default": 1
           },
           "min_tokens": {
@@ -1154,7 +1216,7 @@
             "format": "int64",
             "title": "Max Tokens",
             "description": "The maximum number of tokens to generate in any given call. Note that the model is not aware of this value,  and generation will simply stop at the number of tokens specified.",
-            "default": 128000
+            "default": 16256
           },
           "min_thinking_tokens": {
             "type": "integer",
@@ -1413,6 +1475,12 @@
             "title": "Agentic",
             "description": "Route this request through the agentic RAG pipeline (LangGraph plan-and-execute). When None (default), the server-level CONFIG.enable_agentic_rag config value is used. Explicitly passing True or False overrides the server default for this request.",
             "default": false
+          },
+          "enable_streaming": {
+            "type": "boolean",
+            "title": "Enable Streaming",
+            "description": "Stream intermediate reasoning, stage announcements, and final-answer tokens as they are produced. Currently honored by the agentic RAG pipeline; the regular (non-agentic) pipeline always streams. When False on the agentic path, the graph runs to completion and the full answer is returned as a single SSE chunk (legacy behavior).",
+            "default": true
           }
         },
         "type": "object",
@@ -1460,12 +1528,26 @@
       "RagConfigurationDefaults": {
         "properties": {
           "temperature": {
-            "type": "number",
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Temperature",
             "description": "Default sampling temperature for generation"
           },
           "top_p": {
-            "type": "number",
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Top P",
             "description": "Default top-p sampling mass"
           },

--- a/src/nvidia_rag/rag_server/agentic_rag/agentic_rag.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/agentic_rag.py
@@ -48,7 +48,9 @@ from typing import Any
 
 from langchain_core.language_models import BaseChatModel
 from langchain_core.prompts.chat import ChatPromptTemplate
+from langchain_core.runnables import RunnableConfig
 from langgraph.graph import END, StateGraph
+from langgraph.types import StreamWriter
 from opentelemetry import trace as otel_trace
 from pydantic import BaseModel, Field
 
@@ -297,6 +299,56 @@ class AgenticRag:
             i += 1
         return "".join(out)
 
+    @staticmethod
+    async def _accumulate_astream(
+        chain: Any,
+        inputs: dict[str, Any],
+        config: RunnableConfig,
+        progress: dict[str, Any],
+    ) -> tuple[str, str, dict[str, int] | None]:
+        """Run ``chain.astream(inputs, config=config)`` to completion and
+        return ``(content, reasoning, usage)``.
+
+        ``progress`` is a caller-owned dict used as a mutable holder so the
+        caller can detect partial progress on TimeoutError (where
+        ``asyncio.wait_for`` cancels this coroutine).  Keys mutated here:
+
+        * ``"first_chunk_emitted"`` — flipped to ``True`` once any chunk has
+          arrived, so the retry loop can suppress mid-stream retries.
+
+        Pulled out as a helper so the calling code in ``_call_llm`` doesn't
+        define a closure inside a retry loop (Ruff B023).
+        """
+        content_parts: list[str] = []
+        reasoning_parts: list[str] = []
+        latest_usage: dict[str, int] | None = None
+
+        async for chunk in chain.astream(inputs, config=config):
+            progress["first_chunk_emitted"] = True
+            delta = getattr(chunk, "content", "") or ""
+            if delta and not isinstance(delta, str):
+                delta = str(delta)
+            if delta:
+                content_parts.append(delta)
+            kw = getattr(chunk, "additional_kwargs", None) or {}
+            rd = kw.get("reasoning_content")
+            if rd:
+                reasoning_parts.append(rd if isinstance(rd, str) else str(rd))
+            cu = getattr(chunk, "usage_metadata", None)
+            if cu:
+                if isinstance(cu, dict):
+                    latest_usage = {
+                        "input_tokens": cu.get("input_tokens", 0) or 0,
+                        "output_tokens": cu.get("output_tokens", 0) or 0,
+                    }
+                else:
+                    latest_usage = {
+                        "input_tokens": getattr(cu, "input_tokens", 0) or 0,
+                        "output_tokens": getattr(cu, "output_tokens", 0) or 0,
+                    }
+
+        return "".join(content_parts), "".join(reasoning_parts), latest_usage
+
     async def _call_llm(
         self,
         llm: BaseChatModel,
@@ -304,32 +356,75 @@ class AgenticRag:
         inputs: dict[str, Any],
         step_name: str = "LLM Call",
         json_mode: bool = False,
+        config: RunnableConfig | None = None,
     ) -> str:
+        """Invoke an LLM chain with retry/timeout/rate-limit semantics.
+
+        When ``config`` is provided, the call uses ``chain.astream(...)`` so that
+        token chunks propagate to LangGraph's ``stream_mode="messages"`` channel
+        (so the streaming translator can forward them to the client).  Tokens
+        are accumulated and the full visible content is returned, matching the
+        legacy ``ainvoke`` contract.  Mid-stream retries are deliberately
+        suppressed: once a chunk has been emitted, the client has already seen
+        partial output and re-streaming would duplicate it.
+
+        When ``config`` is None, behaviour is identical to the legacy
+        ``ainvoke``-based implementation (preserves the non-streaming path).
+        """
         from nvidia_rag.rag_server.agentic_rag.tracing import get_current_trace
 
         if json_mode:
-            model_name = getattr(llm, "model_name", "") or getattr(llm, "model", "") or ""
-            if not any(kw in model_name.lower() for kw in ("claude", "anthropic", "gpt", "gemini")):
+            model_name = (
+                getattr(llm, "model_name", "") or getattr(llm, "model", "") or ""
+            )
+            if not any(
+                kw in model_name.lower()
+                for kw in ("claude", "anthropic", "gpt", "gemini")
+            ):
                 llm = llm.bind(response_format={"type": "json_object"})
 
         chain = prompt | llm
         max_retries = self.llm_cfg.max_retries
         llm_timeout = self.llm_cfg.call_timeout
+        streaming = config is not None
 
         with self._otel.start_as_current_span(f"llm:{step_name}") as ospan:
             ospan.set_attribute("openinference.span.kind", "LLM")
-            ospan.set_attribute("input.value", json.dumps(inputs, indent=2, default=str))
+            ospan.set_attribute(
+                "input.value", json.dumps(inputs, indent=2, default=str)
+            )
             ospan.set_attribute("input.mime_type", "application/json")
             t0 = time.perf_counter()
             final_attempt = 1
 
+            response = None  # for ainvoke path
+            stream_content: str = ""
+            stream_reasoning: str = ""
+            stream_usage: dict[str, int] | None = None
+
             for attempt in range(max_retries + 1):
                 final_attempt = attempt + 1
+                stream_content = ""
+                stream_reasoning = ""
+                stream_usage = None
+                progress: dict[str, Any] = {"first_chunk_emitted": False}
                 try:
                     async with self._semaphore:
-                        response = await asyncio.wait_for(
-                            chain.ainvoke(inputs), timeout=llm_timeout
-                        )
+                        if not streaming:
+                            response = await asyncio.wait_for(
+                                chain.ainvoke(inputs), timeout=llm_timeout
+                            )
+                        else:
+                            (
+                                stream_content,
+                                stream_reasoning,
+                                stream_usage,
+                            ) = await asyncio.wait_for(
+                                self._accumulate_astream(
+                                    chain, inputs, config, progress
+                                ),
+                                timeout=llm_timeout,
+                            )
                     break
                 except TimeoutError:
                     logger.warning(
@@ -340,6 +435,10 @@ class AgenticRag:
                         attempt + 1,
                         max_retries + 1,
                     )
+                    if streaming and progress["first_chunk_emitted"]:
+                        raise TimeoutError(
+                            f"[{step_name}] LLM stream stalled mid-response; cannot retry"
+                        ) from None
                     if attempt < max_retries:
                         continue
                     raise TimeoutError(
@@ -359,6 +458,10 @@ class AgenticRag:
                             "Timeout",
                         )
                     )
+                    # Never retry once the stream has started — partial tokens
+                    # have already reached the client.
+                    if streaming and progress["first_chunk_emitted"]:
+                        raise
                     if is_retryable and attempt < max_retries:
                         wait = 2**attempt * 5
                         logger.warning(
@@ -374,9 +477,19 @@ class AgenticRag:
                     else:
                         raise
 
-            reasoning = getattr(response, "reasoning_content", None)
-            if not reasoning and hasattr(response, "additional_kwargs"):
-                reasoning = (response.additional_kwargs or {}).get("reasoning_content")
+            if streaming:
+                reasoning = stream_reasoning or None
+                response_content = self._filter_think_tokens(stream_content)
+                usage = stream_usage
+            else:
+                reasoning = getattr(response, "reasoning_content", None)
+                if not reasoning and hasattr(response, "additional_kwargs"):
+                    reasoning = (response.additional_kwargs or {}).get(
+                        "reasoning_content"
+                    )
+                response_content = self._filter_think_tokens(str(response.content))
+                usage = getattr(response, "usage_metadata", None)
+
             if reasoning:
                 preview = str(reasoning)[:300].replace("\n", " ")
                 logger.debug(
@@ -387,11 +500,8 @@ class AgenticRag:
                     "..." if len(str(reasoning)) > 300 else "",
                 )
 
-            response_content = self._filter_think_tokens(str(response.content))
-
             # Prefer API-reported token counts; fall back to tiktoken estimate.
             # usage_metadata can be a dict (ChatNVIDIA) or an object (other providers).
-            usage = getattr(response, "usage_metadata", None)
             if usage:
                 if isinstance(usage, dict):
                     input_tokens = usage.get("input_tokens", 0)
@@ -521,7 +631,9 @@ class AgenticRag:
             )
         return chunks
 
-    def _format_chunks_for_prompt(self, chunks: list[dict], max_tokens: int | None = None) -> str:
+    def _format_chunks_for_prompt(
+        self, chunks: list[dict], max_tokens: int | None = None
+    ) -> str:
         """Format chunks as a numbered list sorted by relevance, truncated to token budget."""
         if not chunks:
             return "(no documents)"
@@ -537,7 +649,9 @@ class AgenticRag:
             dtype = c.get("document_type", "text")
             label = {"table": "Table", "chart": "Chart"}.get(dtype, "Chunk")
             doc_name = c.get("doc_name", "")
-            header = f"[{label} {idx}] File: {doc_name}" if doc_name else f"[{label} {idx}]"
+            header = (
+                f"[{label} {idx}] File: {doc_name}" if doc_name else f"[{label} {idx}]"
+            )
             section = f"{header}\n{c['content']}"
 
             section_tokens = self._estimate_tokens(section)
@@ -574,7 +688,9 @@ class AgenticRag:
         for line in lines:
             stripped = line.strip()
             if re.match(r"^(?:[-*+•]\s|\d+[.)]\s)", stripped):
-                content = re.sub(r"^(?:[-*+•]\s|\d+[.)]\s)\s*", "", stripped).rstrip(".;,")
+                content = re.sub(r"^(?:[-*+•]\s|\d+[.)]\s)\s*", "", stripped).rstrip(
+                    ".;,"
+                )
                 if content:
                     bullet_buffer.append(content)
             else:
@@ -624,7 +740,26 @@ class AgenticRag:
         is_scope: bool = False,
         stage: str = "execute",
     ) -> dict:
-        """Execute one task as a mini-agent with seed-query retries and partial-answer merging."""
+        """Execute one task as a mini-agent with seed-query retries and partial-answer merging.
+
+        Streaming note
+        --------------
+        ``execute_node`` runs N copies of this method concurrently via
+        ``asyncio.gather`` (one per task in the plan).  We deliberately
+        invoke ``_call_llm`` **without** the LangGraph runtime ``config``
+        here so the inner ``seed_gen`` and ``task_llm`` calls take the
+        non-streaming ``ainvoke`` path.  Were they to stream, every
+        concurrent task's reasoning + output tokens would push into the
+        shared ``stream_mode="messages"`` queue and arrive on the wire
+        interleaved by chunk-arrival order — making the per-task
+        ``intermediate_reasoning`` panel unreadable.
+
+        Trade-off: the caller (``_execute_plan``) waits for each task's
+        full answer to arrive at once instead of streaming tokens live.
+        Live token streaming is preserved for the single-LLM-call nodes
+        (``plan``, ``verify``, ``synthesize``) where there is no
+        concurrent producer to interleave with.
+        """
         effective_max_retries = (
             self.task_exec_cfg.scope_max_retries
             if is_scope
@@ -670,6 +805,7 @@ class AgenticRag:
                         {"question": question, "tried_queries": tried_summary},
                         step_name=f"Task {tid} seed gen (attempt {attempt + 1})",
                         json_mode=False,
+                        # config intentionally omitted — see method docstring.
                     )
                     seed_result = self._parse_json_response(seed_response)
 
@@ -698,7 +834,11 @@ class AgenticRag:
                     current_query = seed_result.get("seed_query") or query
 
                 logger.debug(
-                    "%s Task %s attempt %d — query: %s", _P, tid, attempt + 1, current_query
+                    "%s Task %s attempt %d — query: %s",
+                    _P,
+                    tid,
+                    attempt + 1,
+                    current_query,
                 )
 
                 with self._otel.start_as_current_span(
@@ -712,7 +852,9 @@ class AgenticRag:
                             raw_context = []
                     except Exception as ex:
                         logger.warning("%s Task %s retrieval failed: %s", _P, tid, ex)
-                        rspan.set_attribute("metadata", json.dumps({"error": str(ex)[:200]}))
+                        rspan.set_attribute(
+                            "metadata", json.dumps({"error": str(ex)[:200]})
+                        )
                         raw_context = []
 
                 chunks = self._extract_chunks(
@@ -720,7 +862,12 @@ class AgenticRag:
                 )
 
                 if not chunks:
-                    logger.debug("%s Task %s attempt %d — no chunks returned", _P, tid, attempt + 1)
+                    logger.debug(
+                        "%s Task %s attempt %d — no chunks returned",
+                        _P,
+                        tid,
+                        attempt + 1,
+                    )
                     result = (
                         {
                             "answer": accumulated_answer,
@@ -728,7 +875,11 @@ class AgenticRag:
                             "attempts": attempt + 1,
                         }
                         if accumulated_answer
-                        else {"answer": "[NO DATA]", "status": "no_data", "attempts": attempt + 1}
+                        else {
+                            "answer": "[NO DATA]",
+                            "status": "no_data",
+                            "attempts": attempt + 1,
+                        }
                     )
                     return _finish_task(result)
 
@@ -750,6 +901,7 @@ class AgenticRag:
                     self.task_answer_prompt,
                     {"question": task_question, "documents": docs_str},
                     step_name=f"Task {tid} answer (attempt {attempt + 1})",
+                    # config intentionally omitted — see method docstring.
                 )
                 parsed = self._parse_task_answer(raw_answer)
 
@@ -782,9 +934,17 @@ class AgenticRag:
 
                 logger.debug("%s Task %s — [NO DATA] from %d docs", _P, tid, n_chunks)
                 result = (
-                    {"answer": accumulated_answer, "status": "answered", "attempts": attempt + 1}
+                    {
+                        "answer": accumulated_answer,
+                        "status": "answered",
+                        "attempts": attempt + 1,
+                    }
                     if accumulated_answer
-                    else {"answer": "[NO DATA]", "status": "no_data", "attempts": attempt + 1}
+                    else {
+                        "answer": "[NO DATA]",
+                        "status": "no_data",
+                        "attempts": attempt + 1,
+                    }
                 )
                 return _finish_task(result)
 
@@ -795,7 +955,11 @@ class AgenticRag:
                     "attempts": effective_max_retries,
                 }
                 if accumulated_answer
-                else {"answer": "[NO DATA]", "status": "no_data", "attempts": effective_max_retries}
+                else {
+                    "answer": "[NO DATA]",
+                    "status": "no_data",
+                    "attempts": effective_max_retries,
+                }
             )
             return _finish_task(result)
 
@@ -805,7 +969,13 @@ class AgenticRag:
         is_scope: bool = False,
         stage: str = "execute",
     ) -> dict[str, dict]:
-        """Execute all tasks in parallel."""
+        """Execute all tasks in parallel.
+
+        Note: this helper does not accept a ``config`` arg even though it is
+        called from inside graph nodes that receive one.  Inner task LLM calls
+        are intentionally non-streaming — see ``_execute_single_task`` for the
+        rationale.
+        """
         levels = self._build_execution_levels(tasks)
         all_results: dict[str, dict] = {}
 
@@ -817,7 +987,10 @@ class AgenticRag:
                 [t["id"] for t in level_tasks],
             )
 
-            coros = [self._execute_single_task(task, is_scope=is_scope, stage=stage) for task in level_tasks]
+            coros = [
+                self._execute_single_task(task, is_scope=is_scope, stage=stage)
+                for task in level_tasks
+            ]
             results = await asyncio.gather(*coros, return_exceptions=True)
 
             for task, result in zip(level_tasks, results, strict=True):
@@ -832,9 +1005,20 @@ class AgenticRag:
     # GRAPH NODES
     # =========================================================================
 
-    async def initial_retrieval_node(self, state: AgenticRAGGraphState) -> dict[str, Any]:
+    async def initial_retrieval_node(
+        self,
+        state: AgenticRAGGraphState,
+        writer: StreamWriter,
+        config: RunnableConfig,
+    ) -> dict[str, Any]:
         """Single-query retrieval using the user's original query."""
+        from nvidia_rag.rag_server.agentic_rag.streaming import (
+            make_stage_end,
+            make_stage_start,
+        )
         from nvidia_rag.rag_server.agentic_rag.tracing import get_current_trace
+
+        writer(make_stage_start("initial_retrieval"))
 
         with self._otel_and_trace("initial_retrieval") as ospan:
             ospan.set_attribute("input.value", state.user_query)
@@ -868,7 +1052,9 @@ class AgenticRag:
                     )
                 except Exception as ex:
                     logger.warning("%s Retrieval failed: %s", _P, ex)
-                    rspan.set_attribute("metadata", json.dumps({"error": str(ex)[:200]}))
+                    rspan.set_attribute(
+                        "metadata", json.dumps({"error": str(ex)[:200]})
+                    )
                     chunks = []
 
             logger.info("%s Retrieval complete: %d chunks", _P, len(chunks))
@@ -884,14 +1070,29 @@ class AgenticRag:
 
             rebuilt_context = [{"results": [self._rebuild_result(c) for c in chunks]}]
 
+            writer(make_stage_end("initial_retrieval", chunks=len(chunks)))
             return {"initial_context": rebuilt_context}
 
-    async def plan_node(self, state: AgenticRAGGraphState) -> dict[str, Any]:
+    async def plan_node(
+        self,
+        state: AgenticRAGGraphState,
+        writer: StreamWriter,
+        config: RunnableConfig,
+    ) -> dict[str, Any]:
         """Create or refine the retrieval plan (called once or twice for scope discovery)."""
+        from nvidia_rag.rag_server.agentic_rag.streaming import (
+            make_stage_end,
+            make_stage_start,
+        )
         from nvidia_rag.rag_server.agentic_rag.tracing import get_current_trace
 
         is_replan = bool(state.scope_results)
         phase = "phase 2 (answer plan)" if is_replan else "phase 1 (scope discovery)"
+        writer(
+            make_stage_start(
+                "plan", key="plan.start.answer" if is_replan else "plan.start.scope"
+            )
+        )
         with self._otel_and_trace(f"plan ({phase})") as ospan:
             current_round = state.scope_rounds
             ospan.set_attribute("input.value", state.user_query)
@@ -899,12 +1100,16 @@ class AgenticRag:
 
             chunks = self._extract_chunks(state.initial_context)
             initial_content = (
-                self._format_chunks_for_prompt(chunks) if chunks else "(no documents retrieved)"
+                self._format_chunks_for_prompt(chunks)
+                if chunks
+                else "(no documents retrieved)"
             )
 
             scope_section = ""
             if is_replan:
-                scope_parts = [f"[{tid}]: {answer}" for tid, answer in state.scope_results.items()]
+                scope_parts = [
+                    f"[{tid}]: {answer}" for tid, answer in state.scope_results.items()
+                ]
                 scope_section = (
                     "\nScope Discovery Results (what actually exists in the database):\n"
                     + "\n".join(scope_parts)
@@ -926,6 +1131,7 @@ class AgenticRag:
                         },
                         step_name=f"Planner ({phase})",
                         json_mode=False,
+                        config=config,
                     )
                     plan = self._parse_json_response(response)
 
@@ -947,7 +1153,9 @@ class AgenticRag:
                         }
                         break
 
-                    is_degenerate = "resolved_query" not in plan and "scope_only" not in plan
+                    is_degenerate = (
+                        "resolved_query" not in plan and "scope_only" not in plan
+                    )
                     if is_degenerate and planner_attempt < planner_max_attempts - 1:
                         logger.warning(
                             "%s Degenerate plan (missing key fields), retrying (%d/%d)",
@@ -963,9 +1171,13 @@ class AgenticRag:
                         malformed_keys = [
                             i
                             for i, t in enumerate(tasks_list)
-                            if not isinstance(t, dict) or not required_keys.issubset(t.keys())
+                            if not isinstance(t, dict)
+                            or not required_keys.issubset(t.keys())
                         ]
-                        if malformed_keys and planner_attempt < planner_max_attempts - 1:
+                        if (
+                            malformed_keys
+                            and planner_attempt < planner_max_attempts - 1
+                        ):
                             issues = []
                             for i in malformed_keys:
                                 t = tasks_list[i]
@@ -1010,7 +1222,11 @@ class AgenticRag:
                         )
                         plan["scope_only"] = False
 
-                new_round = current_round + 1 if plan.get("scope_only", False) else current_round
+                new_round = (
+                    current_round + 1
+                    if plan.get("scope_only", False)
+                    else current_round
+                )
 
                 logger.info(
                     "%s Plan: scope_only=%s, %d tasks, resolved_query=%.80s",
@@ -1019,7 +1235,9 @@ class AgenticRag:
                     len(plan.get("tasks", [])),
                     plan.get("resolved_query", "")[:80],
                 )
-                logger.debug("%s Plan detail: %s", _P, json.dumps(plan, indent=2)[:2000])
+                logger.debug(
+                    "%s Plan detail: %s", _P, json.dumps(plan, indent=2)[:2000]
+                )
 
                 task_ids = [t.get("id", "") for t in plan.get("tasks", [])]
                 plan_json = json.dumps(plan, indent=2)
@@ -1047,6 +1265,16 @@ class AgenticRag:
                         "resolved_query": plan.get("resolved_query", ""),
                     }
 
+                if plan.get("scope_only", False):
+                    end_key = "plan.end.scope"
+                elif task_ids:
+                    end_key = "plan.end.with_tasks"
+                else:
+                    end_key = "plan.end.no_tasks"
+                writer(
+                    make_stage_end("plan", key=end_key, task_count=len(task_ids))
+                )
+
                 return {
                     "retrieval_plan": plan,
                     "needs_replan": False,
@@ -1055,6 +1283,7 @@ class AgenticRag:
 
             except Exception as ex:
                 logger.exception("%s Planning failed: %s", _P, ex)
+                writer(make_stage_end("plan", key="plan.end.failed"))
                 return {
                     "retrieval_plan": {
                         "scope_only": False,
@@ -1066,32 +1295,56 @@ class AgenticRag:
                     "needs_replan": False,
                 }
 
-    async def execute_node(self, state: AgenticRAGGraphState) -> dict[str, Any]:
+    async def execute_node(
+        self,
+        state: AgenticRAGGraphState,
+        writer: StreamWriter,
+        config: RunnableConfig,
+    ) -> dict[str, Any]:
         """Execute all tasks from the current plan."""
+        from nvidia_rag.rag_server.agentic_rag.streaming import (
+            make_stage_end,
+            make_stage_start,
+        )
         from nvidia_rag.rag_server.agentic_rag.tracing import get_current_trace
 
         tasks = state.retrieval_plan.get("tasks", [])
         is_scope_only = state.retrieval_plan.get("scope_only", False)
         exec_label = "scope discovery" if is_scope_only else "answer"
+        writer(
+            make_stage_start(
+                "execute",
+                key="execute.start.scope" if is_scope_only else "execute.start.answer",
+                task_count=len(tasks),
+            )
+        )
         with self._otel_and_trace(f"execute ({exec_label})") as ospan:
             task_ids = [t.get("id", "") for t in tasks]
             ospan.set_attribute("input.value", json.dumps(task_ids))
             ospan.set_attribute("input.mime_type", "application/json")
 
             if not tasks:
-                logger.info("%s Execute: no tasks — synthesizing from initial retrieval", _P)
+                logger.info(
+                    "%s Execute: no tasks — synthesizing from initial retrieval", _P
+                )
+                writer(make_stage_end("execute", key="execute.end.no_tasks"))
                 return {"task_results": {}, "needs_replan": False}
 
             logger.info("%s Executing %d %s tasks", _P, len(tasks), exec_label)
 
             exec_stage = "execute_scope" if is_scope_only else "execute"
-            results = await self._execute_plan(tasks, is_scope=is_scope_only, stage=exec_stage)
+            results = await self._execute_plan(
+                tasks, is_scope=is_scope_only, stage=exec_stage
+            )
 
             statuses = [r.get("status", "unknown") for r in results.values()]
             answered = statuses.count("answered")
             no_data = statuses.count("no_data")
             exec_output = {
-                tid: {"status": r.get("status", "unknown"), "answer": r.get("answer", "")}
+                tid: {
+                    "status": r.get("status", "unknown"),
+                    "answer": r.get("answer", ""),
+                }
                 for tid, r in results.items()
             }
             ospan.set_attribute("output.value", json.dumps(exec_output, indent=2))
@@ -1107,7 +1360,9 @@ class AgenticRag:
                     }
                 ),
             )
-            logger.info("%s Execution complete: %d answered, %d no_data", _P, answered, no_data)
+            logger.info(
+                "%s Execution complete: %d answered, %d no_data", _P, answered, no_data
+            )
             logger.debug(
                 "%s Execution detail: %s",
                 _P,
@@ -1153,6 +1408,7 @@ class AgenticRag:
                         len(scope_answers),
                         len(results),
                     )
+                    writer(make_stage_end("execute", key="execute.end.replan"))
                     return {
                         "task_results": results,
                         "scope_results": scope_answers,
@@ -1171,19 +1427,55 @@ class AgenticRag:
                             }
                         ),
                     )
-                    logger.info("%s Scope: all tasks returned [NO DATA] — no replan", _P)
+                    logger.info(
+                        "%s Scope: all tasks returned [NO DATA] — no replan", _P
+                    )
+                    writer(make_stage_end("execute", key="execute.end.no_data"))
                     return {"task_results": results, "needs_replan": False}
 
+            writer(
+                make_stage_end(
+                    "execute",
+                    key="execute.end.done",
+                    task_count=len(tasks),
+                    answered=answered,
+                )
+            )
             return {"task_results": results, "needs_replan": False}
 
-    async def synthesize_node(self, state: AgenticRAGGraphState) -> dict[str, Any]:
+    async def synthesize_node(
+        self,
+        state: AgenticRAGGraphState,
+        writer: StreamWriter,
+        config: RunnableConfig,
+    ) -> dict[str, Any]:
         """Combine task sub-answers (and optionally verification data) into a final answer."""
+        from nvidia_rag.rag_server.agentic_rag.streaming import (
+            make_final_stage_marker,
+            make_stage_end,
+            make_stage_start,
+        )
+
         is_verification_pass = state.verification_round > 0
         synth_label = (
             f"synthesize (verification pass {state.verification_round})"
             if is_verification_pass
             else "synthesize"
         )
+        # This synthesis is final (i.e. nothing follows in the graph) when:
+        #   - verification is disabled entirely, or
+        #   - we are already in a post-verification pass.
+        # See _route_after_synthesize for the authoritative routing predicate.
+        is_final_synthesis = (
+            not self.verification_cfg.enabled or state.verification_round > 0
+        )
+        writer(
+            make_stage_start(
+                "synthesize",
+                key="synthesize.start.refining" if is_verification_pass else "synthesize.start",
+            )
+        )
+        writer(make_final_stage_marker(is_final=is_final_synthesis))
         with self._otel_and_trace(synth_label) as ospan:
             pass_label = synth_label
             ospan.set_attribute("input.value", state.user_query)
@@ -1211,6 +1503,7 @@ class AgenticRag:
                     _P,
                     pass_label,
                 )
+                writer(make_stage_end("synthesize", key="synthesize.end.unchanged"))
                 return {"final_answer": state.final_answer}
 
             chunks = self._extract_chunks(state.initial_context)
@@ -1218,7 +1511,8 @@ class AgenticRag:
             effective_tasks = [
                 t
                 for t in tasks
-                if task_results.get(t["id"], {}).get("answer", "[NO DATA]") != "[NO DATA]"
+                if task_results.get(t["id"], {}).get("answer", "[NO DATA]")
+                != "[NO DATA]"
             ]
 
             if not effective_tasks and not state.verification_results:
@@ -1228,9 +1522,7 @@ class AgenticRag:
                     }
 
                 docs_str = self._format_chunks_for_prompt(chunks)
-                sub_answers = (
-                    f"[Source documents — synthesize the answer directly from these]\n{docs_str}"
-                )
+                sub_answers = f"[Source documents — synthesize the answer directly from these]\n{docs_str}"
             else:
                 answer_parts = []
 
@@ -1238,8 +1530,12 @@ class AgenticRag:
                     if state.final_answer:
                         answer_parts.append(f"[PREVIOUS ANSWER]: {state.final_answer}")
                     if state.verification_issues:
-                        issues_text = "\n".join(f"- {issue}" for issue in state.verification_issues)
-                        answer_parts.append(f"[GAPS IDENTIFIED IN PREVIOUS ANSWER]:\n{issues_text}")
+                        issues_text = "\n".join(
+                            f"- {issue}" for issue in state.verification_issues
+                        )
+                        answer_parts.append(
+                            f"[GAPS IDENTIFIED IN PREVIOUS ANSWER]:\n{issues_text}"
+                        )
                     synthesis_instruction = (
                         "IMPORTANT: The [PREVIOUS ANSWER] had gaps listed under [GAPS IDENTIFIED IN PREVIOUS ANSWER]. "
                         "Keep the [PREVIOUS ANSWER] as the base. "
@@ -1252,7 +1548,9 @@ class AgenticRag:
                     tid = task["id"]
                     result = task_results.get(tid, {})
                     answer = result.get("answer", "[NO DATA]")
-                    answer_parts.append(f"Task {tid} ({task.get('question', '')}): {answer}")
+                    answer_parts.append(
+                        f"Task {tid} ({task.get('question', '')}): {answer}"
+                    )
 
                 if state.verification_results:
                     v_question_map = {
@@ -1279,7 +1577,8 @@ class AgenticRag:
                     )
 
             resolved_query = (
-                state.retrieval_plan.get("resolved_query", state.user_query) or state.user_query
+                state.retrieval_plan.get("resolved_query", state.user_query)
+                or state.user_query
             )
             resolved_section = ""
             if resolved_query.strip().lower() != state.user_query.strip().lower():
@@ -1300,6 +1599,7 @@ class AgenticRag:
                         "sub_answers": sub_answers,
                     },
                     step_name=pass_label,
+                    config=config,
                 )
                 answer = self._clean_answer(response) if response else ""
 
@@ -1318,10 +1618,12 @@ class AgenticRag:
                 )
                 logger.info("%s %s complete", _P, pass_label)
                 logger.debug("%s Answer preview: %.300s", _P, answer)
+                writer(make_stage_end("synthesize", key="synthesize.end"))
                 return {"final_answer": answer}
 
             except Exception as ex:
                 logger.exception("%s Synthesis failed: %s", _P, ex)
+                writer(make_stage_end("synthesize", key="synthesize.end.failed"))
                 return {"final_answer": "I encountered an error generating the answer."}
 
     def _build_resolved_query_section(self, state: AgenticRAGGraphState) -> str:
@@ -1331,13 +1633,25 @@ class AgenticRag:
             return f"\nDisambiguated Question (implicit or ambiguous references in the original question were resolved from the documents): {resolved}\n"
         return ""
 
-    async def verify_node(self, state: AgenticRAGGraphState) -> dict[str, Any]:
+    async def verify_node(
+        self,
+        state: AgenticRAGGraphState,
+        writer: StreamWriter,
+        config: RunnableConfig,
+    ) -> dict[str, Any]:
         """Check answer completeness and identify retrieval gaps."""
+        from nvidia_rag.rag_server.agentic_rag.streaming import (
+            make_stage_end,
+            make_stage_start,
+        )
         from nvidia_rag.rag_server.agentic_rag.tracing import get_current_trace
 
+        writer(make_stage_start("verify"))
         with self._otel_and_trace("verify") as ospan:
             ospan.set_attribute("input.value", state.final_answer)
-            logger.info("%s Verification started (round %d)", _P, state.verification_round)
+            logger.info(
+                "%s Verification started (round %d)", _P, state.verification_round
+            )
 
             tasks = state.retrieval_plan.get("tasks", [])
             task_summary_parts = []
@@ -1351,7 +1665,9 @@ class AgenticRag:
                     f"- {tid}: {task.get('question', '')} → {status}: {answer_preview}"
                 )
             task_summary = (
-                "\n".join(task_summary_parts) if task_summary_parts else "(no tasks were executed)"
+                "\n".join(task_summary_parts)
+                if task_summary_parts
+                else "(no tasks were executed)"
             )
 
             max_v_tasks = self.verification_cfg.max_tasks
@@ -1362,12 +1678,15 @@ class AgenticRag:
                     self.verification_prompt,
                     {
                         "query": state.user_query,
-                        "resolved_query_section": self._build_resolved_query_section(state),
+                        "resolved_query_section": self._build_resolved_query_section(
+                            state
+                        ),
                         "answer": state.final_answer,
                         "task_summary": task_summary,
                     },
                     step_name="Verification",
                     json_mode=False,
+                    config=config,
                 )
                 result = self._parse_json_response(response)
 
@@ -1394,6 +1713,7 @@ class AgenticRag:
                             "issues": [],
                             "follow_up_tasks": 0,
                         }
+                    writer(make_stage_end("verify", key="verify.end.passed"))
                     return {
                         "verification_tasks": [],
                         "verification_round": state.verification_round + 1,
@@ -1404,7 +1724,9 @@ class AgenticRag:
                     v_tasks = []
                 required_keys = {"id", "question", "query"}
                 v_tasks = [
-                    t for t in v_tasks if isinstance(t, dict) and required_keys.issubset(t.keys())
+                    t
+                    for t in v_tasks
+                    if isinstance(t, dict) and required_keys.issubset(t.keys())
                 ][:max_v_tasks]
 
                 ospan.set_attribute("output.value", json.dumps(result, indent=2))
@@ -1441,6 +1763,14 @@ class AgenticRag:
                         "follow_up_tasks": len(v_tasks),
                     }
 
+                issue_count = len(issues) if isinstance(issues, list) else 0
+                writer(
+                    make_stage_end(
+                        "verify",
+                        key="verify.end.failed" if issue_count > 0 else "verify.end.failed_unspecified",
+                        issues=issue_count,
+                    )
+                )
                 return {
                     "verification_tasks": v_tasks,
                     "verification_issues": issues if isinstance(issues, list) else [],
@@ -1449,22 +1779,37 @@ class AgenticRag:
 
             except Exception as ex:
                 logger.exception("%s Verification failed: %s", _P, ex)
+                writer(make_stage_end("verify", key="verify.end.error"))
                 return {
                     "verification_tasks": [],
                     "verification_round": state.verification_round + 1,
                 }
 
-    async def verify_execute_node(self, state: AgenticRAGGraphState) -> dict[str, Any]:
+    async def verify_execute_node(
+        self,
+        state: AgenticRAGGraphState,
+        writer: StreamWriter,
+        config: RunnableConfig,
+    ) -> dict[str, Any]:
         """Execute verification follow-up tasks (targeted re-retrieval)."""
+        from nvidia_rag.rag_server.agentic_rag.streaming import (
+            make_stage_end,
+            make_stage_start,
+        )
+
+        writer(make_stage_start("verify_execute"))
         with self._otel_and_trace("verify_execute") as ospan:
             v_tasks = state.verification_tasks
             ospan.set_attribute(
                 "input.value", json.dumps([t.get("id", "") for t in (v_tasks or [])])
             )
             if not v_tasks:
+                writer(make_stage_end("verify_execute", key="verify_execute.end.no_tasks"))
                 return {"verification_results": {}}
 
-            logger.info("%s Verify-execute: running %d follow-up tasks", _P, len(v_tasks))
+            logger.info(
+                "%s Verify-execute: running %d follow-up tasks", _P, len(v_tasks)
+            )
             results = await self._execute_plan(v_tasks, stage="verify_execute")
 
             statuses = [r.get("status", "unknown") for r in results.values()]
@@ -1483,6 +1828,13 @@ class AgenticRag:
                 _P,
                 statuses.count("answered"),
                 statuses.count("no_data"),
+            )
+            writer(
+                make_stage_end(
+                    "verify_execute",
+                    key="verify_execute.end",
+                    answered=statuses.count("answered"),
+                )
             )
             return {"verification_results": results}
 

--- a/src/nvidia_rag/rag_server/agentic_rag/runner.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/runner.py
@@ -15,11 +15,29 @@
 
 """Agentic RAG pipeline runner.
 
-Executes a pre-built AgenticRag graph for a single request and wraps
-the final answer in a streaming RAGResponse so downstream code (server.py
-StreamingResponse) works without modification.
+Executes a pre-built ``AgenticRag`` graph for a single request and returns
+a ``RAGResponse`` whose generator yields SSE-formatted chunks ready for
+``server.py``'s ``StreamingResponse`` to forward to the HTTP client.
 
-Usage (called from NvidiaRAG._agentic_chain):
+Two execution modes
+-------------------
+* ``enable_streaming=True`` (default) — graph runs via ``astream`` with combined
+  ``stream_mode=["messages", "custom", "debug"]``.  ``streaming.translate_graph_stream``
+  consumes the events live and emits per-chunk SSE strings: stage announcements,
+  intermediate-stage reasoning + output tokens, final-stage reasoning, and the
+  final answer (with citations + TTFT on the first final-answer chunk).
+* ``enable_streaming=False`` — legacy path: the graph runs to completion via
+  ``ainvoke`` and the full answer is wrapped in a single async-generator chunk
+  for ``generate_answer_async``.  Preserves the pre-streaming contract for
+  clients that don't want intermediate events.
+
+ContextVars (``_current_trace``, ``_agentic_search_params``,
+``_agentic_all_citations``) are bound for the lifetime of the request and
+unbound in the ``finally`` block, making this function safe under concurrent
+async invocations.
+
+Usage (called from ``NvidiaRAG._agentic_chain``)::
+
     from nvidia_rag.rag_server.agentic_rag.runner import run_agentic_pipeline
     rag_response = await run_agentic_pipeline(
         agent=agent,
@@ -27,6 +45,7 @@ Usage (called from NvidiaRAG._agentic_chain):
         query=rewritten_query,
         cfg=self.config.agentic_rag,
         search_params=AgenticSearchParams(...),
+        enable_streaming=True,
         ...
     )
 """
@@ -35,6 +54,7 @@ from __future__ import annotations
 
 import logging
 from collections import OrderedDict
+from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 
 from nvidia_rag.rag_server.agentic_rag.agentic_rag import AgenticRAGGraphState
@@ -43,6 +63,7 @@ from nvidia_rag.rag_server.agentic_rag.builder import (
     _agentic_all_citations,
     _agentic_search_params,
 )
+from nvidia_rag.rag_server.agentic_rag.streaming import translate_graph_stream
 from nvidia_rag.rag_server.agentic_rag.tracing import QueryTrace, _current_trace
 from nvidia_rag.rag_server.response_generator import (
     Citations,
@@ -65,41 +86,53 @@ async def _aiter_single(text: str):
     yield text
 
 
+def _collate_citations(
+    acc: OrderedDict[str, list[SourceResult]],
+) -> Citations | None:
+    """Pick citations from the last stage that performed retrieval.
+
+    The accumulator preserves insertion order, so the last value is always
+    the most recently active stage — no stage names need to be hardcoded.
+    """
+    last_stage_results = next(reversed(acc.values()), [])
+    if not last_stage_results:
+        return None
+    return Citations(
+        total_results=len(last_stage_results),
+        results=last_stage_results,
+    )
+
+
 async def run_agentic_pipeline(
     *,
-    agent: "AgenticRag",
+    agent: AgenticRag,
     graph: Any,
     query: str,
-    cfg: "AgenticRAGConfig",
+    cfg: AgenticRAGConfig,
     search_params: AgenticSearchParams,
     enable_citations: bool = True,
     use_nrl_citations: bool = False,
     model: str = "",
     collection_names: list[str] | None = None,
+    enable_streaming: bool = True,
     rag_start_time_sec: float | None = None,
-    metrics: "OtelMetrics | None" = None,
+    metrics: OtelMetrics | None = None,
 ) -> RAGResponse:
     """Run the compiled agentic RAG graph for one request and return a RAGResponse.
-
-    The agent graph runs to completion (non-streaming) inside an OTel root span.
-    The resulting ``final_answer`` string is wrapped in a single-chunk async
-    generator so the rest of the rag-server pipeline (generate_answer_async →
-    StreamingResponse) works unchanged.
-
-    ``_current_trace`` and ``_agentic_search_params`` ContextVars are set for
-    the duration of this call and reset in the ``finally`` block, making this
-    function safe for concurrent async requests.
 
     Args:
         agent:              Compiled AgenticRag (used for metrics bookkeeping).
         graph:              Compiled LangGraph returned by AgenticRag.build_graph().
         query:              User query; already rewritten if query rewriting is enabled.
-        cfg:                AgenticRAGConfig sub-config (recursion limit, etc.).
+        cfg:                AgenticRAGConfig sub-config (recursion limit, debug stream, etc).
         search_params:      All per-request NvidiaRAG.search() parameters.
-        enable_citations:   Forward to generate_answer_async.
+        enable_citations:   Forward to generate_answer_async (non-streaming path) /
+                            controls citation collation (streaming path).
         use_nrl_citations:  Forward to generate_answer_async (NRL/LanceDB mode).
         model:              LLM model name forwarded to generate_answer_async.
         collection_names:   Used for citation metadata; first entry used as collection_name.
+        enable_streaming:   True (default) → live event-stream translator.
+                            False → legacy ainvoke + single-chunk path.
         rag_start_time_sec: Request-start timestamp for end-to-end latency metrics.
         metrics:            Optional OTel metrics client.
     """
@@ -113,12 +146,38 @@ async def run_agentic_pipeline(
     citations_acc: OrderedDict[str, list[SourceResult]] = OrderedDict()
     citations_token = _agentic_all_citations.set(citations_acc)
 
+    initial_state = AgenticRAGGraphState(user_query=query)
+    collection_name = collection_names[0] if collection_names else ""
+
+    if enable_streaming:
+        return await _run_streaming(
+            agent=agent,
+            graph=graph,
+            initial_state=initial_state,
+            cfg=cfg,
+            tracer=tracer,
+            trace=trace,
+            citations_acc=citations_acc,
+            enable_citations=enable_citations,
+            model=model,
+            collection_name=collection_name,
+            rag_start_time_sec=rag_start_time_sec,
+            metrics=metrics,
+            cleanup=lambda: (
+                _current_trace.reset(trace_token),
+                _agentic_search_params.reset(params_token),
+                _agentic_all_citations.reset(citations_token),
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Non-streaming path — preserves legacy behaviour.
+    # ------------------------------------------------------------------
     try:
         with tracer.start_as_current_span("agentic_rag_query") as root_span:
             root_span.set_attribute("openinference.span.kind", "CHAIN")
             root_span.set_attribute("input.value", query)
 
-            initial_state = AgenticRAGGraphState(user_query=query)
             final_state = await graph.ainvoke(
                 initial_state,
                 config={"recursion_limit": cfg.recursion_limit},
@@ -138,23 +197,14 @@ async def run_agentic_pipeline(
             logger.info("[AGENTIC_RAG] Query done: %s", trace.one_line_summary())
             agent.metrics.log_summary()
 
-        # Pick citations from the last stage that performed retrieval.
-        # The OrderedDict preserves insertion order, so the last value is always
-        # the most recently active stage — no stage names need to be hardcoded.
-        acc = _agentic_all_citations.get()
-        last_stage_results = next(reversed(acc.values()), [])
-        collated_citations = (
-            Citations(total_results=len(last_stage_results), results=last_stage_results)
-            if last_stage_results
-            else None
-        )
+        collated_citations = _collate_citations(_agentic_all_citations.get())
 
         return RAGResponse(
             generate_answer_async(
                 _aiter_single(answer),
                 [],
                 model=model,
-                collection_name=collection_names[0] if collection_names else "",
+                collection_name=collection_name,
                 enable_citations=enable_citations,
                 use_nrl_citations=use_nrl_citations,
                 rag_start_time_sec=rag_start_time_sec,
@@ -181,7 +231,7 @@ async def run_agentic_pipeline(
                 _aiter_single(error_msg),
                 [],
                 model=model,
-                collection_name=collection_names[0] if collection_names else "",
+                collection_name=collection_name,
                 enable_citations=enable_citations,
                 otel_metrics_client=metrics,
             ),
@@ -192,3 +242,91 @@ async def run_agentic_pipeline(
         _current_trace.reset(trace_token)
         _agentic_search_params.reset(params_token)
         _agentic_all_citations.reset(citations_token)
+
+
+async def _run_streaming(
+    *,
+    agent: AgenticRag,
+    graph: Any,
+    initial_state: AgenticRAGGraphState,
+    cfg: AgenticRAGConfig,
+    tracer: Any,
+    trace: QueryTrace,
+    citations_acc: OrderedDict[str, list[SourceResult]],
+    enable_citations: bool,
+    model: str,
+    collection_name: str,
+    rag_start_time_sec: float | None,
+    metrics: OtelMetrics | None,
+    cleanup: Any,
+) -> RAGResponse:
+    """Build a RAGResponse whose generator delegates to ``translate_graph_stream``.
+
+    The OTel root span and ContextVar cleanup are owned by the wrapper async
+    generator below so they live for the full lifetime of the stream — not
+    just until this function returns.
+    """
+    debug_stream = bool(getattr(cfg, "enable_debug_stream", False))
+
+    def _build_citations_now() -> Citations | None:
+        if not enable_citations:
+            return None
+        return _collate_citations(citations_acc)
+
+    async def _on_complete(final_answer: str) -> None:
+        trace.final_answer = final_answer
+        trace.finalize()
+        agent.metrics.update(trace)
+        logger.info("[AGENTIC_RAG] Query done: %s", trace.one_line_summary())
+        agent.metrics.log_summary()
+
+    async def _stream() -> AsyncIterator[str]:
+        try:
+            with tracer.start_as_current_span("agentic_rag_query") as root_span:
+                root_span.set_attribute("openinference.span.kind", "CHAIN")
+                root_span.set_attribute("input.value", initial_state.user_query)
+                async for sse in translate_graph_stream(
+                    graph,
+                    initial_state,
+                    model=model,
+                    recursion_limit=cfg.recursion_limit,
+                    citations_provider=_build_citations_now,
+                    enable_debug_stream=debug_stream,
+                    rag_start_time_sec=rag_start_time_sec,
+                    on_complete=_on_complete,
+                ):
+                    yield sse
+                root_span.set_attribute("output.value", trace.final_answer or "")
+        except Exception as ex:
+            logger.exception("Agentic RAG streaming pipeline failed: %s", ex)
+            trace.error = str(ex)[:500]
+            trace.finalize()
+            agent.metrics.update(trace)
+            logger.info("[AGENTIC_RAG] Query failed: %s", trace.one_line_summary())
+            agent.metrics.log_summary()
+            raise
+        finally:
+            try:
+                cleanup()
+            except Exception as cex:  # noqa: BLE001
+                logger.warning("Streaming cleanup failed: %s", cex)
+            # ``metrics`` is passed in for parity with the non-streaming path;
+            # the translator already records TTFT/generation time on the
+            # finishing chunk, but we still want OTel histogram updates.
+            if metrics is not None:
+                try:
+                    payload = {
+                        "rag_ttft_ms": getattr(trace, "rag_ttft_ms", None),
+                        "llm_ttft_ms": getattr(trace, "llm_ttft_ms", None),
+                    }
+                    payload = {k: v for k, v in payload.items() if v is not None}
+                    if payload:
+                        metrics.update_latency_metrics(payload)
+                except Exception as mex:  # noqa: BLE001
+                    logger.debug("OTel latency update failed: %s", mex)
+
+    # collection_name not currently surfaced in streaming chunks, but kept in
+    # signature for parity with the non-streaming branch.
+    _ = collection_name
+
+    return RAGResponse(_stream(), status_code=ErrorCodeMapping.SUCCESS)

--- a/src/nvidia_rag/rag_server/agentic_rag/streaming.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/streaming.py
@@ -1,0 +1,756 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Streaming infrastructure for the agentic RAG pipeline.
+
+This module isolates everything needed to translate LangGraph's combined
+``stream_mode=["messages", "custom", "debug"]`` event stream into the
+``ChainResponse`` SSE chunks that the rag-server emits.  Keeping it here
+means ``agentic_rag.py`` and ``runner.py`` stay focused on RAG logic.
+
+Public surface
+--------------
+* ``EventType``                     — enum of all event_type values emitted on the wire
+* ``USER_FACING_LABELS``            — single source of truth for every UI-visible string
+                                       emitted as a stage_start / stage_end / agent_event
+                                       (writers pass only ``key`` + ``params``; the
+                                       translator does the lookup and substitution)
+* ``make_stage_start``              — writer payload for node entry (key + params)
+* ``make_stage_end``                — writer payload for node exit (key + params)
+* ``make_agent_event``              — writer payload for mid-stage updates (key + params)
+                                       — surfaces on the wire as ``event_type='agent_event'``
+* ``make_final_stage_marker``       — internal routing signal synthesize_node emits
+                                       so the translator knows whether to label its
+                                       subsequent message tokens as ``final_*``
+* ``translate_graph_stream``        — async generator that consumes ``graph.astream(...)``
+                                       and yields SSE-formatted ``ChainResponse`` strings
+
+Design notes
+------------
+* The translator alone formats SSE strings; nodes only emit semantic events via ``writer``.
+* ``synthesize_node`` knows whether it is the *final* synthesize pass (no verification
+  pass will follow) and emits a ``final_stage_marker`` custom event before its LLM call.
+  The translator uses this to route subsequent ``messages``-mode tokens from
+  ``synthesize`` to ``final_answer``/``final_reasoning`` (otherwise ``intermediate_*``).
+* Citations attach to the **first** ``final_answer`` chunk, mirroring
+  ``response_generator.generate_answer_async`` so the existing UI contract is preserved.
+* RAG/LLM TTFT is measured to the first ``final_answer`` content chunk (not to the first
+  reasoning or intermediate chunk).  This matches what users see as "first useful token".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable
+from enum import StrEnum
+from typing import Any
+from uuid import uuid4
+
+from nvidia_rag.rag_server.response_generator import (
+    ChainResponse,
+    ChainResponseChoices,
+    Citations,
+    Message,
+    Metrics,
+    Usage,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# CHUNK TYPES
+# =============================================================================
+
+
+class EventType(StrEnum):
+    """Enumerates the values the ``event_type`` field on ChainResponse can take.
+
+    ``StrEnum`` makes each member a real ``str`` so ``EventType.STAGE_START ==
+    "stage_start"`` and JSON serialization Just Works without custom encoders.
+    """
+
+    # Lifecycle events emitted by nodes via ``writer({...})``.
+    STAGE_START = "stage_start"
+    """Node has started; ``reasoning_content`` carries a friendly one-liner."""
+
+    STAGE_END = "stage_end"
+    """Node has finished; ``reasoning_content`` carries a short summary."""
+
+    # LLM token chunks from the messages stream.  Single-LLM-call nodes
+    # (``plan``, ``verify``) emit these as live token deltas.  Parallel-task
+    # nodes (``execute``, ``verify_execute``) emit them as ONE consolidated
+    # chunk per concurrent task, deferred until the node's ``stage_end`` —
+    # see PARALLEL_TASK_NODES for the rationale.
+    INTERMEDIATE_REASONING = "intermediate_reasoning"
+    """Reasoning-content from a non-final node.  Streamed live for
+    single-LLM-call nodes; one consolidated chunk per task for parallel
+    nodes."""
+
+    INTERMEDIATE_OUTPUT = "intermediate_output"
+    """Visible-content output from a non-final node (planner / verifier JSON,
+    per-task answers, etc.).  Streamed live for single-LLM-call nodes; one
+    consolidated chunk per task for parallel nodes."""
+
+    FINAL_REASONING = "final_reasoning"
+    """Reasoning-content delta from the final synthesize call."""
+
+    FINAL_ANSWER = "final_answer"
+    """Visible-content delta from the final synthesize call.  This is the
+    user-facing answer and is mirrored into ``Message.content`` (delta+message).
+    Citations attach to the first chunk of this kind."""
+
+    # Structured semantic update from any node, plus forwarded LangGraph
+    # debug-mode events.  The ``stage`` field discriminates which node
+    # produced the update (``plan``, ``execute``, ``verify``,
+    # ``initial_retrieval``, ``verify_execute``, etc.).  The detail string is
+    # carried in ``reasoning_content``.
+    AGENT_EVENT = "agent_event"
+    """Structured semantic update from a graph node.  Covers what previously
+    used dedicated chunk types (retrieval summaries, plan summaries,
+    verification outcomes) plus LangGraph debug events when
+    ``AgenticRAGConfig.enable_debug_stream=True``.  The ``stage`` field
+    identifies the source node."""
+
+    ERROR = "error"
+    """Pipeline-level error.  ``Message.content`` carries the user-visible error
+    message; ``reasoning_content`` carries the error detail when available."""
+
+
+# =============================================================================
+# PARALLEL-TASK NODES — PER-RUN BUFFERING
+# =============================================================================
+# Graph nodes that fan out to N concurrent ``_execute_single_task`` coroutines
+# via ``asyncio.gather``.  When tokens from those nested LLM calls reach the
+# ``stream_mode="messages"`` channel, they arrive interleaved across tasks and
+# are unreadable if forwarded as-is.
+#
+# Why filter at the translator (not at the LLM call site): LangGraph
+# propagates its messages-mode callback handler via async context variables,
+# so any chat model invocation inside a node — including ``ainvoke`` — fires
+# ``on_llm_new_token`` callbacks regardless of whether the explicit ``config``
+# argument is passed through.  Translator-side handling is the reliable
+# choke point.
+#
+# Strategy: instead of dropping these tokens, we buffer them per-run-id (the
+# UUID LangChain attaches to each ``BaseChatModel`` invocation) for the
+# duration of the parallel phase.  When the node's ``stage_end`` event
+# arrives — which only fires after ``asyncio.gather`` returns, i.e. all
+# tasks have completed — we drain the buffer and emit ONE consolidated
+# ``intermediate_reasoning`` chunk and ONE ``intermediate_output`` chunk per
+# run_id.  This preserves all information, eliminates token jumbling, and
+# isolates each task in its own pair of chunks.
+#
+# Trade-off: clients see no live tokens during the parallel phase — they
+# get a burst of consolidated chunks at stage_end instead.  Single-LLM-call
+# nodes (``plan``, ``verify``, ``synthesize``) still stream live as before.
+
+PARALLEL_TASK_NODES: frozenset[str] = frozenset({"execute", "verify_execute"})
+
+
+# =============================================================================
+# USER-FACING LABELS
+# =============================================================================
+# Single source of truth for every string we surface on the wire as a
+# stage_start / stage_end / agent_event ``reasoning_content``.  Writer call
+# sites in nodes pass only a ``key`` (and any ``{placeholder}`` params); the
+# translator looks up the template here and formats it.  Keeping the strings
+# in one place means UX wording can be reviewed/changed without grepping
+# through the agentic_rag pipeline code.
+#
+# Convention for keys: ``{stage}.{phase}[.{variant}]`` — e.g.
+# ``plan.start.scope`` / ``execute.end.no_data`` / ``verify.end.passed``.
+# Templates can use ``{placeholder}`` substitutions; values come from the
+# ``params`` kwargs passed to the make_* helpers.
+
+
+USER_FACING_LABELS: dict[str, str] = {
+    # --- initial_retrieval ----------------------------------------------------
+    "initial_retrieval.start": "Searching the knowledge base for relevant information…",
+    "initial_retrieval.end": "Found {chunks} relevant passage(s).",
+    # --- plan: phase 1 (scope discovery) -------------------------------------
+    "plan.start.scope": "Exploring what's available in the knowledge base…",
+    "plan.end.scope": "Identified {task_count} topic(s) to explore further.",
+    # --- plan: phase 2 (answer plan) -----------------------------------------
+    "plan.start.answer": "Planning the next retrieval steps…",
+    "plan.end.with_tasks": "Created {task_count} targeted retrieval task(s).",
+    "plan.end.no_tasks": "Initial context is sufficient — no further retrieval needed.",
+    "plan.end.failed": "Couldn't produce a plan — proceeding with available context.",
+    # --- execute --------------------------------------------------------------
+    "execute.start.answer": "Executing {task_count} retrieval task(s) in parallel…",
+    "execute.start.scope": "Running scope-discovery searches in parallel…",
+    "execute.end.done": "Completed retrieval ({answered} of {task_count} task(s) answered).",
+    "execute.end.no_tasks": "Skipping retrieval — using the initial context.",
+    "execute.end.replan": "Found enough information to refine the plan.",
+    "execute.end.no_data": "No additional information found — using the initial context.",
+    # --- synthesize -----------------------------------------------------------
+    "synthesize.start": "Composing the answer…",
+    "synthesize.start.refining": "Refining the answer with new findings…",
+    "synthesize.end": "Answer ready.",
+    "synthesize.end.unchanged": "Keeping the previous answer (no new information).",
+    "synthesize.end.failed": "Encountered an error while generating the answer.",
+    # --- verify ---------------------------------------------------------------
+    "verify.start": "Reviewing the answer for completeness…",
+    "verify.end.passed": "Answer looks complete.",
+    "verify.end.failed": "Identified {issues} potential gap(s) — running follow-up retrieval.",
+    "verify.end.failed_unspecified": "Need additional information — running follow-up retrieval.",
+    "verify.end.error": "Could not verify the answer — using the current draft.",
+    # --- verify_execute -------------------------------------------------------
+    "verify_execute.start": "Filling in the identified gaps…",
+    "verify_execute.end": "Filled {answered} additional gap(s).",
+    "verify_execute.end.no_tasks": "No follow-up retrieval needed.",
+    # --- generic / fallback ---------------------------------------------------
+    # Used when callers don't pass a specific key.
+    "default.start": "Working…",
+    "default.end": "Done.",
+}
+
+
+def _format_label(key: str, params: dict[str, Any] | None = None) -> str:
+    """Look up ``key`` in :data:`USER_FACING_LABELS` and substitute placeholders.
+
+    Falls back to a humanized version of the key if no template is registered
+    (and logs a warning so missing keys are easy to spot).  This keeps an
+    unknown key from breaking the stream — at worst the client sees a
+    slightly less polished string.
+    """
+    template = USER_FACING_LABELS.get(key)
+    if template is None:
+        logger.warning("[stream] no user-facing label registered for key %r", key)
+        return key.replace("_", " ").replace(".", " — ").strip().capitalize() or "—"
+    if not params:
+        return template
+    try:
+        return template.format(**params)
+    except (KeyError, IndexError) as ex:
+        logger.warning(
+            "[stream] label format error for key %r (params=%s): %s", key, params, ex
+        )
+        return template
+
+
+# =============================================================================
+# CUSTOM-EVENT PAYLOAD BUILDERS
+# =============================================================================
+# Nodes call ``writer(make_*())`` to push semantic events into the custom
+# stream.  Payloads carry a ``key`` (looked up in USER_FACING_LABELS by the
+# translator) plus structured ``params`` — never an inline rendered string.
+
+
+def make_stage_start(
+    stage: str, *, key: str | None = None, **params: Any
+) -> dict[str, Any]:
+    """Build a stage_start payload.
+
+    Args:
+        stage:  Graph node name (used as the ``stage`` field on the wire).
+        key:    Label key in :data:`USER_FACING_LABELS`.  Defaults to
+                ``f"{stage}.start"`` so simple cases need no key argument.
+        **params: Substitutions for ``{placeholder}`` slots in the template.
+    """
+    return {
+        "node": stage,
+        "event": "stage_start",
+        "key": key or f"{stage}.start",
+        "params": params,
+    }
+
+
+def make_stage_end(
+    stage: str, *, key: str | None = None, **params: Any
+) -> dict[str, Any]:
+    """Build a stage_end payload (see :func:`make_stage_start` for arg semantics)."""
+    return {
+        "node": stage,
+        "event": "stage_end",
+        "key": key or f"{stage}.end",
+        "params": params,
+    }
+
+
+def make_agent_event(stage: str, *, key: str, **params: Any) -> dict[str, Any]:
+    """Build a generic ``agent_event`` payload.
+
+    Use this for mid-stage updates that aren't a node start/end (e.g. a
+    per-task retrieval summary inside a long-running parallel execute).
+    """
+    return {
+        "node": stage,
+        "event": "agent_event",
+        "key": key,
+        "params": params,
+    }
+
+
+def make_final_stage_marker(*, is_final: bool) -> dict[str, Any]:
+    """Build a final_stage_marker payload.
+
+    synthesize_node calls this BEFORE its LLM call so the translator knows
+    whether to label subsequent ``synthesize`` token chunks as
+    ``final_*`` (when ``is_final=True``) or ``intermediate_*``.
+    """
+    return {
+        "node": "synthesize",
+        "event": "final_stage_marker",
+        "is_final": is_final,
+    }
+
+
+# =============================================================================
+# SSE CHUNK BUILDERS
+# =============================================================================
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def _build_chunk(
+    *,
+    resp_id: str,
+    model: str,
+    event_type: str | None,
+    stage: str | None,
+    content: str = "",
+    reasoning_content: str | None = None,
+    finish_reason: str | None = None,
+    citations: Citations | None = None,
+    metrics: Metrics | None = None,
+    usage: Usage | None = None,
+) -> str:
+    """Build a single SSE-encoded ChainResponse line."""
+    chain_response = ChainResponse(
+        id=resp_id,
+        model=model,
+        object="chat.completion.chunk",
+        created=_now(),
+        event_type=event_type,
+        stage=stage,
+    )
+    chain_response.choices.append(
+        ChainResponseChoices(
+            index=0,
+            message=Message(
+                role="assistant",
+                content=content,
+                reasoning_content=reasoning_content,
+            ),
+            delta=Message(
+                role=None,
+                content=content,
+                reasoning_content=reasoning_content,
+            ),
+            finish_reason=finish_reason,
+        )
+    )
+    if citations is not None:
+        chain_response.citations = citations
+    if metrics is not None:
+        chain_response.metrics = metrics
+    if usage is not None:
+        chain_response.usage = usage
+
+    return "data: " + chain_response.model_dump_json() + "\n\n"
+
+
+# =============================================================================
+# DEBUG-EVENT FORMATTING
+# =============================================================================
+
+
+def _format_debug_event(payload: dict[str, Any]) -> str:
+    """Compact JSON-string summary of a LangGraph debug event."""
+    event_type = payload.get("type", "?")
+    node_payload = payload.get("payload", {}) or {}
+    summary: dict[str, Any] = {"type": event_type, "step": payload.get("step")}
+    if event_type == "task":
+        summary["node"] = node_payload.get("name")
+    elif event_type == "task_result":
+        summary["node"] = node_payload.get("name")
+        summary["wrote"] = [w[0] for w in node_payload.get("writes", []) if w]
+    return json.dumps(summary, default=str)
+
+
+# =============================================================================
+# PARALLEL-TASK BUFFER DRAIN
+# =============================================================================
+
+
+def _drain_parallel_buffer(
+    parallel_buffers: dict[str, dict[str, dict[str, list[str]]]],
+    node: str,
+    *,
+    resp_id: str,
+    model: str,
+) -> list[str]:
+    """Build SSE chunks from any tokens buffered for ``node`` and clear them.
+
+    ``parallel_buffers`` is shaped ``{node: {run_id: {"content": [...],
+    "reasoning": [...]}}}``.  For each ``run_id`` in insertion order (which
+    corresponds to first-token-arrival order across the concurrent tasks),
+    emits at most two consolidated chunks:
+
+    * one ``intermediate_reasoning`` if the run produced any reasoning tokens
+    * one ``intermediate_output`` if the run produced any visible-content
+      tokens
+
+    Returns an ordered list of SSE-encoded ``ChainResponse`` strings.  The
+    node's entry is removed from ``parallel_buffers`` so a subsequent stage
+    on the same node (e.g. scope-discovery → answer phase) starts fresh.
+    """
+    out: list[str] = []
+    runs = parallel_buffers.pop(node, None)
+    if not runs:
+        return out
+    for parts in runs.values():
+        reasoning = "".join(parts.get("reasoning", []))
+        if reasoning:
+            out.append(
+                _build_chunk(
+                    resp_id=resp_id,
+                    model=model,
+                    event_type=EventType.INTERMEDIATE_REASONING.value,
+                    stage=node,
+                    reasoning_content=reasoning,
+                )
+            )
+        content = "".join(parts.get("content", []))
+        if content:
+            out.append(
+                _build_chunk(
+                    resp_id=resp_id,
+                    model=model,
+                    event_type=EventType.INTERMEDIATE_OUTPUT.value,
+                    stage=node,
+                    reasoning_content=content,
+                )
+            )
+    return out
+
+
+def _resolve_run_id(chunk: Any, metadata: dict[str, Any] | None) -> str:
+    """Best-effort discriminator for grouping tokens from one LLM invocation.
+
+    LangChain stamps every ``BaseChatModel`` invocation with a UUID; chunks
+    from the same astream share that id.  We look at ``chunk.id`` first
+    (most reliable across providers), then ``metadata["run_id"]``, and fall
+    back to ``"_unknown"``.  An ``"_unknown"`` bucket means concurrent
+    tasks would collapse into one consolidated chunk on this provider —
+    not ideal, but never crashes.
+    """
+    candidate = getattr(chunk, "id", None)
+    if not candidate and metadata:
+        candidate = metadata.get("run_id")
+    return str(candidate) if candidate else "_unknown"
+
+
+# =============================================================================
+# THE TRANSLATOR
+# =============================================================================
+
+
+async def translate_graph_stream(
+    graph: Any,
+    initial_state: Any,
+    *,
+    model: str,
+    recursion_limit: int,
+    citations_provider: Callable[[], Citations | None] | None = None,
+    enable_debug_stream: bool = False,
+    rag_start_time_sec: float | None = None,
+    on_complete: Callable[[str], Awaitable[None]] | None = None,
+) -> AsyncIterator[str]:
+    """Consume ``graph.astream(stream_mode=["messages","custom","debug"])`` and
+    yield SSE-formatted ``ChainResponse`` strings ready to be streamed to the
+    HTTP client.
+
+    Args:
+        graph:               Compiled LangGraph (must support ``astream``).
+        initial_state:       Initial state for the graph.
+        model:               Model name to stamp on each ChainResponse.
+        recursion_limit:     LangGraph recursion limit.
+        citations_provider:  A zero-arg callable that returns the current
+                             ``Citations | None`` object built up from the
+                             retriever bridge.  Called when the FIRST
+                             ``final_answer`` chunk is about to be emitted.
+                             Pass ``None`` to skip citations.
+        enable_debug_stream: When True, debug-mode events are forwarded to the
+                             client as ``agent_event`` chunks; otherwise they
+                             are only logged server-side.
+        rag_start_time_sec:  Wall-clock start of the request (for RAG TTFT).
+        on_complete:         Optional zero-arg async callable invoked after the
+                             final-answer stream ends.  Useful for the runner
+                             to record the final answer / log metrics without
+                             coupling that logic into this module.
+    """
+    resp_id = str(uuid4())
+    request_start = time.time()
+
+    # Per-stream state ---------------------------------------------------------
+    # Tracks whether the next "messages" chunk from synthesize_node should be
+    # treated as final or intermediate.  None = unknown (default to intermediate
+    # so we never accidentally swap delta content for a non-final pass).
+    synthesize_is_final: bool | None = None
+
+    first_final_token_seen = False
+    first_token_seen = False  # any kind of token; for logging only
+    rag_ttft_ms: float | None = None
+    llm_ttft_ms: float | None = None
+    accumulated_final_answer: list[str] = []
+
+    # Per-run token buffer for parallel-task nodes.  See PARALLEL_TASK_NODES
+    # for the rationale.  Shape: {node: {run_id: {"content": [parts],
+    # "reasoning": [parts]}}}.  Drained at the corresponding stage_end (and
+    # again at stream end as a safety net for graphs that didn't emit one).
+    parallel_buffers: dict[str, dict[str, dict[str, list[str]]]] = {}
+
+    try:
+        async for mode, data in graph.astream(
+            initial_state,
+            config={"recursion_limit": recursion_limit},
+            stream_mode=["messages", "custom", "debug"],
+        ):
+            # -----------------------------------------------------------------
+            # CUSTOM mode — semantic events emitted by node ``writer({...})``.
+            # -----------------------------------------------------------------
+            if mode == "custom":
+                event = data.get("event", "")
+                node = data.get("node", "")
+
+                if event == "final_stage_marker":
+                    synthesize_is_final = bool(data.get("is_final", False))
+                    logger.debug(
+                        "[stream] synthesize final_stage_marker: is_final=%s",
+                        synthesize_is_final,
+                    )
+                    # No SSE chunk for this — purely internal routing signal.
+                    continue
+
+                if event in ("stage_start", "stage_end", "agent_event"):
+                    # When a parallel-task node closes, drain its per-run
+                    # token buffer first so the consolidated intermediate_*
+                    # chunks land BEFORE the stage_end event on the wire.
+                    if event == "stage_end" and node in PARALLEL_TASK_NODES:
+                        for sse in _drain_parallel_buffer(
+                            parallel_buffers, node, resp_id=resp_id, model=model
+                        ):
+                            yield sse
+
+                    label = _format_label(
+                        data.get("key", ""), data.get("params") or {}
+                    )
+                    if event == "stage_start":
+                        wire_event_type = EventType.STAGE_START.value
+                    elif event == "stage_end":
+                        wire_event_type = EventType.STAGE_END.value
+                    else:
+                        wire_event_type = EventType.AGENT_EVENT.value
+                    yield _build_chunk(
+                        resp_id=resp_id,
+                        model=model,
+                        event_type=wire_event_type,
+                        stage=node,
+                        reasoning_content=label,
+                    )
+                    continue
+
+                # Unknown custom event — log and skip rather than 500.
+                logger.debug("[stream] unknown custom event: %s", data)
+                continue
+
+            # -----------------------------------------------------------------
+            # MESSAGES mode — LLM token deltas.  Tuple of (chunk, metadata).
+            # -----------------------------------------------------------------
+            if mode == "messages":
+                chunk, metadata = data
+                node = (metadata or {}).get("langgraph_node", "") or ""
+
+                content_delta = getattr(chunk, "content", "") or ""
+                if content_delta and not isinstance(content_delta, str):
+                    content_delta = str(content_delta)
+
+                kw = getattr(chunk, "additional_kwargs", None) or {}
+                reasoning_delta = kw.get("reasoning_content")
+                if reasoning_delta and not isinstance(reasoning_delta, str):
+                    reasoning_delta = str(reasoning_delta)
+
+                if not content_delta and not reasoning_delta:
+                    continue
+
+                # Parallel-task nodes — buffer per-run-id; the stage_end
+                # handler will drain the buffer and emit one consolidated
+                # intermediate_reasoning + intermediate_output per task.
+                if node in PARALLEL_TASK_NODES:
+                    run_id = _resolve_run_id(chunk, metadata)
+                    run_buf = parallel_buffers.setdefault(node, {}).setdefault(
+                        run_id, {"content": [], "reasoning": []}
+                    )
+                    if reasoning_delta:
+                        run_buf["reasoning"].append(reasoning_delta)
+                    if content_delta:
+                        run_buf["content"].append(content_delta)
+                    continue
+
+                # Default to intermediate; promote to final only when synthesize
+                # has emitted its is_final marker.
+                is_final_node = node == "synthesize" and synthesize_is_final is True
+
+                if not first_token_seen:
+                    first_token_seen = True
+                    logger.debug(
+                        "[stream] first LLM token from node=%s (final=%s)",
+                        node,
+                        is_final_node,
+                    )
+
+                # Reasoning delta — emit as own chunk so clients can render it
+                # in a separate panel without splitting on content boundaries.
+                if reasoning_delta:
+                    yield _build_chunk(
+                        resp_id=resp_id,
+                        model=model,
+                        event_type=(
+                            EventType.FINAL_REASONING.value
+                            if is_final_node
+                            else EventType.INTERMEDIATE_REASONING.value
+                        ),
+                        stage=node,
+                        reasoning_content=reasoning_delta,
+                    )
+
+                if content_delta:
+                    if is_final_node:
+                        # Mirror response_generator.generate_answer_async:
+                        # citations + TTFT attach to the FIRST final-answer chunk.
+                        citations: Citations | None = None
+                        if not first_final_token_seen:
+                            first_final_token_seen = True
+                            llm_ttft_ms = (time.time() - request_start) * 1000
+                            if rag_start_time_sec is not None:
+                                rag_ttft_ms = (time.time() - rag_start_time_sec) * 1000
+                            logger.info(
+                                "    == LLM Time to First Token (TTFT): %.2f ms ==",
+                                llm_ttft_ms,
+                            )
+                            if rag_ttft_ms is not None:
+                                logger.info(
+                                    "    == RAG Time to First Token (TTFT): %.2f ms ==",
+                                    rag_ttft_ms,
+                                )
+                            if citations_provider is not None:
+                                try:
+                                    citations = citations_provider()
+                                except Exception as cex:  # noqa: BLE001
+                                    logger.warning(
+                                        "[stream] citations provider failed: %s", cex
+                                    )
+
+                        accumulated_final_answer.append(content_delta)
+                        yield _build_chunk(
+                            resp_id=resp_id,
+                            model=model,
+                            event_type=EventType.FINAL_ANSWER.value,
+                            stage=node,
+                            content=content_delta,
+                            citations=citations,
+                        )
+                    else:
+                        yield _build_chunk(
+                            resp_id=resp_id,
+                            model=model,
+                            event_type=EventType.INTERMEDIATE_OUTPUT.value,
+                            stage=node,
+                            reasoning_content=content_delta,
+                        )
+                continue
+
+            # -----------------------------------------------------------------
+            # DEBUG mode — internal LangGraph lifecycle events.
+            # -----------------------------------------------------------------
+            if mode == "debug":
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug("[stream] debug event: %s", _format_debug_event(data))
+                if enable_debug_stream:
+                    yield _build_chunk(
+                        resp_id=resp_id,
+                        model=model,
+                        event_type=EventType.AGENT_EVENT.value,
+                        stage=(data.get("payload") or {}).get("name"),
+                        reasoning_content=_format_debug_event(data),
+                    )
+                continue
+
+        # ---------------------------------------------------------------------
+        # Safety net — flush any parallel-task buffers that didn't get drained
+        # by a stage_end (graph crashed mid-execute, node was cancelled, etc.).
+        # ---------------------------------------------------------------------
+        for leftover_node in list(parallel_buffers.keys()):
+            for sse in _drain_parallel_buffer(
+                parallel_buffers, leftover_node, resp_id=resp_id, model=model
+            ):
+                yield sse
+
+        # ---------------------------------------------------------------------
+        # Stream finished — emit the trailing finish chunk with metrics, just
+        # as generate_answer_async does for the regular pipeline.
+        # ---------------------------------------------------------------------
+        llm_generation_time_ms = (time.time() - request_start) * 1000
+        final_metrics = Metrics(
+            rag_ttft_ms=rag_ttft_ms,
+            llm_ttft_ms=llm_ttft_ms,
+            llm_generation_time_ms=llm_generation_time_ms,
+        )
+
+        finish_response = ChainResponse(
+            id=resp_id,
+            model=model,
+            object="chat.completion.chunk",
+            created=_now(),
+            metrics=final_metrics,
+        )
+        finish_response.choices.append(
+            ChainResponseChoices(
+                index=0,
+                message=Message(role="assistant", content=""),
+                delta=Message(role=None, content=""),
+                finish_reason="stop",
+            )
+        )
+        yield "data: " + finish_response.model_dump_json() + "\n\n"
+
+        if on_complete is not None:
+            try:
+                await on_complete("".join(accumulated_final_answer))
+            except Exception as cex:  # noqa: BLE001
+                logger.warning("[stream] on_complete hook failed: %s", cex)
+
+    except asyncio.CancelledError:
+        logger.info("[stream] client disconnected — cancelling graph stream")
+        raise
+    except Exception as ex:  # noqa: BLE001
+        logger.exception("[stream] graph stream failed: %s", ex)
+        # Surface the error to the client so it doesn't hang on a half-stream.
+        yield _build_chunk(
+            resp_id=resp_id,
+            model=model,
+            event_type=EventType.ERROR.value,
+            stage=None,
+            content="I encountered an error while processing your request via agentic RAG.",
+            reasoning_content=str(ex)[:500],
+            finish_reason="stop",
+        )

--- a/src/nvidia_rag/rag_server/main.py
+++ b/src/nvidia_rag/rag_server/main.py
@@ -220,7 +220,9 @@ class NvidiaRAG:
             "api_key": self.config.query_rewriter.get_api_key(),
         }
         # Log config without sensitive api_key
-        safe_config = {k: v for k, v in query_rewriter_llm_config.items() if k != "api_key"}
+        safe_config = {
+            k: v for k, v in query_rewriter_llm_config.items() if k != "api_key"
+        }
         logger.info(
             "Query rewriter llm config: model name %s, url %s, config %s",
             self.config.query_rewriter.model_name,
@@ -447,6 +449,7 @@ class NvidiaRAG:
         fetch_full_page_context: bool | None = None,
         fetch_neighboring_pages: int | None = None,
         agentic: bool | None = None,
+        enable_streaming: bool = True,
         rag_start_time_sec: float | None = None,
         metrics: OtelMetrics | None = None,
     ) -> AsyncGenerator[str, None]:
@@ -488,9 +491,16 @@ class NvidiaRAG:
         logger.info("  - enable_filter_generator: %s", enable_filter_generator)
         logger.info("  - enable_query_decomposition: %s", enable_query_decomposition)
         logger.info("  - enable_vlm_inference: %s", enable_vlm_inference)
-        logger.info("  - enable_reflection: %s", self.config.reflection.enable_reflection)
+        logger.info(
+            "  - enable_reflection: %s", self.config.reflection.enable_reflection
+        )
         logger.info("  - vdb_top_k: %s, reranker_top_k: %s", vdb_top_k, reranker_top_k)
-        logger.info("  - temperature: %s, top_p: %s, max_tokens: %s", temperature, top_p, max_tokens)
+        logger.info(
+            "  - temperature: %s, top_p: %s, max_tokens: %s",
+            temperature,
+            top_p,
+            max_tokens,
+        )
         logger.info("  - model: %s", model)
         logger.info("  - agentic: %s", agentic)
         logger.info("-" * 80)
@@ -633,7 +643,9 @@ class NvidiaRAG:
         # Log extracted query
         query_text = self._extract_text_from_content(query)
         logger.info("Extracted Query: '%s'", query_text[:200] if query_text else "")
-        logger.info("Chat History: %d message(s)", len(chat_history) if chat_history else 0)
+        logger.info(
+            "Chat History: %d message(s)", len(chat_history) if chat_history else 0
+        )
 
         llm_settings = {
             "model": model,
@@ -696,6 +708,7 @@ class NvidiaRAG:
                     enable_citations=enable_citations,
                     model=model,
                     vdb_op=vdb_op,
+                    enable_streaming=enable_streaming,
                     rag_start_time_sec=rag_start_time_sec,
                     metrics=metrics,
                 )
@@ -870,7 +883,9 @@ class NvidiaRAG:
         # Choose the citations builder based on ingestion mode.
         # NRL (LanceDB) produces text-only flat metadata; nv-ingest produces
         # structured metadata with potential object-store image / table assets.
-        _citations_fn = prepare_citations_nrl if self._is_nrl_mode else prepare_citations
+        _citations_fn = (
+            prepare_citations_nrl if self._is_nrl_mode else prepare_citations
+        )
 
         try:
             if not collection_names:
@@ -1252,7 +1267,9 @@ class NvidiaRAG:
             # Get relevant documents with optional reflection
             otel_ctx = otel_context.get_current()
             if self.config.reflection.enable_reflection:
-                context_reflection_counter = ReflectionCounter(self.config.reflection.max_loops)
+                context_reflection_counter = ReflectionCounter(
+                    self.config.reflection.max_loops
+                )
                 docs, is_relevant = await check_context_relevance(
                     vdb_op=vdb_op,
                     retriever_query=processed_query,
@@ -1275,7 +1292,11 @@ class NvidiaRAG:
                     logger.warning(
                         "Could not find sufficiently relevant context after maximum attempts"
                     )
-                _cit = _citations_fn(retrieved_documents=docs, force_citations=True, enable_citations=enable_citations)
+                _cit = _citations_fn(
+                    retrieved_documents=docs,
+                    force_citations=True,
+                    enable_citations=enable_citations,
+                )
                 for _r in _cit.results:
                     _r.stage = stage
                 return _cit
@@ -1360,7 +1381,9 @@ class NvidiaRAG:
                         )
 
                     _cit = _citations_fn(
-                        retrieved_documents=docs, force_citations=True, enable_citations=enable_citations
+                        retrieved_documents=docs,
+                        force_citations=True,
+                        enable_citations=enable_citations,
                     )
                     for _r in _cit.results:
                         _r.stage = stage
@@ -1394,7 +1417,9 @@ class NvidiaRAG:
                             otel_ctx=otel_ctx,
                         )
                     _cit = _citations_fn(
-                        retrieved_documents=docs, force_citations=True, enable_citations=enable_citations
+                        retrieved_documents=docs,
+                        force_citations=True,
+                        enable_citations=enable_citations,
                     )
                     for _r in _cit.results:
                         _r.stage = stage
@@ -1595,10 +1620,12 @@ class NvidiaRAG:
             logger.info("  - Model: %s", model)
             llm_endpoint_display = llm_settings.get("llm_endpoint") or "api catalog"
             logger.info("  - Endpoint: %s", llm_endpoint_display)
-            logger.info("  - Temperature: %s, Top-P: %s, Max Tokens: %s",
-                       llm_settings.get("temperature"),
-                       llm_settings.get("top_p"),
-                       llm_settings.get("max_tokens"))
+            logger.info(
+                "  - Temperature: %s, Top-P: %s, Max Tokens: %s",
+                llm_settings.get("temperature"),
+                llm_settings.get("top_p"),
+                llm_settings.get("max_tokens"),
+            )
             logger.info("Input:")
             logger.info("  - Query: '%s'", query_text[:200] if query_text else "")
             logger.info("Starting LLM stream generation...")
@@ -1768,12 +1795,19 @@ class NvidiaRAG:
 
             # Resolve VLM settings from dict or config defaults
             vlm_model_cfg = vlm_settings.get("vlm_model") or self.config.vlm.model_name
-            vlm_endpoint_cfg = vlm_settings.get("vlm_endpoint") or self.config.vlm.server_url
-            vlm_temperature_cfg = vlm_settings.get("vlm_temperature") or self.config.vlm.temperature
+            vlm_endpoint_cfg = (
+                vlm_settings.get("vlm_endpoint") or self.config.vlm.server_url
+            )
+            vlm_temperature_cfg = (
+                vlm_settings.get("vlm_temperature") or self.config.vlm.temperature
+            )
             vlm_top_p_cfg = vlm_settings.get("vlm_top_p") or self.config.vlm.top_p
-            vlm_max_tokens_cfg = vlm_settings.get("vlm_max_tokens") or self.config.vlm.max_tokens
+            vlm_max_tokens_cfg = (
+                vlm_settings.get("vlm_max_tokens") or self.config.vlm.max_tokens
+            )
             vlm_max_total_images_cfg = (
-                vlm_settings.get("vlm_max_total_images") or self.config.vlm.max_total_images
+                vlm_settings.get("vlm_max_total_images")
+                or self.config.vlm.max_total_images
             )
 
             # Extract text from query for logging
@@ -1786,13 +1820,20 @@ class NvidiaRAG:
             logger.info("VLM Configuration:")
             logger.info("  - Model: %s", vlm_model_cfg)
             logger.info("  - Endpoint: %s", vlm_endpoint_cfg)
-            logger.info("  - Temperature: %s, Top-P: %s, Max Tokens: %s",
-                       vlm_temperature_cfg, vlm_top_p_cfg, vlm_max_tokens_cfg)
+            logger.info(
+                "  - Temperature: %s, Top-P: %s, Max Tokens: %s",
+                vlm_temperature_cfg,
+                vlm_top_p_cfg,
+                vlm_max_tokens_cfg,
+            )
             logger.info("  - Max Total Images: %s", vlm_max_total_images_cfg)
             logger.info("Input:")
             logger.info("  - Query: '%s'", query_text[:200] if query_text else "")
             logger.info("  - Has Images in Query: %s", has_images)
-            logger.info("  - Chat History Messages: %d", len(chat_history) if chat_history else 0)
+            logger.info(
+                "  - Chat History Messages: %d",
+                len(chat_history) if chat_history else 0,
+            )
             logger.info("Starting VLM stream generation...")
             logger.info("-" * 80)
 
@@ -1879,7 +1920,9 @@ class NvidiaRAG:
                 return RAGResponse(
                     generate_answer_async(
                         _async_iter(
-                            ["Authentication or permission error: Verify the validity and permissions of your NVIDIA API key."]
+                            [
+                                "Authentication or permission error: Verify the validity and permissions of your NVIDIA API key."
+                            ]
                         ),
                         [],
                         model=model,
@@ -2025,11 +2068,13 @@ class NvidiaRAG:
 
             # Process text types first, then image_url types.
             text_items = [
-                item for item in content
+                item
+                for item in content
                 if isinstance(item, dict) and item.get("type") == "text"
             ]
             image_items = [
-                item for item in content
+                item
+                for item in content
                 if isinstance(item, dict) and item.get("type") == "image_url"
             ]
 
@@ -2045,12 +2090,14 @@ class NvidiaRAG:
                 if image_url:
                     image_parts.append(image_url)
                     is_image_query = True
-                    break # only one image is supported
+                    break  # only one image is supported
 
             text_query = "\n\n".join(text_parts)
             if image_parts:
                 image_str = " ".join(image_parts)
-                final_query = (text_query + " " + image_str) if text_query else image_str
+                final_query = (
+                    (text_query + " " + image_str) if text_query else image_str
+                )
             else:
                 final_query = text_query
             return final_query, is_image_query
@@ -2070,10 +2117,14 @@ class NvidiaRAG:
         produce equivalent agents so there is no correctness issue.
         """
         if self._agentic_agent is None:
-            from nvidia_rag.rag_server.agentic_rag.builder import build_agentic_rag_agent
+            from nvidia_rag.rag_server.agentic_rag.builder import (
+                build_agentic_rag_agent,
+            )
 
             logger.info("Building AgenticRag (first agentic request)…")
-            self._agentic_agent, self._agentic_graph = await build_agentic_rag_agent(self)
+            self._agentic_agent, self._agentic_graph = await build_agentic_rag_agent(
+                self
+            )
         return self._agentic_agent, self._agentic_graph
 
     async def _agentic_chain(
@@ -2097,6 +2148,7 @@ class NvidiaRAG:
         enable_citations: bool,
         model: str,
         vdb_op: VDBRag,
+        enable_streaming: bool,
         rag_start_time_sec: float | None,
         metrics: Any | None,
     ) -> RAGResponse:
@@ -2222,7 +2274,11 @@ class NvidiaRAG:
         logger.info("=" * 60)
         logger.info("  - query: '%s'", retriever_query[:200])
         logger.info("  - collections: %s", collection_names)
-        logger.info("  - enable_reranker: %s, reranker_top_k: %s", enable_reranker, reranker_top_k)
+        logger.info(
+            "  - enable_reranker: %s, reranker_top_k: %s",
+            enable_reranker,
+            reranker_top_k,
+        )
 
         return await run_agentic_pipeline(
             agent=agent,
@@ -2234,6 +2290,7 @@ class NvidiaRAG:
             use_nrl_citations=self._is_nrl_mode,
             model=model,
             collection_names=collection_names,
+            enable_streaming=enable_streaming,
             rag_start_time_sec=rag_start_time_sec,
             metrics=metrics,
         )
@@ -2481,10 +2538,18 @@ class NvidiaRAG:
                     logger.info("=" * 80)
                     logger.info("Configuration:")
                     logger.info("  - Model: %s", self.config.query_rewriter.model_name)
-                    logger.info("  - Endpoint: %s", self.config.query_rewriter.server_url)
+                    logger.info(
+                        "  - Endpoint: %s", self.config.query_rewriter.server_url
+                    )
                     logger.info("Input:")
-                    logger.info("  - Query: '%s'", retriever_query[:200] if retriever_query else "")
-                    logger.info("  - Chat History Messages: %d", len(chat_history) if chat_history else 0)
+                    logger.info(
+                        "  - Query: '%s'",
+                        retriever_query[:200] if retriever_query else "",
+                    )
+                    logger.info(
+                        "  - Chat History Messages: %d",
+                        len(chat_history) if chat_history else 0,
+                    )
                     logger.info("-" * 80)
 
                     # Skip query rewriting if conversation history is disabled
@@ -2564,7 +2629,9 @@ class NvidiaRAG:
                             logger.warning("Could not format prompt for logging: %s", e)
 
                         try:
-                            with traced_span("rag.Query Rewriting.token_usage") as qr_span:
+                            with traced_span(
+                                "rag.Query Rewriting.token_usage"
+                            ) as qr_span:
                                 with usage_collector_scope(
                                     aggregate_llm_token_usage, "Query Rewriting"
                                 ):
@@ -2575,7 +2642,10 @@ class NvidiaRAG:
                                         },
                                         config={"run_name": "query-rewriter"},
                                     )
-                                u = aggregate_llm_token_usage.get("Query Rewriting") or {}
+                                u = (
+                                    aggregate_llm_token_usage.get("Query Rewriting")
+                                    or {}
+                                )
                                 set_span_llm_usage(
                                     qr_span,
                                     u.get("input_tokens", 0),
@@ -2597,9 +2667,18 @@ class NvidiaRAG:
                             ) from e
 
                         logger.info("Query Rewriting Output:")
-                        logger.info("  - Original Query: '%s'", processed_query[:200] if processed_query else "")
-                        logger.info("  - Rewritten Query: '%s'", retriever_query[:200] if retriever_query else "")
-                        logger.info("  - Rewritten Query Length: %d characters", len(retriever_query))
+                        logger.info(
+                            "  - Original Query: '%s'",
+                            processed_query[:200] if processed_query else "",
+                        )
+                        logger.info(
+                            "  - Rewritten Query: '%s'",
+                            retriever_query[:200] if retriever_query else "",
+                        )
+                        logger.info(
+                            "  - Rewritten Query Length: %d characters",
+                            len(retriever_query),
+                        )
                         logger.info("Query rewriting completed successfully")
                         logger.info("-" * 80)
 
@@ -2644,10 +2723,19 @@ class NvidiaRAG:
                     logger.info("STAGE: Filter Expression Generation")
                     logger.info("=" * 80)
                     logger.info("Configuration:")
-                    logger.info("  - Model: %s", self.config.filter_expression_generator.model_name)
-                    logger.info("  - Endpoint: %s", self.config.filter_expression_generator.server_url)
+                    logger.info(
+                        "  - Model: %s",
+                        self.config.filter_expression_generator.model_name,
+                    )
+                    logger.info(
+                        "  - Endpoint: %s",
+                        self.config.filter_expression_generator.server_url,
+                    )
                     logger.info("Input:")
-                    logger.info("  - Query: '%s'", processed_query[:200] if processed_query else "")
+                    logger.info(
+                        "  - Query: '%s'",
+                        processed_query[:200] if processed_query else "",
+                    )
                     logger.info("  - Collections: %s", validated_collections)
                     logger.info("Generating filter expressions for collections...")
                     logger.info("-" * 80)
@@ -2728,13 +2816,25 @@ class NvidiaRAG:
                         )
                         if generated_count > 0:
                             logger.info("Filter Generation Output:")
-                            logger.info("  - Successfully generated filters for %d/%d collections",
-                                       generated_count, len(validated_collections))
-                            for coll_name, filter_val in collection_filter_mapping.items():
+                            logger.info(
+                                "  - Successfully generated filters for %d/%d collections",
+                                generated_count,
+                                len(validated_collections),
+                            )
+                            for (
+                                coll_name,
+                                filter_val,
+                            ) in collection_filter_mapping.items():
                                 if filter_val:
-                                    logger.info("  - Collection '%s': %s", coll_name, filter_val[:100])
+                                    logger.info(
+                                        "  - Collection '%s': %s",
+                                        coll_name,
+                                        filter_val[:100],
+                                    )
                         else:
-                            logger.info("Filter Generation Output: No filter expressions generated")
+                            logger.info(
+                                "Filter Generation Output: No filter expressions generated"
+                            )
                         logger.info("-" * 80)
 
                     except Exception as e:
@@ -2748,14 +2848,22 @@ class NvidiaRAG:
                 logger.info("  - LLM Model: %s", model)
                 llm_endpoint_display = llm_settings.get("llm_endpoint") or "api catalog"
                 logger.info("  - LLM Endpoint: %s", llm_endpoint_display)
-                logger.info("  - Recursion Depth: %d", self.config.query_decomposition.recursion_depth)
+                logger.info(
+                    "  - Recursion Depth: %d",
+                    self.config.query_decomposition.recursion_depth,
+                )
                 logger.info("  - Enable Reranker: %s", enable_reranker)
                 if enable_reranker:
                     logger.info("  - Reranker Model: %s", reranker_model)
                     logger.info("  - Reranker Top-K: %d", reranker_top_k)
                 logger.info("Input:")
-                logger.info("  - Query: '%s'", self._extract_text_from_content(query)[:200])
-                logger.info("  - Collection: %s", validated_collections[0] if validated_collections else "")
+                logger.info(
+                    "  - Query: '%s'", self._extract_text_from_content(query)[:200]
+                )
+                logger.info(
+                    "  - Collection: %s",
+                    validated_collections[0] if validated_collections else "",
+                )
                 logger.info("  - Retrieval Top-K: %d", top_k)
                 logger.info("  - Confidence Threshold: %.2f", confidence_threshold)
                 logger.info("Starting iterative query decomposition...")
@@ -2807,11 +2915,16 @@ class NvidiaRAG:
                 logger.info("  - Model: %s", self.config.reflection.model_name)
                 logger.info("  - Endpoint: %s", self.config.reflection.server_url)
                 logger.info("  - Max Loops: %d", self.config.reflection.max_loops)
-                logger.info("  - Relevance Threshold: %d", self.config.reflection.context_relevance_threshold)
+                logger.info(
+                    "  - Relevance Threshold: %d",
+                    self.config.reflection.context_relevance_threshold,
+                )
                 logger.info("Starting context relevance check...")
                 logger.info("-" * 80)
 
-                context_reflection_counter = ReflectionCounter(self.config.reflection.max_loops)
+                context_reflection_counter = ReflectionCounter(
+                    self.config.reflection.max_loops
+                )
 
                 with traced_span(
                     "rag.Self Reflection.context_relevance.token_usage"
@@ -2820,7 +2933,10 @@ class NvidiaRAG:
                         aggregate_llm_token_usage, "Self Reflection"
                     ):
                         try:
-                            context_to_show, is_relevant = await check_context_relevance(
+                            (
+                                context_to_show,
+                                is_relevant,
+                            ) = await check_context_relevance(
                                 vdb_op=vdb_op,
                                 retriever_query=processed_query,
                                 collection_names=validated_collections,
@@ -2864,11 +2980,16 @@ class NvidiaRAG:
 
                 logger.info("Reflection Output:")
                 logger.info("  - Context Relevant: %s", is_relevant)
-                logger.info("  - Reflection Iterations: %d", context_reflection_counter.current_count)
+                logger.info(
+                    "  - Reflection Iterations: %d",
+                    context_reflection_counter.current_count,
+                )
                 logger.info("  - Final Documents: %d", len(context_to_show))
                 if not is_relevant:
-                    logger.warning("  - Could not find sufficiently relevant context after %d attempts",
-                                 context_reflection_counter.current_count)
+                    logger.warning(
+                        "  - Could not find sufficiently relevant context after %d attempts",
+                        context_reflection_counter.current_count,
+                    )
                 logger.info("-" * 80)
             else:
                 otel_ctx = otel_context.get_current()
@@ -2878,23 +2999,43 @@ class NvidiaRAG:
                     logger.info("STAGE: VDB Retrieval + Reranking")
                     logger.info("=" * 80)
                     logger.info("Embedding Configuration:")
-                    if hasattr(vdb_op, 'embedding_model') and vdb_op.embedding_model:
-                        logger.info("  - Model: %s", vdb_op.embedding_model._model if hasattr(vdb_op.embedding_model, '_model') else 'N/A')
-                        logger.info("  - Endpoint: %s", getattr(vdb_op.embedding_model, '_client', {}).base_url if hasattr(vdb_op.embedding_model, '_client') else 'N/A')
+                    if hasattr(vdb_op, "embedding_model") and vdb_op.embedding_model:
+                        logger.info(
+                            "  - Model: %s",
+                            vdb_op.embedding_model._model
+                            if hasattr(vdb_op.embedding_model, "_model")
+                            else "N/A",
+                        )
+                        logger.info(
+                            "  - Endpoint: %s",
+                            getattr(vdb_op.embedding_model, "_client", {}).base_url
+                            if hasattr(vdb_op.embedding_model, "_client")
+                            else "N/A",
+                        )
                     else:
                         logger.info("  - Model: N/A")
                         logger.info("  - Endpoint: N/A")
                     logger.info("Reranker Configuration:")
                     logger.info("  - Model: %s", reranker_model)
-                    logger.info("  - Endpoint: %s", reranker_endpoint or self.config.ranking.server_url)
+                    logger.info(
+                        "  - Endpoint: %s",
+                        reranker_endpoint or self.config.ranking.server_url,
+                    )
                     logger.info("Retrieval Configuration:")
-                    logger.info("  - Query: '%s'", retriever_query[:200] if retriever_query else "")
+                    logger.info(
+                        "  - Query: '%s'",
+                        retriever_query[:200] if retriever_query else "",
+                    )
                     logger.info("  - Collections: %s", validated_collections)
                     logger.info("  - VDB Top-K: %d", top_k)
                     logger.info("  - Reranker Top-K: %d", reranker_top_k)
-                    logger.info("  - Filter Expressions: %s",
-                               {k: v[:50] + "..." if len(v) > 50 else v
-                                for k, v in collection_filter_mapping.items()})
+                    logger.info(
+                        "  - Filter Expressions: %s",
+                        {
+                            k: v[:50] + "..." if len(v) > 50 else v
+                            for k, v in collection_filter_mapping.items()
+                        },
+                    )
                     logger.info("Starting parallel retrieval from collections...")
                     logger.info("-" * 80)
 
@@ -2942,7 +3083,10 @@ class NvidiaRAG:
                     logger.info("-" * 80)
 
                     context_reranker_start_time = time.time()
-                    logger.info("Starting reranking with query: '%s'", processed_query[:200] if processed_query else "")
+                    logger.info(
+                        "Starting reranking with query: '%s'",
+                        processed_query[:200] if processed_query else "",
+                    )
                     try:
                         docs = await context_reranker.ainvoke(
                             {"context": docs, "question": processed_query},
@@ -2973,11 +3117,21 @@ class NvidiaRAG:
                     logger.info("Reranking Output:")
                     logger.info("  - Reranked Documents: %d", len(context_to_show))
                     logger.info("  - Reranking Time: %.2f ms", context_reranker_time_ms)
-                    self._log_retrieved_pages(context_to_show, "Initially retrieved pages")
+                    self._log_retrieved_pages(
+                        context_to_show, "Initially retrieved pages"
+                    )
                     if context_to_show:
-                        scores = [doc.metadata.get("relevance_score", "N/A") for doc in context_to_show[:3]]
-                        logger.info("  - Top Document Scores (normalized): %s",
-                                   [f"{s:.4f}" if isinstance(s, (int, float)) else s for s in scores])
+                        scores = [
+                            doc.metadata.get("relevance_score", "N/A")
+                            for doc in context_to_show[:3]
+                        ]
+                        logger.info(
+                            "  - Top Document Scores (normalized): %s",
+                            [
+                                f"{s:.4f}" if isinstance(s, (int, float)) else s
+                                for s in scores
+                            ],
+                        )
                     logger.info("-" * 80)
                 else:
                     # Multiple retrievers are not supported when reranking is disabled
@@ -2985,15 +3139,31 @@ class NvidiaRAG:
                     logger.info("STAGE: VDB Retrieval (without reranking)")
                     logger.info("=" * 80)
                     logger.info("Embedding Configuration:")
-                    if hasattr(vdb_op, 'embedding_model') and vdb_op.embedding_model:
-                        logger.info("  - Model: %s", vdb_op.embedding_model._model if hasattr(vdb_op.embedding_model, '_model') else 'N/A')
-                        logger.info("  - Endpoint: %s", getattr(vdb_op.embedding_model, '_client', {}).base_url if hasattr(vdb_op.embedding_model, '_client') else 'N/A')
+                    if hasattr(vdb_op, "embedding_model") and vdb_op.embedding_model:
+                        logger.info(
+                            "  - Model: %s",
+                            vdb_op.embedding_model._model
+                            if hasattr(vdb_op.embedding_model, "_model")
+                            else "N/A",
+                        )
+                        logger.info(
+                            "  - Endpoint: %s",
+                            getattr(vdb_op.embedding_model, "_client", {}).base_url
+                            if hasattr(vdb_op.embedding_model, "_client")
+                            else "N/A",
+                        )
                     else:
                         logger.info("  - Model: N/A")
                         logger.info("  - Endpoint: N/A")
                     logger.info("Retrieval Configuration:")
-                    logger.info("  - Query: '%s'", retriever_query[:200] if retriever_query else "")
-                    logger.info("  - Collection: %s", validated_collections[0] if validated_collections else "")
+                    logger.info(
+                        "  - Query: '%s'",
+                        retriever_query[:200] if retriever_query else "",
+                    )
+                    logger.info(
+                        "  - Collection: %s",
+                        validated_collections[0] if validated_collections else "",
+                    )
                     logger.info("  - Top-K: %d", top_k)
                     logger.info("  - Is Image Query: %s", is_image_query)
                     logger.info("Starting retrieval...")
@@ -3034,7 +3204,9 @@ class NvidiaRAG:
                     logger.info("Retrieval Output:")
                     logger.info("  - Retrieved Documents: %d", len(context_to_show))
                     logger.info("  - Retrieval Time: %.2f ms", retrieval_time_ms)
-                    self._log_retrieved_pages(context_to_show, "Initially retrieved pages")
+                    self._log_retrieved_pages(
+                        context_to_show, "Initially retrieved pages"
+                    )
                     logger.info("-" * 80)
 
             if ranker and enable_reranker and confidence_threshold > 0.0:
@@ -3052,7 +3224,9 @@ class NvidiaRAG:
 
                 logger.info("Filtering Output:")
                 logger.info("  - Filtered Documents: %d", len(context_to_show))
-                self._log_retrieved_pages(context_to_show, "Pages after confidence filter")
+                self._log_retrieved_pages(
+                    context_to_show, "Pages after confidence filter"
+                )
                 logger.info("-" * 80)
 
             # Snapshot for citations: only retrieved (and filtered) chunks, not expanded context.
@@ -3069,7 +3243,9 @@ class NvidiaRAG:
                     fetch_neighboring_pages=fetch_neighboring_pages,
                 )
                 logger.info("  - Final Documents: %d", len(context_to_show))
-                self._log_expanded_context_layout(context_to_show, "After expansion (chunks per page)")
+                self._log_expanded_context_layout(
+                    context_to_show, "After expansion (chunks per page)"
+                )
                 logger.info("-" * 80)
 
             if enable_vlm_inference or is_image_query:
@@ -3144,12 +3320,22 @@ class NvidiaRAG:
                         logger.info("VLM Configuration:")
                         logger.info("  - Model: %s", vlm_model_cfg)
                         logger.info("  - Endpoint: %s", vlm_endpoint_cfg)
-                        logger.info("  - Temperature: %s, Top-P: %s, Max Tokens: %s",
-                                   vlm_temperature_cfg, vlm_top_p_cfg, vlm_max_tokens_cfg)
-                        logger.info("  - Max Total Images: %d", vlm_max_total_images_cfg)
+                        logger.info(
+                            "  - Temperature: %s, Top-P: %s, Max Tokens: %s",
+                            vlm_temperature_cfg,
+                            vlm_top_p_cfg,
+                            vlm_max_tokens_cfg,
+                        )
+                        logger.info(
+                            "  - Max Total Images: %d", vlm_max_total_images_cfg
+                        )
                         logger.info("Input:")
-                        logger.info("  - Has Images in Messages: %s", has_images_in_messages)
-                        logger.info("  - Has Images in Context: %s", has_images_in_context)
+                        logger.info(
+                            "  - Has Images in Messages: %s", has_images_in_messages
+                        )
+                        logger.info(
+                            "  - Has Images in Context: %s", has_images_in_context
+                        )
                         logger.info("  - Is Image Query: %s", is_image_query)
                         logger.info("  - Context Documents: %d", len(context_to_show))
                         logger.info("Starting VLM stream generation...")
@@ -3202,7 +3388,9 @@ class NvidiaRAG:
                             vlm_generator
                         )
 
-                        logger.info("VLM stream initiated successfully (first chunk received)")
+                        logger.info(
+                            "VLM stream initiated successfully (first chunk received)"
+                        )
                         logger.info("-" * 80)
 
                         return RAGResponse(
@@ -3210,7 +3398,9 @@ class NvidiaRAG:
                                 prefetched_vlm_stream,
                                 docs_for_citations,
                                 model=model,
-                                collection_name=validated_collections[0] if validated_collections else "",
+                                collection_name=validated_collections[0]
+                                if validated_collections
+                                else "",
                                 enable_citations=enable_citations,
                                 use_nrl_citations=self._is_nrl_mode,
                             ),
@@ -3224,7 +3414,9 @@ class NvidiaRAG:
                                 _async_iter([e.message]),
                                 [],
                                 model=model,
-                                collection_name=validated_collections[0] if validated_collections else "",
+                                collection_name=validated_collections[0]
+                                if validated_collections
+                                else "",
                                 enable_citations=enable_citations,
                                 otel_metrics_client=metrics,
                             ),
@@ -3284,9 +3476,13 @@ class NvidiaRAG:
             self._log_context_structure(docs, "Prompt context structure (to LLM/VLM)")
             if context_to_show:
                 total_context_length = sum(len(d.page_content) for d in context_to_show)
-                logger.info("  - Total Context Length: %d characters", total_context_length)
-                logger.info("  - First Document Preview: %s...",
-                           context_to_show[0].page_content[:100] if context_to_show else "")
+                logger.info(
+                    "  - Total Context Length: %d characters", total_context_length
+                )
+                logger.info(
+                    "  - First Document Preview: %s...",
+                    context_to_show[0].page_content[:100] if context_to_show else "",
+                )
             logger.info("-" * 80)
 
             # Prompt for response generation based on context
@@ -3316,10 +3512,12 @@ class NvidiaRAG:
             logger.info("  - Model: %s", model)
             llm_endpoint_display = llm_settings.get("llm_endpoint") or "api catalog"
             logger.info("  - Endpoint: %s", llm_endpoint_display)
-            logger.info("  - Temperature: %s, Top-P: %s, Max Tokens: %s",
-                       llm_settings.get("temperature"),
-                       llm_settings.get("top_p"),
-                       llm_settings.get("max_tokens"))
+            logger.info(
+                "  - Temperature: %s, Top-P: %s, Max Tokens: %s",
+                llm_settings.get("temperature"),
+                llm_settings.get("top_p"),
+                llm_settings.get("max_tokens"),
+            )
             logger.info("Input:")
             logger.info("  - Query: '%s'", self._extract_text_from_content(query)[:200])
             logger.info("  - Context Documents: %d", len(context_to_show))
@@ -3339,7 +3537,10 @@ class NvidiaRAG:
                 logger.info("  - Model: %s", self.config.reflection.model_name)
                 logger.info("  - Endpoint: %s", self.config.reflection.server_url)
                 logger.info("  - Max Loops: %d", self.config.reflection.max_loops)
-                logger.info("  - Groundedness Threshold: %d", self.config.reflection.response_groundedness_threshold)
+                logger.info(
+                    "  - Groundedness Threshold: %d",
+                    self.config.reflection.response_groundedness_threshold,
+                )
                 logger.info("Starting LLM generation with reflection enabled...")
                 logger.info("-" * 80)
 
@@ -3363,9 +3564,14 @@ class NvidiaRAG:
                             {"question": query, "context": docs},
                             config={"callbacks": [usage_callback_reflection]},
                         )
-                        logger.info("Initial LLM response generated, checking groundedness...")
+                        logger.info(
+                            "Initial LLM response generated, checking groundedness..."
+                        )
                         try:
-                            final_response, is_grounded = await check_response_groundedness(
+                            (
+                                final_response,
+                                is_grounded,
+                            ) = await check_response_groundedness(
                                 query,
                                 initial_response,
                                 docs,
@@ -3393,18 +3599,33 @@ class NvidiaRAG:
                             # Re-raise APIError as-is
                             raise
                     u_after = aggregate_llm_token_usage.get("Self Reflection") or {}
-                    delta_in = u_after.get("input_tokens", 0) - reflection_usage_before.get("input_tokens", 0)
-                    delta_out = u_after.get("output_tokens", 0) - reflection_usage_before.get("output_tokens", 0)
+                    delta_in = u_after.get(
+                        "input_tokens", 0
+                    ) - reflection_usage_before.get("input_tokens", 0)
+                    delta_out = u_after.get(
+                        "output_tokens", 0
+                    ) - reflection_usage_before.get("output_tokens", 0)
                     if delta_in > 0 or delta_out > 0:
                         set_span_llm_usage(ref_rg_span, delta_in, delta_out)
                 logger.info("Reflection Output:")
                 logger.info("  - Response Grounded: %s", is_grounded)
-                logger.info("  - Reflection Iterations: %d", response_reflection_counter.current_count)
-                logger.info("  - Response Length: %d characters", len(final_response) if final_response else 0)
-                logger.info("  - Response Preview: %s...", final_response[:100] if final_response else "")
+                logger.info(
+                    "  - Reflection Iterations: %d",
+                    response_reflection_counter.current_count,
+                )
+                logger.info(
+                    "  - Response Length: %d characters",
+                    len(final_response) if final_response else 0,
+                )
+                logger.info(
+                    "  - Response Preview: %s...",
+                    final_response[:100] if final_response else "",
+                )
                 if not is_grounded:
-                    logger.warning("  - Could not generate sufficiently grounded response after %d attempts",
-                                 response_reflection_counter.current_count)
+                    logger.warning(
+                        "  - Could not generate sufficiently grounded response after %d attempts",
+                        response_reflection_counter.current_count,
+                    )
                 logger.info("-" * 80)
                 logger.info("=" * 80)
                 logger.info("RAG PIPELINE COMPLETE")
@@ -3416,7 +3637,9 @@ class NvidiaRAG:
                         _async_iter([final_response]),
                         docs_for_citations,
                         model=model,
-                        collection_name=validated_collections[0] if validated_collections else "",
+                        collection_name=validated_collections[0]
+                        if validated_collections
+                        else "",
                         enable_citations=enable_citations,
                         use_nrl_citations=self._is_nrl_mode,
                         context_reranker_time_ms=context_reranker_time_ms,
@@ -3434,7 +3657,10 @@ class NvidiaRAG:
                 # Create async stream generator (callback captures token usage)
                 stream_gen = chain.astream(
                     {"question": query, "context": docs},
-                    config={"run_name": "llm-stream", "callbacks": [usage_callback_rag]},
+                    config={
+                        "run_name": "llm-stream",
+                        "callbacks": [usage_callback_rag],
+                    },
                 )
                 # Eagerly fetch first chunk to trigger any errors before returning response
                 prefetched_stream = await self._eager_prefetch_astream(stream_gen)
@@ -3451,7 +3677,9 @@ class NvidiaRAG:
                         prefetched_stream,
                         docs_for_citations,
                         model=model,
-                        collection_name=validated_collections[0] if validated_collections else "",
+                        collection_name=validated_collections[0]
+                        if validated_collections
+                        else "",
                         enable_citations=enable_citations,
                         use_nrl_citations=self._is_nrl_mode,
                         context_reranker_time_ms=context_reranker_time_ms,
@@ -3634,15 +3862,9 @@ class NvidiaRAG:
             page_num = content_md.get("page_number")
             source = meta.get("source", {})
             source_path = (
-                source.get("source_name", "")
-                if isinstance(source, dict)
-                else source
+                source.get("source_name", "") if isinstance(source, dict) else source
             )
-            name = (
-                os.path.basename(str(source_path))
-                if source_path
-                else "unknown"
-            )
+            name = os.path.basename(str(source_path)) if source_path else "unknown"
             if page_num is not None:
                 if name not in by_source:
                     by_source[name] = []
@@ -3673,23 +3895,16 @@ class NvidiaRAG:
             page_num = content_md.get("page_number")
             source = meta.get("source", {})
             source_path = (
-                source.get("source_name", "")
-                if isinstance(source, dict)
-                else source
+                source.get("source_name", "") if isinstance(source, dict) else source
             )
-            name = (
-                os.path.basename(str(source_path))
-                if source_path
-                else "unknown"
-            )
+            name = os.path.basename(str(source_path)) if source_path else "unknown"
             if page_num is not None:
                 key = (name, int(page_num))
                 grouped[key] = grouped.get(key, 0) + 1
             else:
                 no_page_count += 1
         parts = [
-            f"{name} p{p} -> {c} chunk(s)"
-            for (name, p), c in sorted(grouped.items())
+            f"{name} p{p} -> {c} chunk(s)" for (name, p), c in sorted(grouped.items())
         ]
         if no_page_count:
             parts.append(f"(no page: {no_page_count} chunks)")
@@ -3827,7 +4042,10 @@ class NvidiaRAG:
                 pages_by_coll_source[key] = set()
             pages_by_coll_source[key].add(page)
 
-        if getattr(type(vdb_op), "retrieve_chunks_by_filter", None) is VDBRag.retrieve_chunks_by_filter:
+        if (
+            getattr(type(vdb_op), "retrieve_chunks_by_filter", None)
+            is VDBRag.retrieve_chunks_by_filter
+        ):
             logger.warning(
                 "VDB backend %s does not implement retrieve_chunks_by_filter; "
                 "skipping full-page fetch.",
@@ -3901,7 +4119,7 @@ class NvidiaRAG:
             grouped[key].append(doc)
 
         keys_sorted = sorted(grouped.keys(), key=lambda k: (k[0], k[1]))
-        for (source_path, page_num) in keys_sorted:
+        for source_path, page_num in keys_sorted:
             doc_list = grouped[(source_path, page_num)]
             filename = (
                 os.path.splitext(os.path.basename(source_path))[0]

--- a/src/nvidia_rag/rag_server/response_generator.py
+++ b/src/nvidia_rag/rag_server/response_generator.py
@@ -294,6 +294,14 @@ class Message(BaseModel):
         "or an array of content objects for multimodal messages containing text and/or images.",
         default="Hello! What can you help me with?",
     )
+    reasoning_content: str | None = Field(
+        default=None,
+        description="Reasoning trace or intermediate output from the agentic RAG pipeline. "
+        "Populated for streamed chunks whose ``event_type`` indicates a reasoning/intermediate "
+        "event (stage announcements, intermediate-stage reasoning or output tokens, "
+        "final-stage reasoning tokens). The user-facing answer is always streamed via "
+        "``content`` — this field is purely supplementary.",
+    )
 
     @validator("role")
     @classmethod
@@ -381,6 +389,22 @@ class ChainResponse(BaseModel):
     metrics: Metrics | None | None = Field(
         default=Metrics(),
         description="Latency metrics associated with the request",
+    )
+    event_type: str | None = Field(
+        default=None,
+        description="Type of streaming chunk. None for non-streaming and for the regular "
+        "(non-agentic) path's content chunks. Set for agentic-RAG streaming chunks; see "
+        "``nvidia_rag.rag_server.agentic_rag.streaming.EventType`` for the enumerated values "
+        "(e.g. ``stage_start``, ``stage_end``, ``intermediate_reasoning``, "
+        "``intermediate_output``, ``final_reasoning``, ``final_answer``, "
+        "``agent_event``, ``error``).",
+    )
+    stage: str | None = Field(
+        default=None,
+        description="Name of the agentic-RAG graph node that produced this chunk "
+        "(e.g. ``initial_retrieval``, ``plan``, ``execute``, ``synthesize``, ``verify``, "
+        "``verify_execute``). Pairs with ``event_type`` so clients can group reasoning "
+        "by pipeline stage without parsing event_type. None for non-agentic responses.",
     )
 
 

--- a/src/nvidia_rag/rag_server/server.py
+++ b/src/nvidia_rag/rag_server/server.py
@@ -601,6 +601,16 @@ class Prompt(BaseModel):
             "Explicitly passing True or False overrides the server default for this request."
         ),
     )
+    enable_streaming: bool = Field(
+        default=True,
+        description=(
+            "Stream intermediate reasoning, stage announcements, and final-answer tokens as "
+            "they are produced. Currently honored by the agentic RAG pipeline; the regular "
+            "(non-agentic) pipeline always streams. When False on the agentic path, the graph "
+            "runs to completion and the full answer is returned as a single SSE chunk "
+            "(legacy behavior)."
+        ),
+    )
 
     @model_validator(mode="after")
     def validate_confidence_threshold(cls, values):
@@ -1506,6 +1516,7 @@ async def generate_answer(request: Request, prompt: Prompt) -> StreamingResponse
             fetch_full_page_context=prompt.fetch_full_page_context,
             fetch_neighboring_pages=prompt.fetch_neighboring_pages,
             agentic=prompt.agentic,
+            enable_streaming=prompt.enable_streaming,
             rag_start_time_sec=generate_start_time,
             metrics=metrics,
         )

--- a/src/nvidia_rag/utils/agentic_rag_config.py
+++ b/src/nvidia_rag/utils/agentic_rag_config.py
@@ -333,11 +333,21 @@ class AgenticRAGConfig(_ConfigBase):
         env="AGENTIC_LOG_LEVEL",
         description="Logging level for the agentic RAG agent (DEBUG/INFO/WARNING/ERROR).",
     )
+    enable_debug_stream: bool = Field(
+        default=False,
+        env="AGENTIC_ENABLE_DEBUG_STREAM",
+        description=(
+            "Forward LangGraph debug-mode events (task_start, task_result, checkpoint) to the "
+            "client as ``event_type='agent_event'`` SSE chunks (with the originating node in "
+            "``stage``). Off by default — debug events are very chatty and are intended for "
+            "development/troubleshooting only. The translator always consumes the debug stream "
+            "so node lifecycle can be logged server-side; this flag only controls whether those "
+            "events reach the wire."
+        ),
+    )
 
     # --- Component sub-configs ----------------------------------------------
-    planner: AgenticPlannerConfig = PydanticField(
-        default_factory=AgenticPlannerConfig
-    )
+    planner: AgenticPlannerConfig = PydanticField(default_factory=AgenticPlannerConfig)
     task_execution: AgenticTaskExecutionConfig = PydanticField(
         default_factory=AgenticTaskExecutionConfig
     )
@@ -347,6 +357,4 @@ class AgenticRAGConfig(_ConfigBase):
     verification: AgenticVerificationConfig = PydanticField(
         default_factory=AgenticVerificationConfig
     )
-    context: AgenticContextConfig = PydanticField(
-        default_factory=AgenticContextConfig
-    )
+    context: AgenticContextConfig = PydanticField(default_factory=AgenticContextConfig)

--- a/tests/unit/test_rag_server/test_agentic_rag.py
+++ b/tests/unit/test_rag_server/test_agentic_rag.py
@@ -108,10 +108,7 @@ class TestAgenticRagStaticHelpers:
         assert AgenticRag._filter_think_tokens(text) is text
 
     def test_filter_think_tokens_strips_closed_block(self) -> None:
-        raw = (
-            "<think>ignore</think>"
-            '{"scope_only": false}'
-        )
+        raw = '<think>ignore</think>{"scope_only": false}'
         assert AgenticRag._filter_think_tokens(raw) == '{"scope_only": false}'
 
     def test_filter_think_tokens_truncated_block(self) -> None:
@@ -357,6 +354,8 @@ class TestTracing:
 class TestRunAgenticPipeline:
     @pytest.mark.asyncio
     async def test_success_wraps_final_answer(self) -> None:
+        # Non-streaming path: uses graph.ainvoke and wraps the answer in a
+        # single SSE chunk via generate_answer_async.
         graph = MagicMock()
         graph.ainvoke = AsyncMock(return_value={"final_answer": "synthesized"})
 
@@ -371,6 +370,7 @@ class TestRunAgenticPipeline:
             query="user q",
             cfg=cfg,
             search_params=AgenticSearchParams(),
+            enable_streaming=False,
         )
         assert resp.status_code == ErrorCodeMapping.SUCCESS
         blob = "".join([c async for c in resp.generator])
@@ -392,10 +392,315 @@ class TestRunAgenticPipeline:
             query="q",
             cfg=cfg,
             search_params=AgenticSearchParams(),
+            enable_streaming=False,
         )
         assert resp.status_code == ErrorCodeMapping.INTERNAL_SERVER_ERROR
         text = "".join([c async for c in resp.generator])
         assert "error" in text.lower() or "encountered" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_streaming_emits_stage_and_final_chunks(self) -> None:
+        """Streaming path: graph.astream events are translated into SSE chunks
+        with the expected ``event_type``/``stage`` fields."""
+
+        class _FakeChunk:
+            def __init__(self, content: str = "", reasoning: str | None = None) -> None:
+                self.content = content
+                self.additional_kwargs = (
+                    {"reasoning_content": reasoning} if reasoning else {}
+                )
+                self.usage_metadata = None
+
+        async def _fake_astream(_state, *, config, stream_mode):  # noqa: ARG001
+            # 1) plan node starts (intermediate)
+            yield (
+                "custom",
+                {
+                    "node": "plan",
+                    "event": "stage_start",
+                    "key": "plan.start.scope",
+                    "params": {},
+                },
+            )
+            yield (
+                "messages",
+                (
+                    _FakeChunk(reasoning="thinking about plan"),
+                    {"langgraph_node": "plan"},
+                ),
+            )
+            yield (
+                "custom",
+                {
+                    "node": "plan",
+                    "event": "stage_end",
+                    "key": "plan.end.with_tasks",
+                    "params": {"task_count": 1},
+                },
+            )
+            # 2) synthesize: mark final, then stream tokens
+            yield (
+                "custom",
+                {"node": "synthesize", "event": "final_stage_marker", "is_final": True},
+            )
+            yield (
+                "messages",
+                (_FakeChunk(content="Hello "), {"langgraph_node": "synthesize"}),
+            )
+            yield (
+                "messages",
+                (_FakeChunk(content="world"), {"langgraph_node": "synthesize"}),
+            )
+
+        graph = MagicMock()
+        graph.astream = _fake_astream
+
+        class _Agent:
+            def __init__(self) -> None:
+                self.metrics = AgentMetrics()
+
+        cfg = AgenticRAGConfig()
+        resp = await run_agentic_pipeline(
+            agent=_Agent(),
+            graph=graph,
+            query="q",
+            cfg=cfg,
+            search_params=AgenticSearchParams(),
+            enable_streaming=True,
+        )
+        assert resp.status_code == ErrorCodeMapping.SUCCESS
+        chunks = [c async for c in resp.generator]
+        assert chunks, "expected at least one SSE chunk"
+
+        # Parse the SSE-encoded ChainResponse JSONs.
+        parsed = [json.loads(c.removeprefix("data: ").strip()) for c in chunks]
+        event_types = [p.get("event_type") for p in parsed]
+        # Expected ordering: stage_start, intermediate_reasoning, stage_end,
+        # final_answer*, then the trailing finish chunk (event_type=None).
+        assert "stage_start" in event_types
+        assert "intermediate_reasoning" in event_types
+        assert "stage_end" in event_types
+        assert event_types.count("final_answer") == 2
+
+        # The final-answer chunks carry tokens in delta.content.
+        final_tokens = [
+            p["choices"][0]["delta"]["content"]
+            for p in parsed
+            if p.get("event_type") == "final_answer"
+        ]
+        assert "".join(final_tokens) == "Hello world"
+
+        # Trailing finish chunk has finish_reason="stop".
+        assert parsed[-1]["choices"][0]["finish_reason"] == "stop"
+
+        # Stage_start / stage_end labels come from USER_FACING_LABELS, not from
+        # the writer payload — assert the dict is the source of truth.
+        from nvidia_rag.rag_server.agentic_rag.streaming import USER_FACING_LABELS
+
+        stage_start_labels = [
+            p["choices"][0]["message"]["reasoning_content"]
+            for p in parsed
+            if p.get("event_type") == "stage_start"
+        ]
+        assert USER_FACING_LABELS["plan.start.scope"] in stage_start_labels
+
+        stage_end_labels = [
+            p["choices"][0]["message"]["reasoning_content"]
+            for p in parsed
+            if p.get("event_type") == "stage_end"
+        ]
+        assert any("1" in lbl for lbl in stage_end_labels), (
+            f"expected substituted task_count, got: {stage_end_labels}"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_streaming_buffers_parallel_tokens_per_run(self) -> None:
+        """Tokens from parallel-task nodes (execute, verify_execute) must be
+        buffered per run_id and emitted as one consolidated chunk per task at
+        the node's stage_end — preserving information without jumbling.
+        Synthesize-node tokens still stream live (single LLM call)."""
+
+        class _FakeChunk:
+            def __init__(
+                self,
+                content: str = "",
+                reasoning: str | None = None,
+                id: str | None = None,
+            ) -> None:
+                self.content = content
+                self.id = id
+                self.additional_kwargs = (
+                    {"reasoning_content": reasoning} if reasoning else {}
+                )
+                self.usage_metadata = None
+
+        async def _fake_astream(_state, *, config, stream_mode):  # noqa: ARG001
+            yield (
+                "custom",
+                {
+                    "node": "execute",
+                    "event": "stage_start",
+                    "key": "execute.start.answer",
+                    "params": {"task_count": 2},
+                },
+            )
+            # Two parallel tasks emitting interleaved tokens — distinguished
+            # by chunk.id (each LangChain LLM invocation gets its own UUID).
+            # Task A produces reasoning + an answer; Task B does the same.
+            # Tokens are interleaved character-by-character to simulate the
+            # real wire jumble.
+            yield (
+                "messages",
+                (
+                    _FakeChunk(reasoning="lion ", id="run-A"),
+                    {"langgraph_node": "execute"},
+                ),
+            )
+            yield (
+                "messages",
+                (
+                    _FakeChunk(reasoning="hammer ", id="run-B"),
+                    {"langgraph_node": "execute"},
+                ),
+            )
+            yield (
+                "messages",
+                (
+                    _FakeChunk(reasoning="activity", id="run-A"),
+                    {"langgraph_node": "execute"},
+                ),
+            )
+            yield (
+                "messages",
+                (
+                    _FakeChunk(reasoning="cost", id="run-B"),
+                    {"langgraph_node": "execute"},
+                ),
+            )
+            yield (
+                "messages",
+                (
+                    _FakeChunk(content='{"answer": "sun', id="run-A"),
+                    {"langgraph_node": "execute"},
+                ),
+            )
+            yield (
+                "messages",
+                (
+                    _FakeChunk(content='{"answer": "$2', id="run-B"),
+                    {"langgraph_node": "execute"},
+                ),
+            )
+            yield (
+                "messages",
+                (
+                    _FakeChunk(content='screen"}', id="run-A"),
+                    {"langgraph_node": "execute"},
+                ),
+            )
+            yield (
+                "messages",
+                (
+                    _FakeChunk(content='0.00"}', id="run-B"),
+                    {"langgraph_node": "execute"},
+                ),
+            )
+            yield (
+                "custom",
+                {
+                    "node": "execute",
+                    "event": "stage_end",
+                    "key": "execute.end.done",
+                    "params": {"task_count": 2, "answered": 2},
+                },
+            )
+            # Synthesize: single-LLM-call node — tokens stream live.
+            yield (
+                "custom",
+                {"node": "synthesize", "event": "final_stage_marker", "is_final": True},
+            )
+            yield (
+                "messages",
+                (
+                    _FakeChunk(content="final answer", id="run-S"),
+                    {"langgraph_node": "synthesize"},
+                ),
+            )
+
+        graph = MagicMock()
+        graph.astream = _fake_astream
+
+        class _Agent:
+            def __init__(self) -> None:
+                self.metrics = AgentMetrics()
+
+        cfg = AgenticRAGConfig()
+        resp = await run_agentic_pipeline(
+            agent=_Agent(),
+            graph=graph,
+            query="q",
+            cfg=cfg,
+            search_params=AgenticSearchParams(),
+            enable_streaming=True,
+        )
+        assert resp.status_code == ErrorCodeMapping.SUCCESS
+        chunks = [c async for c in resp.generator]
+        parsed = [json.loads(c.removeprefix("data: ").strip()) for c in chunks]
+
+        # Exactly 2 intermediate_reasoning + 2 intermediate_output chunks
+        # from "execute" (one consolidated chunk per run_id).
+        execute_reasoning = [
+            p
+            for p in parsed
+            if p.get("event_type") == "intermediate_reasoning"
+            and p.get("stage") == "execute"
+        ]
+        execute_output = [
+            p
+            for p in parsed
+            if p.get("event_type") == "intermediate_output"
+            and p.get("stage") == "execute"
+        ]
+        assert len(execute_reasoning) == 2, (
+            f"expected 2 consolidated reasoning chunks, got {len(execute_reasoning)}: "
+            f"{[p['choices'][0]['message']['reasoning_content'] for p in execute_reasoning]}"
+        )
+        assert len(execute_output) == 2, (
+            f"expected 2 consolidated output chunks, got {len(execute_output)}: "
+            f"{[p['choices'][0]['message']['reasoning_content'] for p in execute_output]}"
+        )
+
+        # Each consolidated chunk holds ONE task's full text — no cross-task
+        # mixing.  Run A's reasoning is "lion activity"; Run B's is "hammer
+        # cost".  Order between run A and run B follows insertion order
+        # (run A first, since it produced the first chunk).
+        reasoning_texts = [
+            p["choices"][0]["message"]["reasoning_content"] for p in execute_reasoning
+        ]
+        assert reasoning_texts == ["lion activity", "hammer cost"]
+
+        output_texts = [
+            p["choices"][0]["message"]["reasoning_content"] for p in execute_output
+        ]
+        assert output_texts == ['{"answer": "sunscreen"}', '{"answer": "$20.00"}']
+
+        # The consolidated chunks land BEFORE the corresponding stage_end.
+        execute_stage_end_idx = next(
+            i
+            for i, p in enumerate(parsed)
+            if p.get("event_type") == "stage_end" and p.get("stage") == "execute"
+        )
+        for p in execute_reasoning + execute_output:
+            assert parsed.index(p) < execute_stage_end_idx, (
+                "consolidated chunks must precede stage_end"
+            )
+
+        # Synthesize tokens DID pass through (single-LLM-call node, lives on).
+        final_answer_chunks = [
+            p for p in parsed if p.get("event_type") == "final_answer"
+        ]
+        assert final_answer_chunks, "expected final_answer to pass through"
 
 
 class TestBuildAgenticRagAgentSignature:


### PR DESCRIPTION
# Agentic RAG: SSE streaming (stages + tokens + final answer)

Agentic RAG now streams over SSE: graph `astream` with `messages` / `custom` / `debug`, new `streaming.py` translator to `ChainResponse` chunks, graph nodes emit stage events via `StreamWriter`, LLM streaming via `astream` + config. Unit tests updated in `test_agentic_rag.py`.


---

## API-level changes

### Request (`/generate` — `Prompt` body)

| Field | Type | Default | Notes |
|--------|------|---------|--------|
| `enable_streaming` | `boolean` | `true` | **Agentic path only.** When `true`, SSE carries staged chunks (see below). When `false`, the agentic graph runs to completion and the response is a **single** SSE chunk with the full answer (legacy). The regular (non-agentic) RAG path **always** streams final tokens; this flag does not change that behavior. |

### Server / deployment config (agentic)

| Setting | Notes |
|---------|--------|
| `AGENTIC_ENABLE_DEBUG_STREAM` (`AgenticRAGConfig.enable_debug_stream`) | When `true`, LangGraph debug events may be forwarded to the client as SSE chunks with `event_type: "agent_event"` (verbose; intended for dev/troubleshooting). |

### Response — each SSE `data:` line is still a `ChainResponse` JSON object; new or populated fields:

| Field | Where | Meaning |
|--------|--------|---------|
| `event_type` | `ChainResponse` | **Agentic streaming only** (otherwise omitted / `null`). Discriminates the chunk: see table below. Non-agentic streaming chunks typically leave this unset. |
| `stage` | `ChainResponse` | **Agentic streaming:** graph node name for this chunk (e.g. `plan`, `execute`, `synthesize`, `verify`, `verify_execute`, `initial_retrieval`). Use with `event_type` to group UI by pipeline step. |
| `reasoning_content` | `choices[].message` and `choices[].delta` | **Supplementary** text: stage one-liners (`stage_start` / `stage_end`), reasoning token deltas, intermediate output for some event types, or error detail for `error`. The **user-facing answer** for the final result is still in **`content`** (especially for `final_answer`). |
| `citations` / `metrics` | `ChainResponse` | Citations and TTFT-style metrics attach on the **first** `final_answer` chunk (aligned with non-agentic streaming behavior). |

### `event_type` values (see `EventType` in `agentic_rag/streaming.py`)

| `event_type` | Typical use |
|--------------|-------------|
| `stage_start` / `stage_end` | Node entered or finished; human-readable label in `reasoning_content`. |
| `intermediate_reasoning` / `intermediate_output` | Token or consolidated task output from non-final nodes. |
| `final_reasoning` / `final_answer` | Last synthesis pass: reasoning vs user-visible answer deltas; answer text in `content`. |
| `agent_event` | Structured or debug (if debug stream enabled) updates; `stage` identifies the node. |
| `error` | Pipeline error; `content` user message, `reasoning_content` optional detail. |


## Checklist
- [X] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [X] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [X] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.