### PR TITLE
Render agentic-RAG streaming reasoning trace (frontend)

### DIFF
--- a/frontend/src/components/chat/AgenticModeSelector.tsx
+++ b/frontend/src/components/chat/AgenticModeSelector.tsx
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useCallback, useMemo } from "react";
+import { Dropdown, Flex, Text } from "@kui/react";
+import { Workflow } from "lucide-react";
+import { useSettingsStore, type AgenticMode } from "../../store/useSettingsStore";
+
+/**
+ * Static metadata for each agentic mode. Kept as a top-level constant so
+ * the dropdown items are referentially stable across renders.
+ */
+const MODE_OPTIONS: ReadonlyArray<{
+  id: AgenticMode;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: "auto",
+    label: "Auto",
+    description: "Server decides (default)",
+  },
+  {
+    id: "off",
+    label: "Standard",
+    description: "Force standard RAG pipeline",
+  },
+  {
+    id: "on",
+    label: "Agentic",
+    description: "Force LangGraph plan-and-execute",
+  },
+] as const;
+
+const MODE_LABELS: Record<AgenticMode, string> = MODE_OPTIONS.reduce(
+  (acc, opt) => {
+    acc[opt.id] = opt.label;
+    return acc;
+  },
+  {} as Record<AgenticMode, string>
+);
+
+/**
+ * Tri-state selector that controls the per-request `agentic` flag on the
+ * `/generate` endpoint.
+ *
+ * - `Auto` (default): omit the field; server's `CONFIG.enable_agentic_rag` decides.
+ * - `Standard`: force `agentic: false` to bypass the agentic pipeline.
+ * - `Agentic`: force `agentic: true` to use the LangGraph plan-and-execute pipeline.
+ *
+ * The selection is persisted via `useSettingsStore`, matching how every
+ * other chat setting is stored.
+ *
+ * @returns A Dropdown-backed pill that shows the current pipeline mode.
+ */
+export const AgenticModeSelector = () => {
+  const agenticMode = useSettingsStore((s) => s.agenticMode);
+  const setSettings = useSettingsStore((s) => s.set);
+
+  const handleSelect = useCallback(
+    (mode: AgenticMode) => {
+      setSettings({ agenticMode: mode });
+    },
+    [setSettings]
+  );
+
+  const items = useMemo(
+    () =>
+      MODE_OPTIONS.map((opt) => ({
+        children: (
+          <Flex
+            direction="col"
+            gap="density-xs"
+            data-testid={`agentic-mode-option-${opt.id}`}
+            data-active={opt.id === agenticMode ? "true" : "false"}
+          >
+            <Text kind="body/bold/md">{opt.label}</Text>
+            <Text
+              kind="body/regular/sm"
+              style={{ color: "var(--text-color-subtle)" }}
+            >
+              {opt.description}
+            </Text>
+          </Flex>
+        ),
+        onSelect: () => handleSelect(opt.id),
+      })),
+    [agenticMode, handleSelect]
+  );
+
+  return (
+    <Flex align="center" gap="density-sm" data-testid="agentic-mode-selector">
+      <Flex align="center" gap="density-xs">
+        <Workflow
+          size={14}
+          style={{ color: "var(--text-color-subtle)" }}
+          aria-hidden
+        />
+        <Text
+          kind="label/regular/lg"
+          style={{ color: "var(--text-color-subtle)" }}
+        >
+          Pipeline:
+        </Text>
+      </Flex>
+      <Dropdown
+        items={items}
+        size="small"
+        side="top"
+        align="start"
+        aria-label="Select RAG pipeline mode"
+        data-testid="agentic-mode-dropdown"
+      >
+        <span
+          role="button"
+          tabIndex={0}
+          aria-label={`Pipeline mode: ${MODE_LABELS[agenticMode]}`}
+          data-testid="agentic-mode-trigger"
+          data-mode={agenticMode}
+          style={{ cursor: "pointer", display: "inline-flex" }}
+        >
+          <Text kind="body/bold/sm">{MODE_LABELS[agenticMode]}</Text>
+        </span>
+      </Dropdown>
+    </Flex>
+  );
+};

--- a/frontend/src/components/chat/ChatMessageBubble.tsx
+++ b/frontend/src/components/chat/ChatMessageBubble.tsx
@@ -18,6 +18,7 @@ import type { ChatMessage, MessageContent as MessageContentType } from "../../ty
 import { useStreamingStore } from "../../store/useStreamingStore";
 import { MessageContent } from "./MessageContent";
 import { StreamingIndicator } from "./StreamingIndicator";
+import { ReasoningPanel } from "./ReasoningPanel";
 import { CitationButton } from "../citations/CitationButton";
 import { 
   Block, 
@@ -93,14 +94,26 @@ const MessageContainer = ({
   </Flex>
 );
 
-const StreamingMessage = ({ content, isError = false }: { content: MessageContentType; isError?: boolean }) => {
-  const textContent = extractTextFromContent(content);
+const StreamingMessage = ({
+  msg,
+  isError = false,
+}: {
+  msg: ChatMessage;
+  isError?: boolean;
+}) => {
+  const textContent = extractTextFromContent(msg.content);
+  const reasoningSteps = msg.reasoning_steps;
   return (
     <MessageContainer role="assistant" isError={isError}>
-      <Flex align="center" gap="2">
-        <MessageContent content={textContent} />
-        {!textContent && <StreamingIndicator />}
-      </Flex>
+      <Stack gap="2">
+        {reasoningSteps && reasoningSteps.length > 0 && (
+          <ReasoningPanel steps={reasoningSteps} streaming />
+        )}
+        <Flex align="center" gap="2">
+          <MessageContent content={textContent} />
+          {!textContent && <StreamingIndicator />}
+        </Flex>
+      </Stack>
     </MessageContainer>
   );
 };
@@ -180,6 +193,9 @@ const RegularMessage = ({ msg }: { msg: ChatMessage }) => {
               ))}
             </Flex>
           )}
+          {msg.role === "assistant" && msg.reasoning_steps && msg.reasoning_steps.length > 0 && (
+            <ReasoningPanel steps={msg.reasoning_steps} />
+          )}
           {/* Always render text content block to maintain structure */}
           <Block>
             <MessageContent content={textContent} />
@@ -208,7 +224,7 @@ export default function ChatMessageBubble({ msg }: ChatMessageBubbleProps) {
   );
 
   if (isThisMessageStreaming) {
-    return <StreamingMessage content={msg.content} isError={msg.is_error} />;
+    return <StreamingMessage msg={msg} isError={msg.is_error} />;
   }
 
   return <RegularMessage msg={msg} />;

--- a/frontend/src/components/chat/MessageInput.tsx
+++ b/frontend/src/components/chat/MessageInput.tsx
@@ -18,6 +18,7 @@ import { useChatStore } from "../../store/useChatStore";
 import { useCollectionsStore } from "../../store/useCollectionsStore";
 import { CollectionChips } from "../collections/CollectionChips";
 import { MessageInputContainer } from "./MessageInputContainer";
+import { AgenticModeSelector } from "./AgenticModeSelector";
 import SimpleFilterBar from "../filtering/SimpleFilterBar";
 import { Flex, Banner, Block } from "@kui/react";
 
@@ -26,6 +27,7 @@ export { CollectionChips } from "../collections/CollectionChips";
 export { MessageTextarea } from "./MessageTextarea";
 export { MessageActions } from "./MessageActions";
 export { MessageInputContainer } from "./MessageInputContainer";
+export { AgenticModeSelector } from "./AgenticModeSelector";
 
 export default function MessageInput() {
   const { filters, setFilters } = useChatStore();
@@ -33,7 +35,14 @@ export default function MessageInput() {
 
   return (
     <Flex direction="col" padding="density-sm">
-      <CollectionChips />
+      <Flex
+        align="center"
+        gap="density-md"
+        style={{ flexWrap: "wrap" }}
+      >
+        <CollectionChips />
+        <AgenticModeSelector />
+      </Flex>
       
       <>
         {selectedCollections.length === 1 && (

--- a/frontend/src/components/chat/ReasoningPanel.tsx
+++ b/frontend/src/components/chat/ReasoningPanel.tsx
@@ -1,0 +1,214 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useCallback, useEffect, useState } from "react";
+import { Block, Flex, Stack, Text } from "@kui/react";
+import { AlertCircle, Brain, CheckCircle2, ChevronDown, ChevronRight, Loader2 } from "lucide-react";
+import type { ReasoningStep } from "../../types/chat";
+import { useCitationUtils } from "../../hooks/useCitationUtils";
+
+interface ReasoningPanelProps {
+  /** Reasoning trace from the agentic stream. */
+  steps: ReasoningStep[];
+  /** Whether the parent message is still streaming. */
+  streaming?: boolean;
+}
+
+const StepIcon = ({ status }: { status: ReasoningStep["status"] }) => {
+  if (status === "running") {
+    return (
+      <Loader2
+        size={14}
+        style={{
+          color: "var(--text-color-subtle)",
+          animation: "rag-reasoning-spin 1s linear infinite",
+        }}
+        aria-label="Step running"
+      />
+    );
+  }
+  if (status === "error") {
+    return (
+      <AlertCircle
+        size={14}
+        style={{ color: "var(--color-red-500)" }}
+        aria-label="Step errored"
+      />
+    );
+  }
+  return (
+    <CheckCircle2
+      size={14}
+      style={{ color: "var(--text-color-accent-green)" }}
+      aria-label="Step completed"
+    />
+  );
+};
+
+const StepRow = ({
+  step,
+  formatStage,
+}: {
+  step: ReasoningStep;
+  formatStage: (stage: string) => string;
+}) => {
+  const headline = step.summary ?? step.label;
+  return (
+    <Stack
+      gap="density-xs"
+      data-testid={`reasoning-step-${step.stage}`}
+      data-status={step.status}
+    >
+      <Flex align="center" gap="density-xs">
+        <StepIcon status={step.status} />
+        <Text kind="body/bold/sm">{formatStage(step.stage)}</Text>
+        {headline && (
+          <Text
+            kind="body/regular/sm"
+            style={{ color: "var(--text-color-subtle)" }}
+          >
+            — {headline}
+          </Text>
+        )}
+      </Flex>
+      {(step.reasoning || step.output) && (
+        <Block style={{ paddingLeft: "22px" }}>
+          {step.reasoning && (
+            <Text
+              kind="body/regular/sm"
+              style={{
+                color: "var(--text-color-subtle)",
+                whiteSpace: "pre-wrap",
+                fontFamily: "var(--font-family-mono, monospace)",
+                fontSize: "0.85em",
+              }}
+            >
+              {step.reasoning}
+            </Text>
+          )}
+          {step.output && (
+            <Text
+              kind="body/regular/sm"
+              style={{
+                color: "var(--text-color-subtle)",
+                whiteSpace: "pre-wrap",
+                fontFamily: "var(--font-family-mono, monospace)",
+                fontSize: "0.85em",
+              }}
+            >
+              {step.output}
+            </Text>
+          )}
+        </Block>
+      )}
+    </Stack>
+  );
+};
+
+/**
+ * Collapsible "Thinking" panel that renders the agentic-RAG reasoning
+ * trace above the assistant's final answer.
+ *
+ * - Hidden when there are no steps (standard non-agentic responses).
+ * - Auto-expanded while the message is streaming so users can watch the
+ *   agent work; collapses on completion to a "Thought for N steps" line.
+ * - Step labels are formatted via `useCitationUtils.formatStage` so any
+ *   future graph node renders without code changes.
+ */
+export const ReasoningPanel = ({ steps, streaming = false }: ReasoningPanelProps) => {
+  const { formatStage } = useCitationUtils();
+  const [open, setOpen] = useState<boolean>(streaming);
+  const [autoCollapsed, setAutoCollapsed] = useState<boolean>(false);
+
+  // Auto-collapse exactly once when streaming finishes.
+  useEffect(() => {
+    if (!streaming && !autoCollapsed) {
+      setOpen(false);
+      setAutoCollapsed(true);
+    }
+    if (streaming && autoCollapsed) {
+      setAutoCollapsed(false);
+    }
+  }, [streaming, autoCollapsed]);
+
+  const toggle = useCallback(() => setOpen((prev) => !prev), []);
+
+  if (!steps || steps.length === 0) return null;
+
+  const stepCount = steps.length;
+  const headerLabel = streaming
+    ? `Thinking (${stepCount} step${stepCount === 1 ? "" : "s"})`
+    : `Thought for ${stepCount} step${stepCount === 1 ? "" : "s"}`;
+
+  return (
+    <Block
+      data-testid="reasoning-panel"
+      data-streaming={streaming ? "true" : "false"}
+      data-open={open ? "true" : "false"}
+      style={{
+        borderLeft: "2px solid var(--text-color-subtle)",
+        paddingLeft: "8px",
+        marginBottom: "8px",
+      }}
+    >
+      <style>{
+        "@keyframes rag-reasoning-spin{from{transform:rotate(0)}to{transform:rotate(360deg)}}"
+      }</style>
+      <Flex
+        align="center"
+        gap="density-xs"
+        role="button"
+        tabIndex={0}
+        aria-expanded={open}
+        aria-label={open ? "Hide reasoning trace" : "Show reasoning trace"}
+        onClick={toggle}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            toggle();
+          }
+        }}
+        data-testid="reasoning-panel-toggle"
+        style={{ cursor: "pointer", userSelect: "none" }}
+      >
+        {open ? (
+          <ChevronDown size={14} style={{ color: "var(--text-color-subtle)" }} />
+        ) : (
+          <ChevronRight size={14} style={{ color: "var(--text-color-subtle)" }} />
+        )}
+        <Brain size={14} style={{ color: "var(--text-color-subtle)" }} aria-hidden />
+        <Text
+          kind="body/bold/sm"
+          style={{ color: "var(--text-color-subtle)" }}
+        >
+          {headerLabel}
+        </Text>
+      </Flex>
+      {open && (
+        <Block style={{ paddingTop: "8px" }}>
+          <Stack gap="density-sm">
+            {steps.map((step, index) => (
+              <StepRow
+                key={`${step.stage}-${index}`}
+                step={step}
+                formatStage={formatStage}
+              />
+            ))}
+          </Stack>
+        </Block>
+      )}
+    </Block>
+  );
+};

--- a/frontend/src/components/chat/__tests__/AgenticModeSelector.test.tsx
+++ b/frontend/src/components/chat/__tests__/AgenticModeSelector.test.tsx
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '../../../test/utils';
+import { AgenticModeSelector } from '../AgenticModeSelector';
+import { useSettingsStore, type AgenticMode } from '../../../store/useSettingsStore';
+
+// We want the real Zustand store but a minimal Dropdown so `onSelect`
+// handlers are reachable via simple click events in jsdom.
+vi.mock('@kui/react', async () => {
+  const actual = await vi.importActual<typeof import('@kui/react')>('@kui/react');
+  type Item = { children: React.ReactNode; onSelect?: () => void };
+  return {
+    ...actual,
+    Dropdown: ({
+      items,
+      children,
+      ...rest
+    }: {
+      items: Item[];
+      children: React.ReactNode;
+    } & Record<string, unknown>) => (
+      <div data-testid={(rest['data-testid'] as string) ?? 'mock-dropdown'}>
+        {children}
+        <ul>
+          {items.map((item, i) => (
+            <li key={i}>
+              <button
+                type="button"
+                data-testid={`mock-dropdown-item-${i}`}
+                onClick={item.onSelect}
+              >
+                {item.children}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    ),
+  };
+});
+
+describe('AgenticModeSelector', () => {
+  beforeEach(() => {
+    act(() => {
+      useSettingsStore.setState({ agenticMode: 'auto' });
+    });
+  });
+
+  it('renders the current mode in the trigger label', () => {
+    render(<AgenticModeSelector />);
+    const trigger = screen.getByTestId('agentic-mode-trigger');
+    expect(trigger).toHaveTextContent('Auto');
+    expect(trigger).toHaveAttribute('data-mode', 'auto');
+  });
+
+  it('exposes all three modes as dropdown items in a stable order', () => {
+    render(<AgenticModeSelector />);
+    expect(screen.getByTestId('agentic-mode-option-auto')).toHaveTextContent('Auto');
+    expect(screen.getByTestId('agentic-mode-option-off')).toHaveTextContent('Standard');
+    expect(screen.getByTestId('agentic-mode-option-on')).toHaveTextContent('Agentic');
+  });
+
+  it('marks the active option via data-active', () => {
+    act(() => {
+      useSettingsStore.setState({ agenticMode: 'on' });
+    });
+    render(<AgenticModeSelector />);
+    expect(screen.getByTestId('agentic-mode-option-on')).toHaveAttribute(
+      'data-active',
+      'true'
+    );
+    expect(screen.getByTestId('agentic-mode-option-off')).toHaveAttribute(
+      'data-active',
+      'false'
+    );
+    expect(screen.getByTestId('agentic-mode-option-auto')).toHaveAttribute(
+      'data-active',
+      'false'
+    );
+  });
+
+  it.each<[string, AgenticMode]>([
+    ['mock-dropdown-item-0', 'auto'],
+    ['mock-dropdown-item-1', 'off'],
+    ['mock-dropdown-item-2', 'on'],
+  ])('selecting %s sets agenticMode to %s', (testId, expected) => {
+    render(<AgenticModeSelector />);
+    fireEvent.click(screen.getByTestId(testId));
+    expect(useSettingsStore.getState().agenticMode).toBe(expected);
+  });
+
+  it('updates the trigger label after selecting a mode', () => {
+    render(<AgenticModeSelector />);
+    fireEvent.click(screen.getByTestId('mock-dropdown-item-2'));
+    expect(screen.getByTestId('agentic-mode-trigger')).toHaveTextContent('Agentic');
+    expect(screen.getByTestId('agentic-mode-trigger')).toHaveAttribute('data-mode', 'on');
+  });
+
+  it('exposes an aria-label on the trigger reflecting the current mode', () => {
+    render(<AgenticModeSelector />);
+    expect(screen.getByTestId('agentic-mode-trigger')).toHaveAttribute(
+      'aria-label',
+      'Pipeline mode: Auto'
+    );
+  });
+});

--- a/frontend/src/components/chat/__tests__/MessageInput.test.tsx
+++ b/frontend/src/components/chat/__tests__/MessageInput.test.tsx
@@ -23,6 +23,10 @@ vi.mock('../MessageInputContainer', () => ({
   MessageInputContainer: () => <div data-testid="message-input-container">Message Input Container</div>
 }));
 
+vi.mock('../AgenticModeSelector', () => ({
+  AgenticModeSelector: () => <div data-testid="agentic-mode-selector">Agentic Mode Selector</div>
+}));
+
 vi.mock('../../filtering/SimpleFilterBar', () => ({
   default: ({ filters }: { filters: Filter[] }) => (
     <div data-testid="filter-bar">
@@ -71,8 +75,17 @@ describe('MessageInput', () => {
       render(<MessageInput />);
       
       expect(screen.getByTestId('collection-chips')).toBeInTheDocument();
+      expect(screen.getByTestId('agentic-mode-selector')).toBeInTheDocument();
       expect(screen.getByTestId('filter-bar')).toBeInTheDocument();
       expect(screen.getByTestId('message-input-container')).toBeInTheDocument();
+    });
+
+    it('renders the agentic mode selector even when no collections are selected', () => {
+      mockUseCollectionsStore.mockReturnValue({ selectedCollections: [] });
+
+      render(<MessageInput />);
+
+      expect(screen.getByTestId('agentic-mode-selector')).toBeInTheDocument();
     });
 
     it('renders components in correct order', () => {

--- a/frontend/src/components/chat/__tests__/ReasoningPanel.test.tsx
+++ b/frontend/src/components/chat/__tests__/ReasoningPanel.test.tsx
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '../../../test/utils';
+import { ReasoningPanel } from '../ReasoningPanel';
+import type { ReasoningStep } from '../../../types/chat';
+
+const buildStep = (overrides: Partial<ReasoningStep> = {}): ReasoningStep => ({
+  stage: 'plan',
+  reasoning: '',
+  output: '',
+  status: 'done',
+  ...overrides,
+});
+
+describe('ReasoningPanel', () => {
+  it('renders nothing when there are no steps', () => {
+    const { container } = render(<ReasoningPanel steps={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows "Thought for N steps" header when not streaming', () => {
+    render(
+      <ReasoningPanel
+        steps={[
+          buildStep({ stage: 'plan', label: 'Planning…', summary: 'Done.' }),
+          buildStep({ stage: 'execute', label: 'Running tasks…' }),
+        ]}
+      />
+    );
+    expect(screen.getByTestId('reasoning-panel-toggle')).toHaveTextContent(
+      'Thought for 2 steps'
+    );
+  });
+
+  it('shows live "Thinking" header while streaming', () => {
+    render(
+      <ReasoningPanel
+        streaming
+        steps={[buildStep({ stage: 'plan', status: 'running' })]}
+      />
+    );
+    expect(screen.getByTestId('reasoning-panel-toggle')).toHaveTextContent(
+      'Thinking (1 step)'
+    );
+  });
+
+  it('formats the stage identifier into a human-readable label without code change', () => {
+    render(
+      <ReasoningPanel
+        streaming
+        steps={[buildStep({ stage: 'verify_execute', status: 'running' })]}
+      />
+    );
+    expect(screen.getByTestId('reasoning-step-verify_execute')).toHaveTextContent(
+      'Verify execute'
+    );
+  });
+
+  it('auto-expands while streaming and shows step content', () => {
+    const steps: ReasoningStep[] = [
+      buildStep({
+        stage: 'plan',
+        label: 'Planning…',
+        reasoning: 'Step 1: scope.',
+        status: 'running',
+      }),
+    ];
+    render(<ReasoningPanel streaming steps={steps} />);
+    expect(screen.getByTestId('reasoning-panel')).toHaveAttribute(
+      'data-open',
+      'true'
+    );
+    expect(screen.getByTestId('reasoning-step-plan')).toHaveTextContent(
+      'Step 1: scope.'
+    );
+  });
+
+  it('starts collapsed when not streaming and toggles on click', () => {
+    render(
+      <ReasoningPanel
+        steps={[buildStep({ stage: 'plan', label: 'Planning…' })]}
+      />
+    );
+    expect(screen.getByTestId('reasoning-panel')).toHaveAttribute(
+      'data-open',
+      'false'
+    );
+    fireEvent.click(screen.getByTestId('reasoning-panel-toggle'));
+    expect(screen.getByTestId('reasoning-panel')).toHaveAttribute(
+      'data-open',
+      'true'
+    );
+  });
+
+  it('exposes step status via data-status for downstream styling', () => {
+    render(
+      <ReasoningPanel
+        streaming
+        steps={[
+          buildStep({ stage: 'plan', status: 'running' }),
+          buildStep({ stage: 'execute', status: 'error' }),
+          buildStep({ stage: 'synthesize', status: 'done' }),
+        ]}
+      />
+    );
+    expect(screen.getByTestId('reasoning-step-plan')).toHaveAttribute(
+      'data-status',
+      'running'
+    );
+    expect(screen.getByTestId('reasoning-step-execute')).toHaveAttribute(
+      'data-status',
+      'error'
+    );
+    expect(screen.getByTestId('reasoning-step-synthesize')).toHaveAttribute(
+      'data-status',
+      'done'
+    );
+  });
+
+  it('renders both reasoning and output blocks when both are present', () => {
+    render(
+      <ReasoningPanel
+        streaming
+        steps={[
+          buildStep({
+            stage: 'execute',
+            reasoning: 'thinking text',
+            output: '{"task": 1}',
+            status: 'running',
+          }),
+        ]}
+      />
+    );
+    const stepEl = screen.getByTestId('reasoning-step-execute');
+    expect(stepEl).toHaveTextContent('thinking text');
+    expect(stepEl).toHaveTextContent('{"task": 1}');
+  });
+
+  it('toggle is keyboard accessible (Enter / Space)', () => {
+    render(
+      <ReasoningPanel
+        steps={[buildStep({ stage: 'plan', label: 'Planning…' })]}
+      />
+    );
+    const toggle = screen.getByTestId('reasoning-panel-toggle');
+    expect(screen.getByTestId('reasoning-panel')).toHaveAttribute(
+      'data-open',
+      'false'
+    );
+    fireEvent.keyDown(toggle, { key: 'Enter' });
+    expect(screen.getByTestId('reasoning-panel')).toHaveAttribute(
+      'data-open',
+      'true'
+    );
+    fireEvent.keyDown(toggle, { key: ' ' });
+    expect(screen.getByTestId('reasoning-panel')).toHaveAttribute(
+      'data-open',
+      'false'
+    );
+  });
+});

--- a/frontend/src/components/citations/CitationItem.tsx
+++ b/frontend/src/components/citations/CitationItem.tsx
@@ -50,7 +50,7 @@ const CitationHeader = ({
 }) => {
   const { getFileIconByExtension } = useFileIcons();
   const { getAbridgedText } = useCitationText();
-  const { formatScore } = useCitationUtils();
+  const { formatScore, formatStage } = useCitationUtils();
 
   // Keyboard accessibility handler
   const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -116,6 +116,17 @@ const CitationHeader = ({
                   {citation.document_type}
                 </Badge>
               )}
+              {citation.stage && (
+                <Badge
+                  kind="outline"
+                  color="blue"
+                  data-testid="citation-stage-badge"
+                  data-stage={citation.stage}
+                  title={`Pipeline stage: ${citation.stage}`}
+                >
+                  {formatStage(citation.stage)}
+                </Badge>
+              )}
             </Flex>
             {!isExpanded && (
               <Text 
@@ -166,6 +177,7 @@ const CitationContent = ({ citation }: { citation: Citation }) => {
           
           <CitationMetadata 
             source={citation.source} 
+            stage={citation.stage}
           />
         </Stack>
       </Block>

--- a/frontend/src/components/citations/CitationMetadata.tsx
+++ b/frontend/src/components/citations/CitationMetadata.tsx
@@ -15,17 +15,22 @@
 
 import { useCitationUtils } from "../../hooks/useCitationUtils";
 import { Flex, Text, Divider } from "@kui/react";
-import { FileText, TrendingUp } from "lucide-react";
+import { FileText, TrendingUp, Workflow } from "lucide-react";
 
 interface CitationMetadataProps {
   source?: string;
   score?: number;
+  /**
+   * Pipeline stage that produced this citation. Rendered as an opaque,
+   * humanised string so future agentic stages display without code changes.
+   */
+  stage?: string;
 }
 
-export const CitationMetadata = ({ source, score }: CitationMetadataProps) => {
-  const { formatScore } = useCitationUtils();
+export const CitationMetadata = ({ source, score, stage }: CitationMetadataProps) => {
+  const { formatScore, formatStage } = useCitationUtils();
 
-  if (!source && score === undefined) return null;
+  if (!source && score === undefined && !stage) return null;
 
   return (
     <div style={{ paddingTop: 'var(--spacing-density-sm)' }}>
@@ -44,6 +49,14 @@ export const CitationMetadata = ({ source, score }: CitationMetadataProps) => {
             <TrendingUp size={14} style={{ color: 'var(--text-color-subtle)' }} />
             <Text kind="body/regular/sm" style={{ color: 'var(--text-color-subtle)' }}>
               Relevance: {formatScore(score, 3)}
+            </Text>
+          </Flex>
+        )}
+        {stage && (
+          <Flex align="center" gap="density-xs" data-testid="citation-stage-row" data-stage={stage}>
+            <Workflow size={14} style={{ color: 'var(--text-color-subtle)' }} />
+            <Text kind="body/regular/sm" style={{ color: 'var(--text-color-subtle)' }}>
+              Pipeline stage: {formatStage(stage)}
             </Text>
           </Flex>
         )}

--- a/frontend/src/components/citations/__tests__/CitationItem.test.tsx
+++ b/frontend/src/components/citations/__tests__/CitationItem.test.tsx
@@ -47,8 +47,8 @@ vi.mock('../CitationTextContent', () => ({
 }));
 
 vi.mock('../CitationMetadata', () => ({
-  CitationMetadata: ({ source, score }: { source: string; score?: string | number }) => (
-    <div data-testid="citation-metadata">{source} - {score}</div>
+  CitationMetadata: ({ source, score, stage }: { source: string; score?: string | number; stage?: string }) => (
+    <div data-testid="citation-metadata" data-stage={stage ?? ''}>{source} - {score}</div>
   )
 }));
 
@@ -84,7 +84,11 @@ describe('CitationItem', () => {
     mockUseCitationUtils.mockReturnValue({
       generateCitationId: mockGenerateCitationId,
       isVisualType: vi.fn().mockReturnValue(false),
-      formatScore: vi.fn().mockReturnValue('0.85')
+      formatScore: vi.fn().mockReturnValue('0.85'),
+      // Echo back a humanised stage so tests can assert against the rendered text.
+      formatStage: vi.fn((stage: string | undefined) =>
+        stage ? stage.charAt(0).toUpperCase() + stage.slice(1).replace(/_/g, ' ') : ''
+      ),
     });
     
     mockUseCitationExpansion.mockReturnValue({
@@ -261,7 +265,8 @@ describe('CitationItem', () => {
       mockUseCitationUtils.mockReturnValue({
         generateCitationId: mockGenerateCitationId,
         isVisualType: vi.fn().mockReturnValue(true),
-        formatScore: vi.fn().mockReturnValue('0.85')
+        formatScore: vi.fn().mockReturnValue('0.85'),
+        formatStage: vi.fn().mockReturnValue(''),
       });
 
       render(<CitationItem citation={mockCitation} index={0} />);
@@ -279,7 +284,8 @@ describe('CitationItem', () => {
       mockUseCitationUtils.mockReturnValue({
         generateCitationId: mockGenerateCitationId,
         isVisualType: vi.fn().mockReturnValue(false),
-        formatScore: vi.fn().mockReturnValue('0.85')
+        formatScore: vi.fn().mockReturnValue('0.85'),
+        formatStage: vi.fn().mockReturnValue(''),
       });
 
       render(<CitationItem citation={mockCitation} index={0} />);
@@ -326,13 +332,50 @@ describe('CitationItem', () => {
     });
   });
 
+  describe('Stage Badge', () => {
+    it('does not render the stage badge when citation has no stage', () => {
+      render(<CitationItem citation={mockCitation} index={0} />);
+      expect(screen.queryByTestId('citation-stage-badge')).not.toBeInTheDocument();
+    });
+
+    it('renders the stage badge in the header when stage is present', () => {
+      const citation: Citation = { ...mockCitation, stage: 'initial_retrieval' };
+      render(<CitationItem citation={citation} index={0} />);
+
+      const badge = screen.getByTestId('citation-stage-badge');
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveAttribute('data-stage', 'initial_retrieval');
+      // Humanised label appears
+      expect(badge).toHaveTextContent('Initial retrieval');
+    });
+
+    it('passes the stage through to CitationMetadata when expanded', () => {
+      mockUseCitationExpansion.mockReturnValue({ isExpanded: true, toggle: mockToggle });
+      const citation: Citation = { ...mockCitation, stage: 'verify_execute' };
+
+      render(<CitationItem citation={citation} index={0} />);
+
+      const metadata = screen.getByTestId('citation-metadata');
+      expect(metadata).toHaveAttribute('data-stage', 'verify_execute');
+    });
+
+    it('renders any future stage value without code changes', () => {
+      const citation: Citation = { ...mockCitation, stage: 'plan_then_self_critique_v2' };
+      render(<CitationItem citation={citation} index={0} />);
+
+      const badge = screen.getByTestId('citation-stage-badge');
+      expect(badge).toHaveAttribute('data-stage', 'plan_then_self_critique_v2');
+    });
+  });
+
   describe('Integration with Utils', () => {
     it('passes correct parameters to isVisualType', () => {
       const mockIsVisualType = vi.fn().mockReturnValue(false);
       mockUseCitationUtils.mockReturnValue({
         generateCitationId: mockGenerateCitationId,
         isVisualType: mockIsVisualType,
-        formatScore: vi.fn().mockReturnValue('0.85')
+        formatScore: vi.fn().mockReturnValue('0.85'),
+        formatStage: vi.fn().mockReturnValue(''),
       });
 
       mockUseCitationExpansion.mockReturnValue({

--- a/frontend/src/components/citations/__tests__/CitationMetadata.test.tsx
+++ b/frontend/src/components/citations/__tests__/CitationMetadata.test.tsx
@@ -4,9 +4,11 @@ import { CitationMetadata } from '../CitationMetadata';
 
 // Mock the citation utils hook
 const mockFormatScore = vi.fn();
+const mockFormatStage = vi.fn();
 vi.mock('../../../hooks/useCitationUtils', () => ({
   useCitationUtils: () => ({
-    formatScore: mockFormatScore
+    formatScore: mockFormatScore,
+    formatStage: mockFormatStage,
   })
 }));
 
@@ -14,19 +16,30 @@ describe('CitationMetadata', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFormatScore.mockReturnValue('0.850');
+    mockFormatStage.mockImplementation((stage: string | undefined) =>
+      stage ? stage.charAt(0).toUpperCase() + stage.slice(1).replace(/_/g, ' ') : ''
+    );
   });
 
   describe('Conditional Rendering', () => {
-    it('renders nothing when no source and no score', () => {
+    it('renders nothing when no source, score, or stage', () => {
       const { container } = render(<CitationMetadata />);
       
       expect(container.firstChild).toBeNull();
     });
 
-    it('renders nothing when source is undefined and score is undefined', () => {
-      const { container } = render(<CitationMetadata source={undefined} score={undefined} />);
+    it('renders nothing when source, score, and stage are all undefined', () => {
+      const { container } = render(
+        <CitationMetadata source={undefined} score={undefined} stage={undefined} />
+      );
       
       expect(container.firstChild).toBeNull();
+    });
+
+    it('renders when only stage is provided', () => {
+      render(<CitationMetadata stage="execute" />);
+      expect(screen.getByTestId('citation-stage-row')).toBeInTheDocument();
+      expect(screen.getByText('Pipeline stage: Execute')).toBeInTheDocument();
     });
 
     it('renders when source is provided', () => {
@@ -123,6 +136,50 @@ describe('CitationMetadata', () => {
       render(<CitationMetadata source="test.pdf" score={0.123456789} />);
       
       expect(mockFormatScore).toHaveBeenCalledWith(0.123456789, 3);
+    });
+
+    it('renders source, score, and stage together', () => {
+      mockFormatScore.mockReturnValue('0.91');
+      render(
+        <CitationMetadata
+          source="combined.pdf"
+          score={0.91}
+          stage="initial_retrieval"
+        />
+      );
+      expect(screen.getByText('Source: combined.pdf')).toBeInTheDocument();
+      expect(screen.getByText('Relevance: 0.91')).toBeInTheDocument();
+      expect(screen.getByText('Pipeline stage: Initial retrieval')).toBeInTheDocument();
+    });
+  });
+
+  describe('Stage Display', () => {
+    it('calls formatStage with the raw stage value', () => {
+      render(<CitationMetadata stage="verify_execute" />);
+      expect(mockFormatStage).toHaveBeenCalledWith('verify_execute');
+    });
+
+    it('does not display stage row when stage is not provided', () => {
+      render(<CitationMetadata source="test.pdf" />);
+      expect(screen.queryByTestId('citation-stage-row')).not.toBeInTheDocument();
+      expect(screen.queryByText(/Pipeline stage:/)).not.toBeInTheDocument();
+    });
+
+    it('renders future / unknown stage values without code changes', () => {
+      // The component must be value-independent: any new server-side stage
+      // value renders sensibly via formatStage.
+      render(<CitationMetadata stage="plan_then_self_critique_v2" />);
+      const row = screen.getByTestId('citation-stage-row');
+      expect(row).toHaveAttribute('data-stage', 'plan_then_self_critique_v2');
+      expect(row).toHaveTextContent('Pipeline stage: Plan then self critique v2');
+    });
+
+    it('exposes the raw stage as a data attribute for styling/testing', () => {
+      render(<CitationMetadata stage="execute" />);
+      expect(screen.getByTestId('citation-stage-row')).toHaveAttribute(
+        'data-stage',
+        'execute'
+      );
     });
   });
 }); 

--- a/frontend/src/hooks/__tests__/useChatStream.test.ts
+++ b/frontend/src/hooks/__tests__/useChatStream.test.ts
@@ -1,0 +1,380 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useChatStream } from '../useChatStream';
+import type { ChatMessage } from '../../types/chat';
+
+/**
+ * Build a fake `Response` with a body that yields the supplied SSE chunks.
+ * Each chunk is JSON-stringified and prefixed with `data: ` (server contract).
+ */
+const buildResponse = (chunks: object[], status = 200): Response => {
+  const lines = chunks.map((c) => `data: ${JSON.stringify(c)}\n`).join('');
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(lines));
+      controller.close();
+    },
+  });
+  return new Response(stream, { status });
+};
+
+/**
+ * Drain processStream against a fake stream, accumulating every
+ * updateMessage call so tests can inspect the final assistant payload.
+ */
+const drain = async (chunks: object[], status = 200) => {
+  const { result } = renderHook(() => useChatStream());
+  const updates: Array<Partial<ChatMessage>> = [];
+  const updateMessage = vi.fn(
+    (_id: string, update: Partial<ChatMessage>) => {
+      updates.push({ ...update });
+    }
+  );
+  await act(async () => {
+    result.current.startStream();
+    await result.current.processStream(
+      buildResponse(chunks, status),
+      'assistant-1',
+      updateMessage
+    );
+  });
+  return { updates, last: updates[updates.length - 1] };
+};
+
+describe('useChatStream — legacy non-agentic path (regression)', () => {
+  it('concatenates delta.content when chunks have no event_type', async () => {
+    const { last } = await drain([
+      { choices: [{ delta: { content: 'Hello, ' } }] },
+      { choices: [{ delta: { content: 'world.' } }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+    expect(last.content).toBe('Hello, world.');
+    expect(last.reasoning_steps).toBeUndefined();
+  });
+
+  it('extracts citations from sources/results without event_type', async () => {
+    const { last } = await drain([
+      {
+        choices: [{ delta: { content: 'Answer' } }],
+        citations: {
+          results: [
+            {
+              content: 'snippet',
+              document_name: 'a.pdf',
+              document_type: 'text',
+              score: 0.9,
+              stage: 'rag',
+            },
+          ],
+        },
+      },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+    expect(last.citations).toHaveLength(1);
+    expect(last.citations?.[0]).toMatchObject({
+      source: 'a.pdf',
+      stage: 'rag',
+    });
+  });
+});
+
+describe('useChatStream — agentic streaming path (PR #512)', () => {
+  it('routes final_answer chunks to content and other events to reasoning steps', async () => {
+    const { last } = await drain([
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'stage_start',
+              stage: 'plan',
+              reasoning_content: 'Planning the retrieval strategy…',
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'intermediate_reasoning',
+              stage: 'plan',
+              reasoning_content: 'Step 1: scope discovery. ',
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'intermediate_reasoning',
+              stage: 'plan',
+              reasoning_content: 'Step 2: focused retrieval.',
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'stage_end',
+              stage: 'plan',
+              reasoning_content: 'Plan ready.',
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'stage_start',
+              stage: 'synthesize',
+              reasoning_content: 'Composing the final answer…',
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'final_answer',
+              stage: 'synthesize',
+              content: 'The lion ',
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'final_answer',
+              stage: 'synthesize',
+              content: 'is the king.',
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'stage_end',
+              stage: 'synthesize',
+              reasoning_content: 'Done.',
+            },
+          },
+        ],
+      },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+
+    expect(last.content).toBe('The lion is the king.');
+    expect(last.reasoning_steps).toHaveLength(2);
+    const [planStep, synthStep] = last.reasoning_steps!;
+    expect(planStep).toMatchObject({
+      stage: 'plan',
+      label: 'Planning the retrieval strategy…',
+      summary: 'Plan ready.',
+      status: 'done',
+    });
+    expect(planStep.reasoning).toBe(
+      'Step 1: scope discovery. Step 2: focused retrieval.'
+    );
+    expect(synthStep.stage).toBe('synthesize');
+    expect(synthStep.status).toBe('done');
+  });
+
+  it('attaches citations + metrics when they arrive on the first final_answer chunk', async () => {
+    const { last } = await drain([
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'final_answer',
+              stage: 'synthesize',
+              content: 'ok',
+            },
+          },
+        ],
+        citations: {
+          results: [
+            {
+              content: 'snippet',
+              document_name: 'doc.pdf',
+              document_type: 'text',
+              score: 0.7,
+              stage: 'verify_execute',
+            },
+          ],
+        },
+        metrics: {
+          rag_ttft_ms: 120,
+          llm_ttft_ms: 80,
+          llm_generation_time_ms: 1500,
+        },
+      },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+
+    expect(last.citations?.[0].stage).toBe('verify_execute');
+    expect(last.metrics).toEqual({
+      rag_ttft_ms: 120,
+      llm_ttft_ms: 80,
+      llm_generation_time_ms: 1500,
+    });
+  });
+
+  it('lazy-creates a step when reasoning_content arrives without stage_start', async () => {
+    const { last } = await drain([
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'intermediate_reasoning',
+              stage: 'execute',
+              reasoning_content: 'orphan token',
+            },
+          },
+        ],
+      },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+    expect(last.reasoning_steps).toHaveLength(1);
+    expect(last.reasoning_steps?.[0]).toMatchObject({
+      stage: 'execute',
+      reasoning: 'orphan token',
+      status: 'done',
+    });
+  });
+
+  it('routes intermediate_output to step.output, distinct from reasoning', async () => {
+    const { last } = await drain([
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'stage_start',
+              stage: 'execute',
+              reasoning_content: 'Running tasks…',
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'intermediate_output',
+              stage: 'execute',
+              reasoning_content: '{"tasks":[{"id":1}]}',
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'stage_end',
+              stage: 'execute',
+              reasoning_content: 'Found 4 results.',
+            },
+          },
+        ],
+      },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+    expect(last.reasoning_steps?.[0].output).toBe('{"tasks":[{"id":1}]}');
+    expect(last.reasoning_steps?.[0].reasoning).toBe('');
+  });
+
+  it('marks the message as errored on event_type=error and stops accumulating answer', async () => {
+    const { last } = await drain([
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'stage_start',
+              stage: 'plan',
+              reasoning_content: 'Planning…',
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'error',
+              stage: 'plan',
+              content: 'pipeline failed',
+              reasoning_content: 'detail: timeout',
+            },
+          },
+        ],
+      },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+    expect(last.is_error).toBe(true);
+    expect(last.content).toBe('pipeline failed');
+    const step = last.reasoning_steps?.[0];
+    expect(step?.status).toBe('error');
+    expect(step?.output).toContain('timeout');
+  });
+
+  it('forward-compat: agent_event / unknown event types preserve reasoning_content', async () => {
+    const { last } = await drain([
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'agent_event',
+              stage: 'execute',
+              reasoning_content: 'mid-stage update',
+            },
+          },
+        ],
+      },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+    expect(last.reasoning_steps?.[0].reasoning).toBe('mid-stage update');
+  });
+
+  it('closes any still-running step when the trailing finish_reason chunk arrives', async () => {
+    const { last } = await drain([
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'stage_start',
+              stage: 'execute',
+              reasoning_content: 'Running tasks…',
+            },
+          },
+        ],
+      },
+      // No matching stage_end — server may drop one if pipeline interrupts.
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+    expect(last.reasoning_steps?.[0].status).toBe('done');
+  });
+});

--- a/frontend/src/hooks/__tests__/useCitationUtils.test.ts
+++ b/frontend/src/hooks/__tests__/useCitationUtils.test.ts
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useCitationUtils } from '../useCitationUtils';
+
+describe('useCitationUtils', () => {
+  describe('formatStage', () => {
+    it('returns empty string for undefined', () => {
+      const { result } = renderHook(() => useCitationUtils());
+      expect(result.current.formatStage(undefined)).toBe('');
+    });
+
+    it('returns empty string for an empty / whitespace-only stage', () => {
+      const { result } = renderHook(() => useCitationUtils());
+      expect(result.current.formatStage('')).toBe('');
+      expect(result.current.formatStage('   ')).toBe('');
+    });
+
+    it('humanises snake_case stage identifiers', () => {
+      const { result } = renderHook(() => useCitationUtils());
+      expect(result.current.formatStage('initial_retrieval')).toBe('Initial retrieval');
+      expect(result.current.formatStage('verify_execute')).toBe('Verify execute');
+    });
+
+    it('humanises kebab-case stage identifiers', () => {
+      const { result } = renderHook(() => useCitationUtils());
+      expect(result.current.formatStage('post-execute-verify')).toBe('Post execute verify');
+    });
+
+    it('preserves a single-word stage but capitalises it', () => {
+      const { result } = renderHook(() => useCitationUtils());
+      expect(result.current.formatStage('rag')).toBe('Rag');
+      expect(result.current.formatStage('execute')).toBe('Execute');
+    });
+
+    it('handles future / unknown stage values without code changes', () => {
+      const { result } = renderHook(() => useCitationUtils());
+      // Whatever new stage the server adds, formatStage must not throw and
+      // must return a non-empty humanised string.
+      const future = 'plan_then_self_critique_v2';
+      expect(result.current.formatStage(future)).toBe('Plan then self critique v2');
+    });
+  });
+
+  describe('formatScore (regression)', () => {
+    it('returns N/A for undefined and a fixed-precision string for numbers', () => {
+      const { result } = renderHook(() => useCitationUtils());
+      expect(result.current.formatScore(undefined)).toBe('N/A');
+      expect(result.current.formatScore(0.876543)).toBe('0.88');
+      expect(result.current.formatScore(0.876543, 3)).toBe('0.877');
+    });
+  });
+
+  describe('isVisualType (regression)', () => {
+    it('classifies image / chart / table as visual', () => {
+      const { result } = renderHook(() => useCitationUtils());
+      expect(result.current.isVisualType('image')).toBe(true);
+      expect(result.current.isVisualType('chart')).toBe(true);
+      expect(result.current.isVisualType('table')).toBe(true);
+      expect(result.current.isVisualType('text')).toBe(false);
+    });
+  });
+});

--- a/frontend/src/hooks/__tests__/useMessageSubmit.test.ts
+++ b/frontend/src/hooks/__tests__/useMessageSubmit.test.ts
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'vitest';
+import { cleanRequestObject } from '../useMessageSubmit';
+import type { GenerateRequest } from '../../types/requests';
+
+describe('cleanRequestObject', () => {
+  // Minimum payload to satisfy the GenerateRequest contract.
+  const baseRequest: Partial<GenerateRequest> = {
+    messages: [{ role: 'user', content: 'hello' }],
+    use_knowledge_base: false,
+  };
+
+  it('omits undefined / null / empty values', () => {
+    const cleaned = cleanRequestObject({
+      ...baseRequest,
+      temperature: undefined,
+      filter_expr: '',
+      stop: [],
+      // null is allowed by the type for some fields and must be dropped
+      agentic: null,
+    });
+    expect(cleaned).not.toHaveProperty('temperature');
+    expect(cleaned).not.toHaveProperty('filter_expr');
+    expect(cleaned).not.toHaveProperty('stop');
+    expect(cleaned).not.toHaveProperty('agentic');
+  });
+
+  it('preserves explicit `agentic: true` (force agentic)', () => {
+    const cleaned = cleanRequestObject({
+      ...baseRequest,
+      agentic: true,
+    });
+    expect(cleaned.agentic).toBe(true);
+  });
+
+  it('preserves explicit `agentic: false` (force standard) — must NOT be dropped', () => {
+    // This is the safety-critical guarantee: if we dropped `false`, the
+    // server's CONFIG.enable_agentic_rag would silently take over and the
+    // user's "Standard" choice would be ignored.
+    const cleaned = cleanRequestObject({
+      ...baseRequest,
+      agentic: false,
+    });
+    expect(cleaned).toHaveProperty('agentic', false);
+  });
+
+  it('omits `agentic` when undefined (auto mode → server decides)', () => {
+    const cleaned = cleanRequestObject({
+      ...baseRequest,
+      agentic: undefined,
+    });
+    expect(cleaned).not.toHaveProperty('agentic');
+  });
+
+  it('preserves other always-include feature toggles set to false', () => {
+    // Regression guard for the existing alwaysInclude list.
+    const cleaned = cleanRequestObject({
+      ...baseRequest,
+      enable_reranker: false,
+      enable_citations: false,
+      enable_query_rewriting: false,
+      enable_guardrails: false,
+      enable_vlm_inference: false,
+      enable_filter_generator: false,
+    });
+    expect(cleaned.enable_reranker).toBe(false);
+    expect(cleaned.enable_citations).toBe(false);
+    expect(cleaned.enable_query_rewriting).toBe(false);
+    expect(cleaned.enable_guardrails).toBe(false);
+    expect(cleaned.enable_vlm_inference).toBe(false);
+    expect(cleaned.enable_filter_generator).toBe(false);
+  });
+
+  it('preserves always-include `use_knowledge_base: false`', () => {
+    const cleaned = cleanRequestObject({
+      ...baseRequest,
+      use_knowledge_base: false,
+    });
+    expect(cleaned.use_knowledge_base).toBe(false);
+  });
+
+  it('preserves numeric and string values', () => {
+    const cleaned = cleanRequestObject({
+      ...baseRequest,
+      temperature: 0.7,
+      max_tokens: 1024,
+      model: 'meta/llama-3.3-70b',
+      collection_names: ['docs'],
+    });
+    expect(cleaned.temperature).toBe(0.7);
+    expect(cleaned.max_tokens).toBe(1024);
+    expect(cleaned.model).toBe('meta/llama-3.3-70b');
+    expect(cleaned.collection_names).toEqual(['docs']);
+  });
+
+  it('drops booleans set to false that are NOT in the always-include list', () => {
+    // `random_unknown_toggle` isn't a real GenerateRequest field — we cast
+    // through unknown to verify the cleaner's behavior on arbitrary keys
+    // without weakening GenerateRequest's type.
+    const cleaned = cleanRequestObject({
+      ...baseRequest,
+      ...({ random_unknown_toggle: false } as unknown as Partial<GenerateRequest>),
+    });
+    expect(cleaned).not.toHaveProperty('random_unknown_toggle');
+  });
+});

--- a/frontend/src/hooks/useChatStream.ts
+++ b/frontend/src/hooks/useChatStream.ts
@@ -14,7 +14,12 @@
 // limitations under the License.
 
 import { useState, useRef } from "react";
-import type { ChatMessage, Citation } from "../types/chat";
+import type {
+  AgenticMetrics,
+  ChatMessage,
+  Citation,
+  ReasoningStep,
+} from "../types/chat";
 
 /**
  * Interface representing the state of a chat stream.
@@ -26,19 +31,105 @@ export interface StreamState {
   isTyping: boolean;
 }
 
+/** Server-emitted `event_type` discriminators (see PR #512). */
+type AgenticEventType =
+  | "stage_start"
+  | "stage_end"
+  | "intermediate_reasoning"
+  | "intermediate_output"
+  | "final_reasoning"
+  | "final_answer"
+  | "agent_event"
+  | "error";
+
+const STAGE_START_EVENT: AgenticEventType = "stage_start";
+const STAGE_END_EVENT: AgenticEventType = "stage_end";
+const FINAL_ANSWER_EVENT: AgenticEventType = "final_answer";
+const ERROR_EVENT: AgenticEventType = "error";
+const OUTPUT_EVENT: AgenticEventType = "intermediate_output";
+
+/** Lazy-create or reuse the open step for an incoming chunk's stage. */
+const ensureOpenStep = (
+  steps: ReasoningStep[],
+  stage: string | undefined
+): ReasoningStep => {
+  const last = steps[steps.length - 1];
+  if (last && last.status === "running" && (!stage || last.stage === stage)) {
+    return last;
+  }
+  const next: ReasoningStep = {
+    stage: stage ?? "unknown",
+    reasoning: "",
+    output: "",
+    status: "running",
+  };
+  steps.push(next);
+  return next;
+};
+
+const closeRunningSteps = (
+  steps: ReasoningStep[],
+  status: "done" | "error" = "done"
+) => {
+  for (const step of steps) {
+    if (step.status === "running") step.status = status;
+  }
+};
+
+const parseSources = (raw: unknown): ChatMessage["citations"] => {
+  if (!Array.isArray(raw)) return undefined;
+  const scored: ChatMessage["citations"] = raw.map(
+    (src: Record<string, unknown>) => {
+      const score =
+        typeof src.score === "string" || typeof src.score === "number"
+          ? src.score
+          : typeof src.confidence_score === "string" ||
+              typeof src.confidence_score === "number"
+            ? src.confidence_score
+            : typeof src.similarity_score === "string" ||
+                typeof src.similarity_score === "number"
+              ? src.similarity_score
+              : undefined;
+      const stage =
+        typeof src.stage === "string" && src.stage.length > 0
+          ? src.stage
+          : undefined;
+      return {
+        text: String(src.content || src.text || ""),
+        source: String(
+          src.document_name || src.source || src.title || "Unknown"
+        ),
+        document_type: (src.document_type as Citation["document_type"]) || "text",
+        score,
+        stage,
+      };
+    }
+  );
+  return scored;
+};
+
 /**
  * Custom hook for managing chat streaming functionality.
- * 
- * Provides utilities to start, process, and stop streaming chat responses.
- * Handles streaming text content, citations, and error states.
- * 
+ *
+ * Handles two SSE contracts on `/generate`:
+ *
+ * 1. **Standard / non-agentic** (and `agentic` with `enable_streaming=false`):
+ *    chunks have no `event_type`; `delta.content` is concatenated into the
+ *    user-facing answer; citations attach on the final chunk.
+ *
+ * 2. **Agentic streaming** (PR #512): each chunk carries an `event_type`
+ *    that discriminates whether the payload is final-answer text, reasoning
+ *    trace, intermediate output, or a stage boundary. The hook builds a
+ *    `reasoning_steps[]` trace alongside the final answer; citations and
+ *    metrics arrive on the first `final_answer` chunk.
+ *
  * @returns An object containing stream state and control functions
- * 
+ *
  * @example
  * ```tsx
  * const { streamState, startStream, processStream, stopStream } = useChatStream();
  * const controller = startStream();
- * await processStream(response, messageId, updateMessage, threshold);
+ * await processStream(response, messageId, updateMessage);
  * ```
  */
 export const useChatStream = () => {
@@ -79,9 +170,20 @@ export const useChatStream = () => {
     let buffer = "";
     let content = "";
     let latestCitations: ChatMessage["citations"] = [];
-    
-    // Detect if this is an error response based on HTTP status code
-    const isError = response.status >= 400;
+    const steps: ReasoningStep[] = [];
+    let metrics: AgenticMetrics | undefined;
+    let isError = response.status >= 400;
+
+    const emit = () => {
+      updateMessage(assistantId, {
+        content,
+        citations:
+          latestCitations && latestCitations.length ? latestCitations : undefined,
+        is_error: isError,
+        reasoning_steps: steps.length ? [...steps] : undefined,
+        metrics,
+      });
+    };
 
     try {
       while (true) {
@@ -96,49 +198,109 @@ export const useChatStream = () => {
           if (!line.startsWith("data: ")) continue;
 
           const json = JSON.parse(line.slice(6));
-          const delta = json.choices?.[0]?.delta?.content;
-          if (delta) content += delta;
+          const choice = json.choices?.[0];
+          const delta = choice?.delta ?? {};
+          const eventType: AgenticEventType | undefined =
+            (delta.event_type as AgenticEventType | undefined) ??
+            (choice?.message?.event_type as AgenticEventType | undefined) ??
+            (json.event_type as AgenticEventType | undefined);
+          const stage: string | undefined =
+            (typeof delta.stage === "string" ? delta.stage : undefined) ??
+            (typeof choice?.message?.stage === "string"
+              ? choice.message.stage
+              : undefined) ??
+            (typeof json.stage === "string" ? json.stage : undefined);
 
-          // Extract citations from any expected location
+          const reasoningContent: string | undefined =
+            typeof delta.reasoning_content === "string"
+              ? delta.reasoning_content
+              : undefined;
+          const deltaContent: string | undefined =
+            typeof delta.content === "string" ? delta.content : undefined;
+
+          // Branch on event_type. When event_type is absent (standard /
+          // non-agentic stream, or pre-#512 backend), fall through the
+          // legacy path: append delta.content to the answer.
+          if (eventType === STAGE_START_EVENT) {
+            closeRunningSteps(steps);
+            steps.push({
+              stage: stage ?? "unknown",
+              label: reasoningContent || undefined,
+              reasoning: "",
+              output: "",
+              status: "running",
+            });
+          } else if (eventType === STAGE_END_EVENT) {
+            const open = steps[steps.length - 1];
+            if (open && open.status === "running") {
+              if (reasoningContent) open.summary = reasoningContent;
+              open.status = "done";
+            }
+          } else if (
+            eventType === "intermediate_reasoning" ||
+            eventType === "final_reasoning"
+          ) {
+            if (reasoningContent) {
+              const step = ensureOpenStep(steps, stage);
+              step.reasoning += reasoningContent;
+            }
+          } else if (eventType === OUTPUT_EVENT) {
+            if (reasoningContent) {
+              const step = ensureOpenStep(steps, stage);
+              step.output += reasoningContent;
+            }
+          } else if (eventType === ERROR_EVENT) {
+            isError = true;
+            if (deltaContent) content += deltaContent;
+            if (reasoningContent) {
+              const step = ensureOpenStep(steps, stage);
+              step.output += reasoningContent;
+              step.status = "error";
+            } else {
+              closeRunningSteps(steps, "error");
+            }
+          } else if (eventType === FINAL_ANSWER_EVENT) {
+            if (deltaContent) content += deltaContent;
+          } else if (eventType !== undefined) {
+            // agent_event or future / unknown event types:
+            // forward-compat — capture any reasoning_content into the
+            // current step so we don't lose information.
+            if (reasoningContent) {
+              const step = ensureOpenStep(steps, stage);
+              step.reasoning += reasoningContent;
+            }
+          } else {
+            // Legacy non-agentic chunk: no event_type discriminator.
+            if (deltaContent) content += deltaContent;
+          }
+
+          // Citations and metrics may arrive on any agentic chunk, but the
+          // server contract pins them to the first `final_answer` chunk.
+          // We accept whichever arrives first / most recent.
           const sources =
             json.citations?.results ??
             json.sources?.results ??
-            json.choices?.[0]?.message?.citations ??
-            json.choices?.[0]?.message?.sources ??
+            choice?.message?.citations ??
+            choice?.message?.sources ??
             [];
+          const parsed = parseSources(sources);
+          if (parsed && parsed.length) latestCitations = parsed;
 
-          if (Array.isArray(sources)) {
-            const scored: ChatMessage["citations"] = sources.map((src: Record<string, unknown>) => {
-              const score = typeof src.score === 'string' || typeof src.score === 'number' ? src.score :
-                           typeof src.confidence_score === 'string' || typeof src.confidence_score === 'number' ? src.confidence_score :
-                           typeof src.similarity_score === 'string' || typeof src.similarity_score === 'number' ? src.similarity_score :
-                           undefined;
-              // `stage` is propagated as an opaque string so future agentic
-              // pipeline stages render without requiring frontend changes.
-              const stage = typeof src.stage === 'string' && src.stage.length > 0
-                ? src.stage
-                : undefined;
-              return {
-                text: String(src.content || src.text || ""),
-                source: String(src.document_name || src.source || src.title || "Unknown"),
-                document_type: (src.document_type as Citation["document_type"]) || "text",
-                score,
-                stage,
-              };
-            });
-
-            // Backend already filters by confidence threshold, so no need to filter here
-            latestCitations = scored;
+          if (json.metrics && typeof json.metrics === "object") {
+            metrics = { ...(metrics ?? {}), ...(json.metrics as AgenticMetrics) };
           }
 
-          updateMessage(assistantId, {
-            content,
-            citations: latestCitations && latestCitations.length ? latestCitations : undefined,
-            is_error: isError,
-          });
+          emit();
 
-          if (json.choices?.[0]?.finish_reason === "stop") {
-            setStreamState({ content, citations: latestCitations, error: null, isTyping: false });
+          if (choice?.finish_reason === "stop") {
+            closeRunningSteps(steps);
+            emit();
+            setStreamState({
+              content,
+              citations: latestCitations,
+              error: null,
+              isTyping: false,
+            });
             return;
           }
         }

--- a/frontend/src/hooks/useChatStream.ts
+++ b/frontend/src/hooks/useChatStream.ts
@@ -113,11 +113,17 @@ export const useChatStream = () => {
                            typeof src.confidence_score === 'string' || typeof src.confidence_score === 'number' ? src.confidence_score :
                            typeof src.similarity_score === 'string' || typeof src.similarity_score === 'number' ? src.similarity_score :
                            undefined;
+              // `stage` is propagated as an opaque string so future agentic
+              // pipeline stages render without requiring frontend changes.
+              const stage = typeof src.stage === 'string' && src.stage.length > 0
+                ? src.stage
+                : undefined;
               return {
                 text: String(src.content || src.text || ""),
                 source: String(src.document_name || src.source || src.title || "Unknown"),
                 document_type: (src.document_type as Citation["document_type"]) || "text",
                 score,
+                stage,
               };
             });
 

--- a/frontend/src/hooks/useCitationUtils.ts
+++ b/frontend/src/hooks/useCitationUtils.ts
@@ -35,9 +35,24 @@ export const useCitationUtils = () => {
     []
   );
 
+  // Convert a server-emitted stage identifier (e.g. "initial_retrieval",
+  // "verify_execute") into a human-readable label. Value-independent: any
+  // future stage name will be displayed sensibly without a code change.
+  const formatStage = useMemo(
+    () => (stage: string | undefined): string => {
+      if (!stage) return "";
+      const cleaned = stage.trim();
+      if (!cleaned) return "";
+      const spaced = cleaned.replace(/[_-]+/g, " ");
+      return spaced.charAt(0).toUpperCase() + spaced.slice(1).toLowerCase();
+    },
+    []
+  );
+
   return {
     isVisualType,
     formatScore,
     generateCitationId,
+    formatStage,
   };
 }; 

--- a/frontend/src/hooks/useMessageSubmit.ts
+++ b/frontend/src/hooks/useMessageSubmit.ts
@@ -29,8 +29,12 @@ import type { Collection } from "../types/collections";
 /**
  * Utility function to remove undefined, null, empty string, and empty array values from a request object.
  * This ensures we only send meaningful parameters to the API.
+ *
+ * Exported so the wire-format guarantees (notably: `agentic: false` must be
+ * preserved to override the server default, while `agentic: undefined` must
+ * be omitted) can be unit-tested in isolation.
  */
-function cleanRequestObject(obj: Partial<GenerateRequest>): GenerateRequest {
+export function cleanRequestObject(obj: Partial<GenerateRequest>): GenerateRequest {
   const cleaned: Partial<GenerateRequest> = {};
   
   for (const [key, value] of Object.entries(obj)) {
@@ -50,7 +54,11 @@ function cleanRequestObject(obj: Partial<GenerateRequest>): GenerateRequest {
         'enable_query_rewriting',
         'enable_guardrails',
         'enable_vlm_inference',
-        'enable_filter_generator'
+        'enable_filter_generator',
+        // `agentic: false` must reach the server to force the standard
+        // pipeline; otherwise it would be dropped and CONFIG.enable_agentic_rag
+        // (which may be true) would silently take over.
+        'agentic',
       ];
       if (value === true || alwaysInclude.includes(key)) {
         (cleaned as Record<string, unknown>)[key] = value;
@@ -91,6 +99,15 @@ export const useMessageSubmit = () => {
   const { shouldDisableHealthFeatures, isHealthLoading } = useHealthDependentFeatures();
 
   const createRequest = useCallback((currentMessages: ChatMessage[]) => {
+    // Map the per-request agentic mode to the wire format:
+    //   "auto" -> undefined (omitted; server's CONFIG.enable_agentic_rag decides)
+    //   "on"   -> true      (force agentic LangGraph pipeline)
+    //   "off"  -> false     (force standard RAG pipeline)
+    const agentic =
+      settings.agenticMode === "on" ? true :
+      settings.agenticMode === "off" ? false :
+      undefined;
+
     const rawRequest = {
       messages: currentMessages.map(({ role, content }) => ({ 
         role, 
@@ -120,6 +137,7 @@ export const useMessageSubmit = () => {
       vlm_endpoint: settings.vlmEndpoint,
       stop: settings.stopTokens,
       confidence_threshold: settings.confidenceScoreThreshold,
+      agentic,
       filter_expr: filters.length
         ? filters
             .map((f: Filter, index: number) => {

--- a/frontend/src/store/useSettingsStore.ts
+++ b/frontend/src/store/useSettingsStore.ts
@@ -21,6 +21,16 @@ import { useServerConfiguration } from "../api/useConfigurationApi";
 import type { ConfigurationResponse } from "../types/api";
 
 /**
+ * Per-request agentic pipeline mode.
+ *
+ * - `"auto"` (default) → omit the `agentic` field from `/generate` and let
+ *   the server's `CONFIG.enable_agentic_rag` decide.
+ * - `"on"` → force the agentic LangGraph plan-and-execute pipeline.
+ * - `"off"` → force the standard RAG pipeline.
+ */
+export type AgenticMode = "auto" | "on" | "off";
+
+/**
  * Interface defining the shape of the settings state.
  * Contains RAG configuration, feature toggles, model settings, and endpoints.
  * Most fields are optional to avoid sending unnecessary defaults in API calls.
@@ -41,6 +51,10 @@ interface SettingsState {
   includeCitations: boolean;
   enableVlmInference?: boolean;
   enableFilterGenerator?: boolean;
+
+  // Agentic pipeline mode - per-request override; defaults to "auto"
+  // ("auto" omits the field so the server's enable_agentic_rag decides)
+  agenticMode: AgenticMode;
   
   // Models - All optional, populated from health endpoint or user input
   model?: string;
@@ -97,6 +111,9 @@ export const useSettingsStore = create<SettingsState>()(
       includeCitations: true,
       enableVlmInference: undefined,
       enableFilterGenerator: undefined,
+
+      // Agentic pipeline mode - default to "auto" (server config decides)
+      agenticMode: "auto" as const,
       
       // Models - All start undefined, will be populated from health endpoint
       model: undefined,

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -58,6 +58,50 @@ export interface ImageContent {
 export type MessageContent = string | (TextContent | ImageContent)[];
 
 /**
+ * One node-level entry in the agentic-RAG reasoning trace.
+ *
+ * Built incrementally by `useChatStream` from `event_type` chunks of an
+ * agentic `/generate` SSE stream. Standard (non-agentic) responses leave
+ * `reasoning_steps` undefined.
+ *
+ * The `stage` is treated as an opaque string (e.g. `"plan"`, `"execute"`,
+ * `"synthesize"`, `"verify"`, `"verify_execute"`, `"initial_retrieval"`),
+ * so any future graph node renders without code changes.
+ */
+export interface ReasoningStep {
+  /** Graph node identifier supplied by the server's `stage` field. */
+  stage: string;
+  /** One-liner from the matching `stage_start` chunk. */
+  label?: string;
+  /** One-liner from the matching `stage_end` chunk. */
+  summary?: string;
+  /**
+   * Concatenated `reasoning_content` from `intermediate_reasoning` and
+   * `final_reasoning` chunks for this stage.
+   */
+  reasoning: string;
+  /**
+   * Concatenated `reasoning_content` from `intermediate_output` chunks
+   * for this stage (planner / verifier JSON, per-task answers, ...).
+   */
+  output: string;
+  /** Lifecycle: open between `stage_start` and `stage_end`. */
+  status: "running" | "done" | "error";
+}
+
+/**
+ * TTFT-style timings emitted on the trailing `finish_reason: "stop"` chunk.
+ * All fields are optional so future metrics added by the server flow
+ * through unchanged.
+ */
+export interface AgenticMetrics {
+  rag_ttft_ms?: number;
+  llm_ttft_ms?: number;
+  llm_generation_time_ms?: number;
+  [key: string]: number | undefined;
+}
+
+/**
  * Represents a message in the chat conversation.
  */
 export interface ChatMessage {
@@ -67,6 +111,13 @@ export interface ChatMessage {
   timestamp: string;
   citations?: Citation[];
   is_error?: boolean;
+  /**
+   * Agentic-RAG reasoning trace, populated only when the server emits
+   * `event_type` chunks (see PR #512). Undefined for standard responses.
+   */
+  reasoning_steps?: ReasoningStep[];
+  /** Trailing-chunk metrics from agentic streaming. */
+  metrics?: AgenticMetrics;
 }
 
 /**

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -21,6 +21,16 @@ export interface Citation {
   source: string;
   document_type: "text" | "image" | "table" | "chart";
   score?: number | string;
+  /**
+   * Pipeline stage that produced this citation.
+   *
+   * Mirrors `SourceResult.stage` on the server. The server defaults to
+   * `"rag"` for the standard pipeline; the agentic pipeline emits values
+   * like `"initial_retrieval"`, `"execute"`, `"verify_execute"`, and may
+   * add new values over time. Treated as an opaque string so we render
+   * any future stage without code changes.
+   */
+  stage?: string;
 }
 
 /**

--- a/frontend/src/types/requests.ts
+++ b/frontend/src/types/requests.ts
@@ -56,4 +56,16 @@ export interface GenerateRequest {
   // Optional other fields
   filter_expr?: string;
   stop?: string[];
+
+  /**
+   * Route this request through the agentic RAG pipeline.
+   *
+   * - `undefined` / omitted → server decides based on its own configuration
+   *   (`CONFIG.enable_agentic_rag`).
+   * - `true` → force the LangGraph plan-and-execute agentic pipeline.
+   * - `false` → force the standard RAG pipeline.
+   *
+   * Mirrors `Prompt.agentic` on the server (`bool | None`).
+   */
+  agentic?: boolean | null;
 }


### PR DESCRIPTION
Frontend counterpart to #512 ("Added Streaming support in Agentic
RAG"). Surfaces the new `event_type` / `reasoning_content` SSE chunks
from `/v1/generate` so users can watch the LangGraph agent plan,
execute, verify, and synthesize before the final answer arrives.

> **Stacks on top of #514** (agentic-mode selector + citation badges).
> While #514 is open this PR's diff against `develop` will include those
> commits too; they fall out automatically once #514 merges.

## Summary

1. **Stream parser (`useChatStream`)** — switches on the new `event_type`
   discriminator and routes payload appropriately:

    | event_type | Routed to |
    |---|---|
    | `null` / unset / `final_answer` | append `delta.content` to the user-visible answer (legacy non-agentic path is the `null` branch — full backward compat) |
    | `stage_start` / `stage_end` | open / close a `ReasoningStep`; `reasoning_content` lands as `label` / `summary` |
    | `intermediate_reasoning` / `final_reasoning` | append `reasoning_content` to current step's `reasoning` |
    | `intermediate_output` | append `reasoning_content` to current step's `output` |
    | `error` | mark message `is_error`, `delta.content` is user-visible, `reasoning_content` is detail, current step → `error` |
    | `agent_event` / unknown | forward-compat: preserve `reasoning_content` so future event types don't drop silently |

    Citations + metrics still attach on the first `final_answer` chunk
    (same contract as today). The trailing `finish_reason: "stop"` chunk
    closes any still-running steps and finalizes metrics. `stage` is
    treated as an opaque string so any future graph node renders without
    code changes.

2. **`ReasoningPanel` UI** — new collapsible "Thinking" panel rendered
   above the assistant's answer in `ChatMessageBubble`. Hidden when the
   message has no `reasoning_steps`, so **standard non-agentic responses
   are visually unchanged**. Auto-expanded while streaming; collapses on
   completion to a "Thought for N steps" line. Each step shows status
   icon (running / done / error), formatted stage name (\`formatStage\`
   from \`useCitationUtils\`), label / summary, and the accumulated
   reasoning + output text.

3. **Types** — \`ChatMessage\` gains optional \`reasoning_steps?:
   ReasoningStep[]\` and \`metrics?: AgenticMetrics\`. Both undefined for
   non-agentic responses.

## Behavior contract

- Non-agentic responses: zero behavior change. \`event_type\` is unset →
  the legacy \`delta.content\` path runs unchanged. No reasoning panel
  rendered. Existing tests cover this path as a regression.
- Agentic responses: stream is rendered live; reasoning panel collapses
  once the final answer is in.
- All event types are forward-compatible — new event types or stage
  values added by the server flow through and are formatted
  automatically.

## Test plan

- [x] All 709 frontend tests pass (\`pnpm run test:run\`).
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] ESLint clean on touched files.
- [x] New unit coverage:
    - \`useChatStream.test.ts\` (8) — legacy non-agentic regression,
      full agentic event sequence, citations + metrics on first
      final_answer, lazy-create-on-orphan, intermediate_output
      separation, error path, forward-compat for unknown event types,
      finish_reason cleanup of running steps.
    - \`ReasoningPanel.test.tsx\` (9) — empty state hidden, header text
      in streaming vs done, value-independent stage formatting (e.g.
      \`verify_execute\` → \`Verify execute\`), auto-expand while
      streaming, click + keyboard toggle, status data attrs, both
      reasoning + output blocks.
- [ ] Manual smoke against a backend that includes #512 — to be done
      once #512 is deployable on a dev box.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] All commits are signed-off (\`git commit -s\`).
- [x] New or existing tests cover these changes.
- [x] No docker-compose / helm env var changes (FE-only).