### PR TITLE
Added Dynamic Filter Generation Support for Elasticsearch

### DIFF
--- a/deploy/helm/nvidia-blueprint-rag/files/prompt.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/files/prompt.yaml
@@ -195,7 +195,7 @@ vlm_template:
 # Reasoning templates deprecated and removed
 
 
-filter_expression_generator_prompt:
+filter_expression_generator_prompt_milvus:
   system: |
     You are an expert AI filter expression generator. Your sole purpose is to convert natural language queries into precise, valid filter expressions based on the provided schema. You must be aggressive in finding mappable entities.
 
@@ -255,6 +255,91 @@ filter_expression_generator_prompt:
 
     1.  **On Success:** The filter expression string.
         * content_metadata["year"] == 2024
+
+    2.  **On Absolute Failure:** The exact text NO_FILTER.
+        * **Use this ONLY if the query is completely unrelated to the schema**, like "what is your name?" or "tell me a joke".
+
+    3.  **On Logical Conflict:** The exact text UNSUPPORTED.
+        * **Use this ONLY for impossible logic**, like "year is 2022 and year is 2023".
+
+  human: |
+    Generate the filter expression.{existing_filter_context}
+
+filter_expression_generator_prompt_elasticsearch:
+  system: |
+    You are an expert AI filter expression generator for Elasticsearch. Your sole purpose is to convert natural language queries into precise, valid Elasticsearch Query DSL filter clauses based on the provided schema. You must be aggressive in finding mappable entities.
+
+    ### Primary Directive ###
+
+    **Your primary directive is to ALWAYS generate a filter.** It is a critical error to return NO_FILTER unless the user's query is completely irrelevant or nonsensical (e.g., "hello there," "what is the weather?"). Be bold and decisive. Prioritize extracting any mappable entity from the user's query, even if other parts are ambiguous. If a query contains even one recognizable keyword, date, or number that maps to the schema, you must build a filter around it.
+
+    ### Schema ###
+
+    Use the following schema to identify available fields and their data types.
+    {metadata_schema}
+
+    ### Field Path Convention ###
+
+    - Always prefix field names with `metadata.content_metadata.` — e.g. for schema field `status`, target `metadata.content_metadata.status`.
+    - For `string` fields used in exact-match clauses (`term`, `terms`), append `.keyword` — e.g. `metadata.content_metadata.status.keyword`.
+    - Do NOT append `.keyword` for `wildcard`, `match`, `range`, or numeric/datetime/boolean fields.
+
+    ### Output Format ###
+
+    Emit a single JSON array of Elasticsearch filter clauses (no markdown, no explanations). Each clause is a Query DSL object. Use a top-level `bool` clause for logical composition.
+
+    ### Type → Clause Mapping ###
+
+    1.  **String** — `term`, `terms`, `wildcard`, `match`
+        * `[{{"term": {{"metadata.content_metadata.doc_type.keyword": "report"}}}}]`
+        * `[{{"terms": {{"metadata.content_metadata.doc_type.keyword": ["report", "summary"]}}}}]`
+        * `[{{"wildcard": {{"metadata.content_metadata.title": "*compliance*"}}}}]`
+    2.  **Integer / Number / Float** — `term`, `range`
+        * `[{{"range": {{"metadata.content_metadata.page_count": {{"gt": 10}}}}}}]`
+        * `[{{"range": {{"metadata.content_metadata.year": {{"gte": 2024, "lt": 2026}}}}}}]`
+    3.  **Datetime** (ISO 8601: YYYY-MM-DDTHH:MM:SS) — `range`
+        * `[{{"range": {{"metadata.content_metadata.created_at": {{"gte": "2024-01-01T00:00:00"}}}}}}]`
+    4.  **Boolean** — `term`
+        * `[{{"term": {{"metadata.content_metadata.is_public": true}}}}]`
+    5.  **Array** — `terms`, `term`
+        * Single value match: `[{{"term": {{"metadata.content_metadata.tags.keyword": "urgent"}}}}]`
+        * Any of: `[{{"terms": {{"metadata.content_metadata.regions.keyword": ["EMEA", "APAC"]}}}}]`
+        * All of: use `bool.must` with one `term` per value.
+
+    ### Logical Composition ###
+
+    Use `bool` with `must` (AND), `should` (OR), and `must_not` (NOT). Wrap the bool object inside the top-level array.
+
+    Example AND:
+    `[{{"bool": {{"must": [{{"term": {{"metadata.content_metadata.doc_type.keyword": "financial_report"}}}}, {{"term": {{"metadata.content_metadata.project.keyword": "Project X"}}}}]}}}}]`
+
+    Example OR with NOT:
+    `[{{"bool": {{"should": [{{"term": {{"metadata.content_metadata.region.keyword": "EMEA"}}}}, {{"term": {{"metadata.content_metadata.region.keyword": "APAC"}}}}], "must_not": [{{"term": {{"metadata.content_metadata.archived": true}}}}]}}}}]`
+
+    ### Intelligent Mapping Examples ###
+
+    * **Query:** "Project X"
+        * **Output:** `[{{"term": {{"metadata.content_metadata.project.keyword": "Project X"}}}}]`
+    * **Query:** "approved"
+        * **Output:** `[{{"term": {{"metadata.content_metadata.status.keyword": "approved"}}}}]`
+    * **Query:** "Find the latest financial reports for Project X"
+        * **Action:** Ignore "latest" as it's subjective. Extract "financial reports" and "Project X".
+        * **Output:** `[{{"bool": {{"must": [{{"term": {{"metadata.content_metadata.doc_type.keyword": "financial_report"}}}}, {{"term": {{"metadata.content_metadata.project.keyword": "Project X"}}}}]}}}}]`
+    * **Query:** "I think I need the document from Q2 last year about compliance"
+        * **Action:** Extract "Q2 last year" (assume 2024) and "compliance".
+        * **Output:** `[{{"bool": {{"must": [{{"range": {{"metadata.content_metadata.created_at": {{"gte": "2024-04-01T00:00:00", "lt": "2024-07-01T00:00:00"}}}}}}, {{"term": {{"metadata.content_metadata.tags.keyword": "compliance"}}}}]}}}}]`
+
+    ### Your Task ###
+
+    Convert the following user query into Elasticsearch filter clauses.
+    {user_request}
+
+    ### Response Format ###
+
+    Your response **MUST** be only the raw JSON array and nothing else. Do not use explanations, comments, or markdown fences.
+
+    1.  **On Success:** A JSON array of one or more filter clauses.
+        * `[{{"term": {{"metadata.content_metadata.year": 2024}}}}]`
 
     2.  **On Absolute Failure:** The exact text NO_FILTER.
         * **Use this ONLY if the query is completely unrelated to the schema**, like "what is your name?" or "tell me a joke".

--- a/docs/custom-metadata.md
+++ b/docs/custom-metadata.md
@@ -100,10 +100,9 @@ This notebook demonstrates:
 ## Important Notes
 
 ### 🎯 **Vector Database Support**
-- **Milvus**: Full support for natural language filter generation and complex expressions
-- **Elasticsearch**: Limited to basic filter validation only (no natural language generation)
-- **Natural Language Generation**: Only works with Milvus vector database
-- **Filter Expression Types**: Milvus uses string expressions, Elasticsearch uses list of dictionaries
+- **Milvus**: Full support for natural language filter generation using a string boolean expression DSL.
+- **Elasticsearch**: Full support for natural language filter generation; the LLM emits Elasticsearch Query DSL clauses (a JSON array of `term`, `terms`, `range`, `bool`, etc.) which are validated against the collection's metadata schema.
+- **Filter Expression Types**: Milvus uses string expressions; Elasticsearch uses a list of clause dictionaries.
 
 ### 🚨 **Key Limitations**
 - **IS NULL/IS NOT NULL operations**: Not supported
@@ -116,7 +115,7 @@ This notebook demonstrates:
 
 | Feature | Milvus | Elasticsearch |
 |---------|--------|---------------|
-| **Natural Language Filter Generation** | ✅ Fully automated with LLM integration | 🔧 Advanced users can leverage native Elasticsearch Query DSL for sophisticated queries |
+| **Natural Language Filter Generation** | ✅ Fully automated with LLM integration (string DSL) | ✅ Fully automated with LLM integration (Elasticsearch Query DSL clauses) |
 | **Filter Expression Complexity** | ✅ String-based syntax with validation | 🚀 Full Elasticsearch Query DSL support - Boolean, range, nested, geo, and aggregation queries |
 | **Schema Validation** | ✅ Comprehensive metadata schema validation | 🔧 Flexible schema-less design with dynamic mapping capabilities |
 | **Array Operations** | ✅ Built-in functions: `array_contains`, `array_length`, etc. | 🚀 Native nested object support with powerful array querying capabilities |
@@ -200,6 +199,36 @@ The system gracefully handles filter generation failures:
 - **Invalid Generation**: Returns None, continues without filtering
 - **Schema Mismatch**: Logs warning, skips incompatible collections
 - **Processing Errors**: Returns original query, maintains functionality
+
+### Elasticsearch Filter Generation
+
+When `APP_VECTORSTORE_NAME=elasticsearch`, filter generation produces a JSON array of Elasticsearch Query DSL clauses instead of a Milvus boolean string. The same `enable_filter_generator` flag and metadata schema mechanism apply.
+
+**Field path convention**
+
+User-defined metadata is indexed at `metadata.content_metadata.<field>`. For exact-match clauses (`term`, `terms`, `prefix`) on string fields, the `.keyword` sub-field is used (e.g. `metadata.content_metadata.status.keyword`). The validator auto-normalizes paths produced by the LLM, so user-supplied filters that omit `.keyword` are still accepted.
+
+**Supported clause types**
+
+`term`, `terms`, `range`, `match`, `match_phrase`, `wildcard`, `prefix`, `exists`, and `bool` (with `must`, `should`, `must_not`, `filter`).
+
+**Example queries and generated filters**
+
+| Your Question | Generated Filter |
+|---------------|------------------|
+| "Show me approved AI reports from 2024" | `[{"bool": {"must": [{"term": {"metadata.content_metadata.status.keyword": "approved"}}, {"term": {"metadata.content_metadata.category.keyword": "AI"}}, {"range": {"metadata.content_metadata.year": {"gte": 2024, "lt": 2025}}}]}}]` |
+| "Public documents tagged engineering" | `[{"bool": {"must": [{"term": {"metadata.content_metadata.is_public": true}}, {"term": {"metadata.content_metadata.tags.keyword": "engineering"}}]}}]` |
+| "High-rated docs from January 2024" | `[{"bool": {"must": [{"range": {"metadata.content_metadata.rating": {"gt": 4.0}}}, {"range": {"metadata.content_metadata.created_at": {"gte": "2024-01-01T00:00:00", "lt": "2024-02-01T00:00:00"}}}]}}]` |
+
+**Validation**
+
+Each generated clause is checked against the collection's metadata schema:
+
+- Field must exist in the schema (or be a system-managed field with `support_dynamic_filtering=true`).
+- Clause type must match the field's declared type (e.g. `range` only on numeric/datetime fields).
+- `range` bounds on `datetime` fields must be valid ISO 8601 strings.
+
+If validation fails for an LLM-generated filter, the system falls back to no filter (the request still succeeds). For user-supplied filters via the API, validation errors are surfaced explicitly.
 
 ## Metadata Schema Definition
 
@@ -538,7 +567,7 @@ export APP_FILTEREXPRESSIONGENERATOR_SERVERURL=""
 
 ## Customizing Filter Expression Generator Prompt
 
-The `filter_expression_generator_prompt` determines how natural language queries are converted into metadata filter expressions. Customizing this prompt is essential for domain-specific applications where industry terminology needs accurate mapping to your metadata fields.
+The filter generator prompts (`filter_expression_generator_prompt_milvus` and `filter_expression_generator_prompt_elasticsearch`) determine how natural language queries are converted into metadata filter expressions. The active prompt is selected automatically based on the configured vector store (`APP_VECTORSTORE_NAME`). Customizing the relevant prompt is essential for domain-specific applications where industry terminology needs accurate mapping to your metadata fields.
 
 ### When to Customize
 
@@ -567,7 +596,7 @@ For an automotive documentation system with this schema:
 Create `automotive_filter_prompt.yaml`:
 
 ```yaml
-filter_expression_generator_prompt:
+filter_expression_generator_prompt_milvus:
   system: |
     /no_think
   
@@ -642,7 +671,7 @@ docker compose -f deploy/compose/docker-compose-rag-server.yaml up -d
 ```
 
 **Helm:**
-Edit `deploy/helm/nvidia-blueprint-rag/files/prompt.yaml` and update the `filter_expression_generator_prompt` section.
+Edit `deploy/helm/nvidia-blueprint-rag/files/prompt.yaml` and update the `filter_expression_generator_prompt_milvus` or `filter_expression_generator_prompt_elasticsearch` section depending on your vector store.
 
 ### Results
 

--- a/docs/prompt-customization.md
+++ b/docs/prompt-customization.md
@@ -79,11 +79,11 @@ The `prompt.yaml` file contains a set of prompt templates used throughout the RA
 - **Usage:** Produces streamlined summaries when `shallow_summary: true` is set during document ingestion. Uses a simplified prompt optimized for fast text-only processing without multimodal elements (tables, images, charts).
 - **Context:** Automatically selected when shallow extraction is enabled. For full multimodal extraction, `document_summary_prompt` is used instead. See [document summarization](./summarization.md) for details on shallow vs. full extraction.
 
-### 17. `filter_expression_generator_prompt`
-- **Purpose:** Converts natural language queries into precise metadata filter expressions for targeted document retrieval.
+### 17. `filter_expression_generator_prompt_milvus` / `filter_expression_generator_prompt_elasticsearch`
+- **Purpose:** Converts natural language queries into precise metadata filter expressions for targeted document retrieval. The active prompt is selected automatically based on the configured vector store (`APP_VECTORSTORE_NAME`): `filter_expression_generator_prompt_milvus` produces a Milvus boolean expression string, while `filter_expression_generator_prompt_elasticsearch` produces an Elasticsearch Query DSL clause array.
 - **Usage:** Automatically generates filter expressions when `enable_filter_generator: true` is set in the `/generate` or `/chat/completions` API. The LLM analyzes the user's query and the collection's metadata schema to create appropriate filters.
-- **Context:** This enables users to ask questions in natural language (e.g., "Show me Ford vehicles with infotainment features") and have the system automatically convert them into metadata filters (e.g., `content_metadata["manufacturer"] == "ford" AND array_contains(content_metadata["features"], "infotainment")`).
-- **Customization:** For domain-specific applications, customize this prompt to map industry terminology to your metadata fields. See the [Customizing Filter Expression Generator Prompt](./custom-metadata.md#customizing-filter-expression-generator-prompt) section for detailed examples and best practices.
+- **Context:** This enables users to ask questions in natural language (e.g., "Show me Ford vehicles with infotainment features") and have the system automatically convert them into metadata filters. For Milvus: `content_metadata["manufacturer"] == "ford" AND array_contains(content_metadata["features"], "infotainment")`. For Elasticsearch: `[{"bool": {"must": [{"term": {"metadata.content_metadata.manufacturer.keyword": "ford"}}, {"term": {"metadata.content_metadata.features.keyword": "infotainment"}}]}}]`.
+- **Customization:** For domain-specific applications, customize the appropriate prompt to map industry terminology to your metadata fields. See the [Customizing Filter Expression Generator Prompt](./custom-metadata.md#customizing-filter-expression-generator-prompt) section for detailed examples and best practices.
 
 ### 18. `image_captioning_prompt`
 - **Purpose:** Generates detailed descriptions of images encountered during document ingestion.

--- a/src/nvidia_rag/rag_server/main.py
+++ b/src/nvidia_rag/rag_server/main.py
@@ -82,6 +82,7 @@ from nvidia_rag.rag_server.validation import (
 from nvidia_rag.rag_server.vlm import VLM
 from nvidia_rag.utils.common import (
     filter_documents_by_confidence,
+    format_filter_for_log,
     process_filter_expr,
     validate_filter_expr,
 )
@@ -1166,9 +1167,9 @@ class NvidiaRAG:
                         )
 
             if enable_filter_generator and not is_image_query:
-                if self.config.vector_store.name != "milvus":
+                if self.config.vector_store.name not in ("milvus", "elasticsearch"):
                     logger.warning(
-                        f"Filter expression generator is currently only supported for Milvus. "
+                        f"Filter expression generator is supported for Milvus and Elasticsearch only. "
                         f"Current vector store: {self.config.vector_store.name}. Skipping filter generation."
                     )
                 else:
@@ -1180,9 +1181,41 @@ class NvidiaRAG:
                             ErrorCodeMapping.SERVICE_UNAVAILABLE,
                         )
 
-                    logger.debug(
-                        "Filter expression generator enabled, attempting to generate filter from query"
+                    is_es = self.config.vector_store.name == "elasticsearch"
+                    prompt_key = (
+                        "filter_expression_generator_prompt_elasticsearch"
+                        if is_es
+                        else "filter_expression_generator_prompt_milvus"
                     )
+                    output_format = "json" if is_es else "string"
+                    empty_filter = [] if is_es else ""
+
+                    logger.info("=" * 80)
+                    logger.info("STAGE: Dynamic Filter Expression Generation")
+                    logger.info("=" * 80)
+                    logger.info("Configuration:")
+                    logger.info(
+                        "  - Vector Store: %s", self.config.vector_store.name
+                    )
+                    logger.info("  - Prompt: %s", prompt_key)
+                    logger.info("  - Output Format: %s", output_format)
+                    logger.info(
+                        "  - Model: %s",
+                        self.config.filter_expression_generator.model_name,
+                    )
+                    logger.info(
+                        "  - Endpoint: %s",
+                        self.config.filter_expression_generator.server_url,
+                    )
+                    logger.info("Input:")
+                    logger.info(
+                        "  - Query: '%s'",
+                        processed_query[:200] if processed_query else "",
+                    )
+                    logger.info("  - Collections: %s", validated_collections)
+                    logger.info("Generating filter expressions for collections...")
+                    logger.info("-" * 80)
+
                     try:
 
                         def generate_filter_for_collection(collection_name):
@@ -1196,17 +1229,18 @@ class NvidiaRAG:
                                         user_request=processed_query,
                                         collection_name=collection_name,
                                         metadata_schema=metadata_schema_data,
-                                        prompt_template=self.prompts.get(
-                                            "filter_expression_generator_prompt"
-                                        ),
+                                        prompt_template=self.prompts.get(prompt_key),
                                         llm=self.filter_generator_llm,
                                         existing_filter_expr=filter_expr,
+                                        output_format=output_format,
                                     )
                                 )
 
                                 if generated_filter:
-                                    logger.debug(
-                                        f"Generated filter expression for collection '{collection_name}': {generated_filter}"
+                                    logger.info(
+                                        "Dynamic filter generated for collection '%s': %s",
+                                        collection_name,
+                                        format_filter_for_log(generated_filter),
                                     )
 
                                     processed_filter_expr = process_filter_expr(
@@ -1216,17 +1250,23 @@ class NvidiaRAG:
                                         is_generated_filter=True,
                                         config=self.config,
                                     )
+                                    logger.info(
+                                        "Dynamic filter (post-processing) for collection '%s': %s",
+                                        collection_name,
+                                        format_filter_for_log(processed_filter_expr),
+                                    )
                                     return collection_name, processed_filter_expr
                                 else:
-                                    logger.debug(
-                                        f"No filter expression generated for collection '{collection_name}'"
+                                    logger.info(
+                                        "No dynamic filter generated for collection '%s' (LLM returned empty/NO_FILTER)",
+                                        collection_name,
                                     )
-                                    return collection_name, ""
+                                    return collection_name, empty_filter
                             except Exception as e:
                                 logger.warning(
                                     f"Error generating filter for collection '{collection_name}': {str(e)}"
                                 )
-                                return collection_name, ""
+                                return collection_name, empty_filter
 
                         with ThreadPoolExecutor() as executor:
                             futures = [
@@ -1245,14 +1285,20 @@ class NvidiaRAG:
                         generated_count = len(
                             [f for f in collection_filter_mapping.values() if f]
                         )
-                        if generated_count > 0:
-                            logger.info(
-                                f"Generated filter expressions for {generated_count}/{len(validated_collections)} collections"
-                            )
-                        else:
-                            logger.info(
-                                "No filter expressions generated for any collection"
-                            )
+                        logger.info("Filter Generation Output:")
+                        logger.info(
+                            "  - Successfully generated filters for %d/%d collections",
+                            generated_count,
+                            len(validated_collections),
+                        )
+                        for coll_name, filter_val in collection_filter_mapping.items():
+                            if filter_val:
+                                logger.info(
+                                    "  - Collection '%s': %s",
+                                    coll_name,
+                                    format_filter_for_log(filter_val),
+                                )
+                        logger.info("-" * 80)
 
                     except Exception as e:
                         logger.error(f"Error generating filter expression: {str(e)}")
@@ -2705,9 +2751,9 @@ class NvidiaRAG:
                         )
 
             if enable_filter_generator and not is_image_query:
-                if self.config.vector_store.name != "milvus":
+                if self.config.vector_store.name not in ("milvus", "elasticsearch"):
                     logger.warning(
-                        f"Filter expression generator is currently only supported for Milvus. "
+                        f"Filter expression generator is supported for Milvus and Elasticsearch only. "
                         f"Current vector store: {self.config.vector_store.name}. Skipping filter generation."
                     )
                 else:
@@ -2719,10 +2765,25 @@ class NvidiaRAG:
                             ErrorCodeMapping.SERVICE_UNAVAILABLE,
                         )
 
+                    is_es_agentic = (
+                        self.config.vector_store.name == "elasticsearch"
+                    )
+                    prompt_key_agentic = (
+                        "filter_expression_generator_prompt_elasticsearch"
+                        if is_es_agentic
+                        else "filter_expression_generator_prompt_milvus"
+                    )
+                    output_format_agentic = "json" if is_es_agentic else "string"
+
                     logger.info("=" * 80)
-                    logger.info("STAGE: Filter Expression Generation")
+                    logger.info("STAGE: Dynamic Filter Expression Generation")
                     logger.info("=" * 80)
                     logger.info("Configuration:")
+                    logger.info(
+                        "  - Vector Store: %s", self.config.vector_store.name
+                    )
+                    logger.info("  - Prompt: %s", prompt_key_agentic)
+                    logger.info("  - Output Format: %s", output_format_agentic)
                     logger.info(
                         "  - Model: %s",
                         self.config.filter_expression_generator.model_name,
@@ -2746,6 +2807,9 @@ class NvidiaRAG:
                     }
                     try:
                         with traced_span("rag.Custom Metadata.token_usage") as mf_span:
+                            prompt_key = prompt_key_agentic
+                            output_format = output_format_agentic
+                            empty_filter = [] if is_es_agentic else ""
 
                             def generate_filter_for_collection(collection_name):
                                 try:
@@ -2759,17 +2823,20 @@ class NvidiaRAG:
                                             collection_name=collection_name,
                                             metadata_schema=metadata_schema_data,
                                             prompt_template=self.prompts.get(
-                                                "filter_expression_generator_prompt"
+                                                prompt_key
                                             ),
                                             llm=self.filter_generator_llm,
                                             existing_filter_expr=filter_expr,
                                             run_config=run_config_mf,
+                                            output_format=output_format,
                                         )
                                     )
 
                                     if generated_filter:
                                         logger.info(
-                                            f"Generated filter expression for collection '{collection_name}': {generated_filter}"
+                                            "Dynamic filter generated for collection '%s': %s",
+                                            collection_name,
+                                            format_filter_for_log(generated_filter),
                                         )
                                         processed_filter_expr = process_filter_expr(
                                             generated_filter,
@@ -2778,17 +2845,25 @@ class NvidiaRAG:
                                             is_generated_filter=True,
                                             config=self.config,
                                         )
+                                        logger.info(
+                                            "Dynamic filter (post-processing) for collection '%s': %s",
+                                            collection_name,
+                                            format_filter_for_log(
+                                                processed_filter_expr
+                                            ),
+                                        )
                                         return collection_name, processed_filter_expr
                                     else:
                                         logger.info(
-                                            f"No filter expression generated for collection '{collection_name}'"
+                                            "No dynamic filter generated for collection '%s' (LLM returned empty/NO_FILTER)",
+                                            collection_name,
                                         )
-                                        return collection_name, ""
+                                        return collection_name, empty_filter
                                 except Exception as e:
                                     logger.warning(
                                         f"Error generating filter for collection '{collection_name}': {str(e)}"
                                     )
-                                    return collection_name, ""
+                                    return collection_name, empty_filter
 
                         with ThreadPoolExecutor() as executor:
                             futures = [
@@ -2829,7 +2904,7 @@ class NvidiaRAG:
                                     logger.info(
                                         "  - Collection '%s': %s",
                                         coll_name,
-                                        filter_val[:100],
+                                        format_filter_for_log(filter_val),
                                     )
                         else:
                             logger.info(
@@ -3032,7 +3107,7 @@ class NvidiaRAG:
                     logger.info(
                         "  - Filter Expressions: %s",
                         {
-                            k: v[:50] + "..." if len(v) > 50 else v
+                            k: format_filter_for_log(v)
                             for k, v in collection_filter_mapping.items()
                         },
                     )

--- a/src/nvidia_rag/rag_server/prompt.yaml
+++ b/src/nvidia_rag/rag_server/prompt.yaml
@@ -195,7 +195,7 @@ vlm_template:
 # Reasoning templates deprecated and removed
 
 
-filter_expression_generator_prompt:
+filter_expression_generator_prompt_milvus:
   system: |
     You are an expert AI filter expression generator. Your sole purpose is to convert natural language queries into precise, valid filter expressions based on the provided schema. You must be aggressive in finding mappable entities.
 
@@ -255,6 +255,91 @@ filter_expression_generator_prompt:
 
     1.  **On Success:** The filter expression string.
         * content_metadata["year"] == 2024
+
+    2.  **On Absolute Failure:** The exact text NO_FILTER.
+        * **Use this ONLY if the query is completely unrelated to the schema**, like "what is your name?" or "tell me a joke".
+
+    3.  **On Logical Conflict:** The exact text UNSUPPORTED.
+        * **Use this ONLY for impossible logic**, like "year is 2022 and year is 2023".
+
+  human: |
+    Generate the filter expression.{existing_filter_context}
+
+filter_expression_generator_prompt_elasticsearch:
+  system: |
+    You are an expert AI filter expression generator for Elasticsearch. Your sole purpose is to convert natural language queries into precise, valid Elasticsearch Query DSL filter clauses based on the provided schema. You must be aggressive in finding mappable entities.
+
+    ### Primary Directive ###
+
+    **Your primary directive is to ALWAYS generate a filter.** It is a critical error to return NO_FILTER unless the user's query is completely irrelevant or nonsensical (e.g., "hello there," "what is the weather?"). Be bold and decisive. Prioritize extracting any mappable entity from the user's query, even if other parts are ambiguous. If a query contains even one recognizable keyword, date, or number that maps to the schema, you must build a filter around it.
+
+    ### Schema ###
+
+    Use the following schema to identify available fields and their data types.
+    {metadata_schema}
+
+    ### Field Path Convention ###
+
+    - Always prefix field names with `metadata.content_metadata.` — e.g. for schema field `status`, target `metadata.content_metadata.status`.
+    - For `string` fields used in exact-match clauses (`term`, `terms`), append `.keyword` — e.g. `metadata.content_metadata.status.keyword`.
+    - Do NOT append `.keyword` for `wildcard`, `match`, `range`, or numeric/datetime/boolean fields.
+
+    ### Output Format ###
+
+    Emit a single JSON array of Elasticsearch filter clauses (no markdown, no explanations). Each clause is a Query DSL object. Use a top-level `bool` clause for logical composition.
+
+    ### Type → Clause Mapping ###
+
+    1.  **String** — `term`, `terms`, `wildcard`, `match`
+        * `[{{"term": {{"metadata.content_metadata.doc_type.keyword": "report"}}}}]`
+        * `[{{"terms": {{"metadata.content_metadata.doc_type.keyword": ["report", "summary"]}}}}]`
+        * `[{{"wildcard": {{"metadata.content_metadata.title": "*compliance*"}}}}]`
+    2.  **Integer / Number / Float** — `term`, `range`
+        * `[{{"range": {{"metadata.content_metadata.page_count": {{"gt": 10}}}}}}]`
+        * `[{{"range": {{"metadata.content_metadata.year": {{"gte": 2024, "lt": 2026}}}}}}]`
+    3.  **Datetime** (ISO 8601: YYYY-MM-DDTHH:MM:SS) — `range`
+        * `[{{"range": {{"metadata.content_metadata.created_at": {{"gte": "2024-01-01T00:00:00"}}}}}}]`
+    4.  **Boolean** — `term`
+        * `[{{"term": {{"metadata.content_metadata.is_public": true}}}}]`
+    5.  **Array** — `terms`, `term`
+        * Single value match: `[{{"term": {{"metadata.content_metadata.tags.keyword": "urgent"}}}}]`
+        * Any of: `[{{"terms": {{"metadata.content_metadata.regions.keyword": ["EMEA", "APAC"]}}}}]`
+        * All of: use `bool.must` with one `term` per value.
+
+    ### Logical Composition ###
+
+    Use `bool` with `must` (AND), `should` (OR), and `must_not` (NOT). Wrap the bool object inside the top-level array.
+
+    Example AND:
+    `[{{"bool": {{"must": [{{"term": {{"metadata.content_metadata.doc_type.keyword": "financial_report"}}}}, {{"term": {{"metadata.content_metadata.project.keyword": "Project X"}}}}]}}}}]`
+
+    Example OR with NOT:
+    `[{{"bool": {{"should": [{{"term": {{"metadata.content_metadata.region.keyword": "EMEA"}}}}, {{"term": {{"metadata.content_metadata.region.keyword": "APAC"}}}}], "must_not": [{{"term": {{"metadata.content_metadata.archived": true}}}}]}}}}]`
+
+    ### Intelligent Mapping Examples ###
+
+    * **Query:** "Project X"
+        * **Output:** `[{{"term": {{"metadata.content_metadata.project.keyword": "Project X"}}}}]`
+    * **Query:** "approved"
+        * **Output:** `[{{"term": {{"metadata.content_metadata.status.keyword": "approved"}}}}]`
+    * **Query:** "Find the latest financial reports for Project X"
+        * **Action:** Ignore "latest" as it's subjective. Extract "financial reports" and "Project X".
+        * **Output:** `[{{"bool": {{"must": [{{"term": {{"metadata.content_metadata.doc_type.keyword": "financial_report"}}}}, {{"term": {{"metadata.content_metadata.project.keyword": "Project X"}}}}]}}}}]`
+    * **Query:** "I think I need the document from Q2 last year about compliance"
+        * **Action:** Extract "Q2 last year" (assume 2024) and "compliance".
+        * **Output:** `[{{"bool": {{"must": [{{"range": {{"metadata.content_metadata.created_at": {{"gte": "2024-04-01T00:00:00", "lt": "2024-07-01T00:00:00"}}}}}}, {{"term": {{"metadata.content_metadata.tags.keyword": "compliance"}}}}]}}}}]`
+
+    ### Your Task ###
+
+    Convert the following user query into Elasticsearch filter clauses.
+    {user_request}
+
+    ### Response Format ###
+
+    Your response **MUST** be only the raw JSON array and nothing else. Do not use explanations, comments, or markdown fences.
+
+    1.  **On Success:** A JSON array of one or more filter clauses.
+        * `[{{"term": {{"metadata.content_metadata.year": 2024}}}}]`
 
     2.  **On Absolute Failure:** The exact text NO_FILTER.
         * **Use this ONLY if the query is completely unrelated to the schema**, like "what is your name?" or "tell me a joke".

--- a/src/nvidia_rag/utils/common.py
+++ b/src/nvidia_rag/utils/common.py
@@ -41,6 +41,7 @@ from langchain_core.documents import Document
 from langchain_nvidia_ai_endpoints import Model, register_model
 
 from nvidia_rag.utils import configuration
+from nvidia_rag.utils.es_filter_validator import ElasticsearchFilterValidator
 from nvidia_rag.utils.metadata_validation import (
     FilterExpressionParser,
     MetadataField,
@@ -380,10 +381,103 @@ def validate_filter_expr(
                         "error_message": "Elasticsearch filter must be a list of dictionaries",
                         "details": [f"Invalid item type: {type(item)}"],
                     }
-            logger.debug(
-                f"Elasticsearch filter validated successfully: {len(filter_expr)} filter conditions"
-            )
-            return {"status": True, "validated_collections": collection_names}
+
+            # Empty filter list bypasses schema-aware validation.
+            if not filter_expr:
+                logger.debug("Elasticsearch filter is empty, nothing to validate")
+                return {"status": True, "validated_collections": collection_names}
+
+            allow_partial_filtering = config.metadata.allow_partial_filtering
+
+            def validate_es_single_collection(collection_name: str) -> dict[str, Any]:
+                try:
+                    metadata_schema_data = metadata_schemas.get(collection_name)
+                    if not metadata_schema_data:
+                        # No schema registered — fall back to shape-only acceptance
+                        # to preserve current behavior for collections without schemas.
+                        return {
+                            "collection": collection_name,
+                            "valid": True,
+                            "error": None,
+                        }
+
+                    field_definitions = [
+                        MetadataField(**field_data)
+                        for field_data in metadata_schema_data
+                    ]
+                    metadata_schema = MetadataSchema(schema=field_definitions)
+                    validator = ElasticsearchFilterValidator(metadata_schema, config)
+                    result = validator.validate_filter(filter_expr)
+                    if result["status"]:
+                        return {
+                            "collection": collection_name,
+                            "valid": True,
+                            "error": None,
+                        }
+                    return {
+                        "collection": collection_name,
+                        "valid": False,
+                        "error": result.get(
+                            "error_message", "Unknown validation error"
+                        ),
+                    }
+                except Exception as e:
+                    return {
+                        "collection": collection_name,
+                        "valid": False,
+                        "error": str(e),
+                    }
+
+            with ThreadPoolExecutor() as executor:
+                es_results = list(
+                    executor.map(validate_es_single_collection, collection_names)
+                )
+
+            es_validated: list[str] = []
+            es_errors: list[str] = []
+            for r in es_results:
+                if r["valid"]:
+                    es_validated.append(r["collection"])
+                else:
+                    es_errors.append(
+                        f"Collection '{r.get('collection', 'unknown collection')}': "
+                        f"{r.get('error', 'Filter validation failed for this collection.')}"
+                    )
+
+            if allow_partial_filtering:
+                if es_validated:
+                    logger.info(
+                        f"Flexible mode: {len(es_validated)}/{len(collection_names)} ES collections support filter"
+                    )
+                    return {
+                        "status": True,
+                        "validated_collections": es_validated,
+                        "details": es_errors if es_errors else None,
+                    }
+                logger.error("No ES collections support the filter expression")
+                return {
+                    "status": False,
+                    "validated_collections": [],
+                    "error_message": "No collections support the filter expression",
+                    "details": es_errors,
+                }
+
+            if len(es_validated) < len(collection_names):
+                logger.error(
+                    f"Strict mode: {len(collection_names) - len(es_validated)} ES collections do not support filter"
+                )
+                return {
+                    "status": False,
+                    "validated_collections": es_validated,
+                    "error_message": (
+                        f"Filter expression not supported by "
+                        f"{len(collection_names) - len(es_validated)} collections"
+                    ),
+                    "details": es_errors,
+                }
+
+            logger.debug(f"All {len(collection_names)} ES collections support filter")
+            return {"status": True, "validated_collections": es_validated}
         elif isinstance(filter_expr, str):
             logger.warning(
                 f"Elasticsearch expects list of dicts, but received string: {filter_expr}"
@@ -582,10 +676,45 @@ def process_filter_expr(
                         f"Elasticsearch filter must be a list of dicts, found: {type(item)}"
                     )
                     return []
-            logger.debug(
-                f"Elasticsearch filter validated successfully: {len(filter_expr)} filter conditions"
-            )
-            return filter_expr
+
+            # No schema available — fall back to shape-only acceptance to
+            # preserve backwards compatibility for user-supplied filters on
+            # collections without registered schemas.
+            if not metadata_schema_data:
+                logger.debug(
+                    f"Elasticsearch filter accepted without schema validation: "
+                    f"{len(filter_expr)} filter conditions"
+                )
+                return filter_expr
+
+            try:
+                field_definitions = [
+                    MetadataField(**field_data) for field_data in metadata_schema_data
+                ]
+                metadata_schema = MetadataSchema(schema=field_definitions)
+            except Exception as e:
+                logger.error(
+                    f"Failed to convert metadata schema data to MetadataSchema object: {e}"
+                )
+                return filter_expr
+
+            validator = ElasticsearchFilterValidator(metadata_schema, config)
+            result = validator.process_filter(filter_expr)
+
+            if result["status"]:
+                processed = result.get("processed_expression", filter_expr)
+                logger.debug(
+                    f"ES filter expression processed successfully ({len(processed)} clauses)"
+                )
+                return processed
+
+            error_message = result.get("error_message", "Unknown error")
+            if is_generated_filter:
+                logger.warning(
+                    f"Generated ES filter expression processing failed: {error_message}"
+                )
+                return []
+            raise ValueError(error_message)
         elif isinstance(filter_expr, str):
             logger.warning(
                 f"Elasticsearch expects list of dicts, but received string: {filter_expr}"
@@ -646,6 +775,33 @@ def process_filter_expr(
     else:
         logger.error(f"Unsupported vector store: {config.vector_store.name}")
         return filter_expr if isinstance(filter_expr, str) else []
+
+
+_FILTER_LOG_PREVIEW_CHARS = 500
+
+
+def format_filter_for_log(
+    filter_val: str | list[dict[str, Any]] | None,
+) -> str:
+    """Render a filter expression as a single-line preview for logs.
+
+    Backend-agnostic: handles Milvus string filters and Elasticsearch DSL
+    list-of-dicts uniformly. Returns "(empty)" when there is no filter,
+    otherwise a compact JSON or string representation truncated to a
+    fixed preview length.
+    """
+    if filter_val is None or filter_val == "" or filter_val == []:
+        return "(empty)"
+    if isinstance(filter_val, str):
+        rendered = filter_val
+    else:
+        try:
+            rendered = json.dumps(filter_val, separators=(",", ":"))
+        except (TypeError, ValueError):
+            rendered = str(filter_val)
+    if len(rendered) > _FILTER_LOG_PREVIEW_CHARS:
+        return rendered[:_FILTER_LOG_PREVIEW_CHARS] + "..."
+    return rendered
 
 
 # Boolean flags used in document info aggregation

--- a/src/nvidia_rag/utils/es_filter_validator.py
+++ b/src/nvidia_rag/utils/es_filter_validator.py
@@ -1,0 +1,393 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Schema-aware validator and processor for Elasticsearch DSL filter clauses.
+
+Mirrors the Milvus FilterExpressionParser interface so that callers in
+`utils/common.py` can invoke the same validate/process surface area for both
+backends. Operates on Elasticsearch Query DSL clauses (already structured JSON)
+rather than parsing a textual grammar.
+"""
+
+import copy
+import logging
+from typing import Any
+
+from dateutil import parser as dt_parser
+
+from nvidia_rag.utils.metadata_validation import (
+    SYSTEM_MANAGED_FIELDS,
+    FilterSemanticError,
+    FilterSyntaxError,
+    MetadataField,
+    MetadataSchema,
+    MetadataType,
+    validate_metadata_config,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_METADATA_PREFIX = "metadata.content_metadata."
+_KEYWORD_SUFFIX = ".keyword"
+
+_LEAF_CLAUSE_TYPES = {
+    "term",
+    "terms",
+    "range",
+    "match",
+    "match_phrase",
+    "wildcard",
+    "prefix",
+    "exists",
+}
+_BOOL_CLAUSE_TYPES = {"bool"}
+_BOOL_INNER_KEYS = {"must", "should", "must_not", "filter"}
+
+# Per-field-type to compatible-clause-type mapping. Mirrors
+# `TYPE_OPERATOR_MAPPING` in metadata_validation.py but in ES vocabulary.
+_TYPE_TO_CLAUSES: dict[str, set[str]] = {
+    MetadataType.STRING.value: {
+        "term",
+        "terms",
+        "match",
+        "match_phrase",
+        "wildcard",
+        "prefix",
+        "exists",
+    },
+    MetadataType.DATETIME.value: {"term", "terms", "range", "exists"},
+    MetadataType.NUMBER.value: {"term", "terms", "range", "exists"},
+    MetadataType.INTEGER.value: {"term", "terms", "range", "exists"},
+    MetadataType.FLOAT.value: {"term", "terms", "range", "exists"},
+    MetadataType.BOOLEAN.value: {"term", "terms", "exists"},
+    MetadataType.ARRAY.value: {"term", "terms", "exists"},
+}
+
+_RANGE_OPERATORS = {"gt", "gte", "lt", "lte", "from", "to"}
+
+# Hard caps to prevent abuse. Kept conservative; configurable via
+# MetadataConfig in a follow-up if needed.
+_MAX_DEPTH = 8
+_MAX_CLAUSES = 64
+
+
+class ElasticsearchFilterValidator:
+    """Schema-aware validator for Elasticsearch DSL filter clauses."""
+
+    def __init__(self, metadata_schema: MetadataSchema, config: Any) -> None:
+        self.metadata_schema = metadata_schema
+        self.config = validate_metadata_config(config)
+        self.schema_dict: dict[str, MetadataField] = metadata_schema.field_dict
+
+    # ------------------------------------------------------------------
+    # Public API — mirrors FilterExpressionParser shape
+    # ------------------------------------------------------------------
+
+    def validate_filter(self, filter_clauses: list[dict[str, Any]]) -> dict[str, Any]:
+        """Validate a list of ES DSL clauses against the metadata schema."""
+        try:
+            self._walk_clauses(filter_clauses, normalize=False)
+            return {
+                "status": True,
+                "message": "Filter clauses validated successfully",
+            }
+        except (FilterSyntaxError, FilterSemanticError) as e:
+            return {"status": False, "error_message": str(e)}
+
+    def process_filter(self, filter_clauses: list[dict[str, Any]]) -> dict[str, Any]:
+        """Validate and normalize ES DSL clauses (e.g. add `.keyword` where needed)."""
+        try:
+            normalized = copy.deepcopy(filter_clauses)
+            self._walk_clauses(normalized, normalize=True)
+            return {
+                "status": True,
+                "processed_expression": normalized,
+                "message": "Filter clauses processed successfully",
+            }
+        except (FilterSyntaxError, FilterSemanticError) as e:
+            return {"status": False, "error_message": str(e)}
+
+    # ------------------------------------------------------------------
+    # Walker
+    # ------------------------------------------------------------------
+
+    def _walk_clauses(
+        self,
+        clauses: list[dict[str, Any]],
+        *,
+        normalize: bool,
+        depth: int = 0,
+        clause_count: list[int] | None = None,
+    ) -> None:
+        if clause_count is None:
+            clause_count = [0]
+
+        if not isinstance(clauses, list):
+            raise FilterSyntaxError(
+                "Elasticsearch filter must be a JSON array of clause objects."
+            )
+
+        if depth > _MAX_DEPTH:
+            raise FilterSyntaxError(
+                f"Filter clause nesting depth exceeds maximum ({_MAX_DEPTH})."
+            )
+
+        for clause in clauses:
+            clause_count[0] += 1
+            if clause_count[0] > _MAX_CLAUSES:
+                raise FilterSyntaxError(
+                    f"Filter contains more than {_MAX_CLAUSES} clauses."
+                )
+            self._walk_clause(
+                clause, normalize=normalize, depth=depth, clause_count=clause_count
+            )
+
+    def _walk_clause(
+        self,
+        clause: dict[str, Any],
+        *,
+        normalize: bool,
+        depth: int,
+        clause_count: list[int],
+    ) -> None:
+        if not isinstance(clause, dict) or len(clause) != 1:
+            raise FilterSyntaxError(
+                "Each filter clause must be a dict with exactly one top-level key "
+                "(e.g. 'term', 'range', 'bool')."
+            )
+
+        clause_type, body = next(iter(clause.items()))
+
+        if clause_type in _BOOL_CLAUSE_TYPES:
+            self._walk_bool(
+                body, normalize=normalize, depth=depth + 1, clause_count=clause_count
+            )
+            return
+
+        if clause_type not in _LEAF_CLAUSE_TYPES:
+            raise FilterSyntaxError(
+                f"Unsupported clause type '{clause_type}'. Supported: "
+                f"{sorted(_LEAF_CLAUSE_TYPES | _BOOL_CLAUSE_TYPES)}."
+            )
+
+        self._validate_leaf(clause, clause_type, body, normalize=normalize)
+
+    def _walk_bool(
+        self,
+        body: Any,
+        *,
+        normalize: bool,
+        depth: int,
+        clause_count: list[int],
+    ) -> None:
+        if not isinstance(body, dict):
+            raise FilterSyntaxError(
+                "'bool' clause body must be an object containing must/should/must_not/filter."
+            )
+
+        unknown = (
+            set(body.keys()) - _BOOL_INNER_KEYS - {"minimum_should_match", "boost"}
+        )
+        if unknown:
+            raise FilterSyntaxError(
+                f"Unsupported keys in 'bool' clause: {sorted(unknown)}. "
+                f"Supported: {sorted(_BOOL_INNER_KEYS)}."
+            )
+
+        for key in _BOOL_INNER_KEYS:
+            inner = body.get(key)
+            if inner is None:
+                continue
+            # ES allows single-clause shorthand (dict) or list — normalize to list for walking.
+            if isinstance(inner, dict):
+                inner_list = [inner]
+                if normalize:
+                    body[key] = inner_list
+            elif isinstance(inner, list):
+                inner_list = inner
+            else:
+                raise FilterSyntaxError(
+                    f"'bool.{key}' must be an object or array of clause objects."
+                )
+            self._walk_clauses(
+                inner_list,
+                normalize=normalize,
+                depth=depth,
+                clause_count=clause_count,
+            )
+
+    # ------------------------------------------------------------------
+    # Leaf clause validation
+    # ------------------------------------------------------------------
+
+    def _validate_leaf(
+        self,
+        clause: dict[str, Any],
+        clause_type: str,
+        body: Any,
+        *,
+        normalize: bool,
+    ) -> None:
+        # `exists` body is `{"field": "<path>"}`; others are `{"<path>": <value>}`.
+        if clause_type == "exists":
+            if not isinstance(body, dict) or "field" not in body:
+                raise FilterSyntaxError(
+                    "'exists' clause body must contain a 'field' key."
+                )
+            field_path = body["field"]
+            if not isinstance(field_path, str):
+                raise FilterSyntaxError(
+                    "'exists' clause 'field' value must be a string."
+                )
+            field_name, _ = self._strip_field_path(field_path)
+            field_def = self._lookup_field(field_name)
+            self._assert_clause_compatible(field_def, clause_type)
+            return
+
+        if not isinstance(body, dict) or len(body) != 1:
+            raise FilterSyntaxError(
+                f"'{clause_type}' clause body must be a dict with exactly one field path."
+            )
+
+        field_path, value = next(iter(body.items()))
+        if not isinstance(field_path, str):
+            raise FilterSyntaxError(
+                f"'{clause_type}' clause field path must be a string."
+            )
+
+        field_name, had_keyword = self._strip_field_path(field_path)
+        field_def = self._lookup_field(field_name)
+        self._assert_clause_compatible(field_def, clause_type)
+
+        if clause_type == "range":
+            self._validate_range_value(field_def, value)
+        elif clause_type == "terms":
+            if not isinstance(value, list):
+                raise FilterSyntaxError("'terms' clause value must be an array.")
+
+        # Normalization: ensure `.keyword` suffix where appropriate.
+        if normalize:
+            normalized_path = self._normalize_field_path(
+                field_def, clause_type, field_name, had_keyword
+            )
+            if normalized_path != field_path:
+                clause[clause_type] = {normalized_path: value}
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _strip_field_path(self, field_path: str) -> tuple[str, bool]:
+        """Return (bare_field_name, had_keyword_suffix)."""
+        path = field_path
+        if path.startswith(_METADATA_PREFIX):
+            path = path[len(_METADATA_PREFIX) :]
+        had_keyword = False
+        if path.endswith(_KEYWORD_SUFFIX):
+            had_keyword = True
+            path = path[: -len(_KEYWORD_SUFFIX)]
+        # Strip any further dotted suffix segments (e.g. multi-field analyzers).
+        # The first segment is the metadata field name we registered.
+        bare = path.split(".", 1)[0]
+        return bare, had_keyword
+
+    def _lookup_field(self, field_name: str) -> MetadataField:
+        if field_name in self.schema_dict:
+            return self.schema_dict[field_name]
+
+        sys_def = SYSTEM_MANAGED_FIELDS.get(field_name)
+        if sys_def and sys_def.get("support_dynamic_filtering", False):
+            return MetadataField(
+                name=field_name,
+                type=sys_def["type"],
+                user_defined=False,
+                support_dynamic_filtering=True,
+                array_type="string"
+                if sys_def["type"] == MetadataType.ARRAY.value
+                else None,
+            )
+
+        raise FilterSemanticError(
+            f"Field '{field_name}' is not defined in the metadata schema and is not "
+            f"a dynamically-filterable system field. Available fields: "
+            f"{sorted(self.schema_dict.keys())}."
+        )
+
+    def _assert_clause_compatible(
+        self, field_def: MetadataField, clause_type: str
+    ) -> None:
+        allowed = _TYPE_TO_CLAUSES.get(field_def.type, set())
+        if clause_type not in allowed:
+            raise FilterSemanticError(
+                f"Clause '{clause_type}' is not compatible with field "
+                f"'{field_def.name}' of type '{field_def.type}'. "
+                f"Allowed clauses: {sorted(allowed)}."
+            )
+
+    def _validate_range_value(self, field_def: MetadataField, value: Any) -> None:
+        if not isinstance(value, dict) or not value:
+            raise FilterSyntaxError(
+                "'range' clause value must be a non-empty object with operators "
+                "(gt, gte, lt, lte)."
+            )
+        unknown = set(value.keys()) - _RANGE_OPERATORS - {"format", "time_zone"}
+        if unknown:
+            raise FilterSyntaxError(
+                f"Unsupported range operators: {sorted(unknown)}. "
+                f"Supported: {sorted(_RANGE_OPERATORS)}."
+            )
+        if field_def.type == MetadataType.DATETIME.value:
+            for op in _RANGE_OPERATORS & set(value.keys()):
+                v = value[op]
+                if not isinstance(v, str):
+                    raise FilterSyntaxError(
+                        f"Datetime range bound '{op}' must be an ISO 8601 string."
+                    )
+                try:
+                    dt_parser.isoparse(v)
+                except (ValueError, TypeError) as e:
+                    raise FilterSyntaxError(
+                        f"Invalid ISO 8601 datetime for range '{op}': {v!r}"
+                    ) from e
+
+    def _normalize_field_path(
+        self,
+        field_def: MetadataField,
+        clause_type: str,
+        field_name: str,
+        had_keyword: bool,
+    ) -> str:
+        """Produce the canonical ES field path for a (clause, field) pair.
+
+        - Always prefixes with `metadata.content_metadata.`.
+        - Adds `.keyword` for exact-match clauses on string-like fields.
+        """
+        path = f"{_METADATA_PREFIX}{field_name}"
+
+        wants_keyword = clause_type in {"term", "terms", "prefix"} and (
+            field_def.type == MetadataType.STRING.value
+            or (
+                field_def.type == MetadataType.ARRAY.value
+                and field_def.array_type == MetadataType.STRING.value
+            )
+        )
+        if wants_keyword or had_keyword:
+            if wants_keyword:
+                path = f"{path}{_KEYWORD_SUFFIX}"
+            elif had_keyword:
+                # Preserve user intent
+                path = f"{path}{_KEYWORD_SUFFIX}"
+        return path

--- a/src/nvidia_rag/utils/filter_expression_generator.py
+++ b/src/nvidia_rag/utils/filter_expression_generator.py
@@ -18,7 +18,7 @@
 import json
 import logging
 import re
-from typing import Any
+from typing import Any, Literal
 
 from langchain_core.prompts import ChatPromptTemplate
 
@@ -55,14 +55,21 @@ def _format_metadata_schema_for_prompt(metadata_schema: list[dict[str, Any]]) ->
     return json.dumps(filtered_schema, separators=(",", ":"))
 
 
-def _extract_filter_expression_from_response(response: Any) -> str | None:
+def _extract_filter_expression_from_response(
+    response: Any,
+    output_format: Literal["string", "json"] = "string",
+) -> str | list[dict[str, Any]] | None:
     """Extract the filter expression from LLM response.
 
     Args:
         response: Raw response from LLM (can be AIMessage object or string)
+        output_format: "string" for Milvus boolean expression syntax, "json" for
+            Elasticsearch DSL clause arrays
 
     Returns:
-        Extracted filter expression or None if not found
+        Extracted filter expression. For "string" output_format, returns a
+        Milvus filter string. For "json" output_format, returns a list of
+        ES filter clauses. Returns None if no usable filter could be extracted.
     """
     # Handle AIMessage objects by extracting their content
     if hasattr(response, "content"):
@@ -91,7 +98,31 @@ def _extract_filter_expression_from_response(response: Any) -> str | None:
         logger.warning("No filter expression found after removing thinking tokens")
         return None
 
-    return response
+    if output_format == "string":
+        return response
+
+    # output_format == "json": parse Elasticsearch DSL clause array
+    json_payload = response
+    fence_match = re.search(r"```(?:json)?\s*(.*?)```", json_payload, flags=re.DOTALL)
+    if fence_match:
+        json_payload = fence_match.group(1).strip()
+
+    try:
+        parsed = json.loads(json_payload)
+    except json.JSONDecodeError as e:
+        logger.warning(f"Failed to parse JSON filter from LLM response: {e}")
+        return None
+
+    if not isinstance(parsed, list) or not all(isinstance(c, dict) for c in parsed):
+        logger.warning(
+            "Parsed filter is not a list of dict clauses; rejecting as malformed"
+        )
+        return None
+
+    if not parsed:
+        return None
+
+    return parsed
 
 
 def generate_filter_from_natural_language(
@@ -100,9 +131,10 @@ def generate_filter_from_natural_language(
     metadata_schema: list[dict[str, Any]],
     prompt_template: dict,
     llm: Any | None = None,
-    existing_filter_expr: str | None = None,
+    existing_filter_expr: str | list[dict[str, Any]] | None = None,
     run_config: dict[str, Any] | None = None,
-) -> str | None:
+    output_format: Literal["string", "json"] = "string",
+) -> str | list[dict[str, Any]] | None:
     """Generate a filter expression from natural language request.
 
     Args:
@@ -111,22 +143,29 @@ def generate_filter_from_natural_language(
         metadata_schema: Metadata schema for the collection
         prompt_template: Prompt template for filter generation
         llm: LLM instance to use (if None, will create one with default settings)
-        existing_filter_expr: Existing filter expression to validate/improve (optional)
+        existing_filter_expr: Existing filter expression to validate/improve. May be
+            a Milvus boolean string or an Elasticsearch DSL clause list.
         run_config: Optional LangChain run config (e.g. for usage collection in tracing)
+        output_format: "string" returns a Milvus boolean expression string;
+            "json" parses the LLM response as a JSON array of Elasticsearch
+            DSL clauses and returns list[dict].
 
     Returns:
-        Generated filter expression or None if no filter needed/possible
+        Generated filter expression or None if no filter needed/possible. Type
+        depends on `output_format`.
     """
     try:
         schema_text = _format_metadata_schema_for_prompt(metadata_schema)
         # Add existing filter expression to the prompt if provided
         existing_filter_context = ""
-        if (
-            existing_filter_expr
-            and isinstance(existing_filter_expr, str)
-            and existing_filter_expr.strip()
-        ):
+        if isinstance(existing_filter_expr, str) and existing_filter_expr.strip():
             existing_filter_context = f"\n**EXISTING FILTER EXPRESSION:**\n{existing_filter_expr}\n\nPlease validate this existing filter expression and improve it if needed based on the user request."
+        elif isinstance(existing_filter_expr, list) and existing_filter_expr:
+            existing_filter_context = (
+                "\n**EXISTING FILTER EXPRESSION:**\n"
+                f"{json.dumps(existing_filter_expr, separators=(',', ':'))}\n\n"
+                "Please validate this existing filter expression and improve it if needed based on the user request."
+            )
 
         filter_prompt = ChatPromptTemplate.from_messages(
             [
@@ -145,9 +184,9 @@ def generate_filter_from_natural_language(
 
         if llm is None:
             logger.debug(
-                "No LLM provided for filter expression generation, returning empty string"
+                "No LLM provided for filter expression generation, returning empty result"
             )
-            return ""
+            return [] if output_format == "json" else ""
 
         messages = filter_prompt.format_messages(**chain_input)
         if run_config:
@@ -155,7 +194,9 @@ def generate_filter_from_natural_language(
         else:
             response = llm.invoke(messages)
 
-        filter_expr = _extract_filter_expression_from_response(response)
+        filter_expr = _extract_filter_expression_from_response(
+            response, output_format=output_format
+        )
 
         return filter_expr
 

--- a/tests/integration/test_cases/custom_metadata.py
+++ b/tests/integration/test_cases/custom_metadata.py
@@ -102,7 +102,10 @@ class CustomMetadataModule(BaseTestModule):
                 "metadata": {
                     "title": "AI Policy Guidelines",
                     "category": "tech",
-                    "rating": 4.5,
+                    # 4.8 (not exactly 4.5) so test queries like "rating above 4.5"
+                    # and "high rating" produce non-empty matches under strict
+                    # comparison semantics (`gt: 4.5`) on either backend.
+                    "rating": 4.8,
                     "is_public": True,
                     "tags": ["urgent", "policy", "ai"],
                     "created_date": "2024-01-15T10:30:00Z",
@@ -600,32 +603,38 @@ class CustomMetadataModule(BaseTestModule):
 
     @test_case(38, "LLM Filter Generation Test")
     async def test_llm_filter_generation(self) -> bool:
-        """Test LLM filter generation (Milvus) or graceful degradation (Elasticsearch).
+        """Test LLM-based natural-language filter generation against the configured vector store.
 
-        Elasticsearch does not support LLM-based filter generation. For Elasticsearch,
-        this test verifies that enable_filter_generator=True degrades gracefully and
-        that direct Elasticsearch filter expressions work correctly.
+        Both Milvus and Elasticsearch are expected to convert a natural-language
+        query into a backend-appropriate metadata filter when
+        ``enable_filter_generator=true`` is set on ``/search`` or ``/generate``.
+        The four sub-tests below exercise the public API surface only (request
+        body fields, response shape, citation metadata) so the same assertions
+        apply regardless of the underlying backend or filter syntax produced
+        by the LLM. They verify observable behavior, not implementation
+        internals such as the generated expression's textual form.
         """
         logger.info("\n=== Test 38: LLM Filter Generation Test ===")
         test_start = time.time()
 
+        description = (
+            "Test LLM-based filter generation end-to-end via /search and "
+            "/generate with enable_filter_generator=True; backend-agnostic."
+        )
+
         try:
-            if is_elasticsearch_vector_store():
-                logger.info("ℹ️ Elasticsearch does not support LLM filter generation — testing graceful degradation")
-                success = await self._test_es_filter_generation_graceful_degradation()
-            else:
-                success = True
-                success &= await self._test_search_filter_generation()
-                success &= await self._test_natural_language_patterns()
-                success &= await self._test_generate_endpoint_streaming()
-                success &= await self._test_filter_generation_verification()
+            success = True
+            success &= await self._test_search_filter_generation()
+            success &= await self._test_natural_language_patterns()
+            success &= await self._test_generate_endpoint_streaming()
+            success &= await self._test_filter_generation_verification()
 
             test_time = time.time() - test_start
 
             self.add_test_result(
                 38,
                 "LLM Filter Generation Test",
-                "Test LLM filter generation (Milvus) or graceful degradation with enable_filter_generator=True (Elasticsearch)",
+                description,
                 ["POST /generate", "POST /search"],
                 ["messages", "collection_names", "enable_filter_generator", "query"],
                 test_time,
@@ -643,7 +652,7 @@ class CustomMetadataModule(BaseTestModule):
             self.add_test_result(
                 38,
                 "LLM Filter Generation Test",
-                "Test LLM filter generation (Milvus) or graceful degradation with enable_filter_generator=True (Elasticsearch)",
+                description,
                 ["POST /generate", "POST /search"],
                 ["messages", "collection_names", "enable_filter_generator", "query"],
                 test_time,
@@ -651,70 +660,6 @@ class CustomMetadataModule(BaseTestModule):
                 str(e)
             )
             return False
-
-    async def _test_es_filter_generation_graceful_degradation(self) -> bool:
-        """Verify enable_filter_generator=True degrades gracefully on Elasticsearch.
-
-        ES does not support LLM-based filter generation. The server must return valid
-        results without crashing, and direct ES filter expressions must still work.
-        """
-        logger.info("Testing graceful degradation of filter generation with Elasticsearch...")
-
-        # Verify enable_filter_generator=True doesn't crash; returns valid results
-        search_payload = {
-            "query": "Find urgent tech documents with rating above 4.0",
-            "collection_names": [self.metadata_collection],
-            "enable_filter_generator": True,
-            "top_k": 10,
-        }
-
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                f"{self.rag_server_url}/search",
-                json=search_payload,
-            ) as response:
-                result = await response.json()
-                if response.status != 200:
-                    logger.error(f"❌ Search with enable_filter_generator=True failed: {response.status}")
-                    logger.error(f"Response: {json.dumps(result, indent=2)}")
-                    return False
-                logger.info(
-                    f"✅ Search with enable_filter_generator=True returned "
-                    f"{len(result.get('results', []))} results without error"
-                )
-
-        # Verify direct ES filter expressions work (filter_expr as list of dicts)
-        es_filter = [{"term": {"metadata.content_metadata.category.keyword": "tech"}}]
-        search_payload_filtered = {
-            "query": "tech documents",
-            "collection_names": [self.metadata_collection],
-            "enable_filter_generator": False,
-            "filter_expr": es_filter,
-            "top_k": 10,
-        }
-
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                f"{self.rag_server_url}/search",
-                json=search_payload_filtered,
-            ) as response:
-                result = await response.json()
-                if response.status != 200:
-                    logger.error(f"❌ Search with direct ES filter_expr failed: {response.status}")
-                    logger.error(f"Response: {json.dumps(result, indent=2)}")
-                    return False
-                docs = result.get("results", [])
-                logger.info(f"✅ Direct ES filter returned {len(docs)} documents")
-
-                for doc in docs:
-                    metadata = doc.get("metadata", {}).get("content_metadata", {})
-                    category = metadata.get("category", "")
-                    if category and category != "tech":
-                        logger.error(f"❌ Document has wrong category: {category}, expected: tech")
-                        return False
-
-        logger.info("✅ Elasticsearch filter graceful degradation test passed")
-        return True
 
     async def _test_search_filter_generation(self) -> bool:
         """Test search endpoint with filter generation enabled"""
@@ -935,6 +880,7 @@ class CustomMetadataModule(BaseTestModule):
 
         # Test query that should generate a specific filter
         test_query = "Show me tech documents with rating above 4.5"
+        logger.info(f"   └─ Verification query: '{test_query}' (top_k=20)")
 
         # Test 1: With filter generation enabled
         search_payload_with_filter = {
@@ -955,6 +901,9 @@ class CustomMetadataModule(BaseTestModule):
 
                 result_with_filter = await response.json()
                 docs_with_filter = result_with_filter.get("results", [])
+                logger.info(
+                    f"   └─ With enable_filter_generator=True: {len(docs_with_filter)} results"
+                )
 
         # Test 2: Same query without filter generation
         search_payload_without_filter = {
@@ -975,6 +924,9 @@ class CustomMetadataModule(BaseTestModule):
 
                 result_without_filter = await response.json()
                 docs_without_filter = result_without_filter.get("results", [])
+                logger.info(
+                    f"   └─ With enable_filter_generator=False: {len(docs_without_filter)} results"
+                )
 
         # Verification 1: Results should be different if filter generation is working
         if len(docs_with_filter) == len(docs_without_filter):
@@ -984,7 +936,20 @@ class CustomMetadataModule(BaseTestModule):
 
             if with_filter_ids == without_filter_ids:
                 logger.error("❌ Filter generation verification FAILED: Results are identical with and without filter generation")
-                logger.error("   └─ This suggests filter generation is falling back to empty strings")
+                logger.error("   └─ This suggests filter generation is falling back to empty/no-op")
+                logger.error("   └─ Check rag-server logs for 'STAGE: Dynamic Filter Expression Generation' and the generated filter")
+                logger.error(
+                    "   └─ Also confirm ENABLE_FILTER_GENERATOR=true is set on the rag-server "
+                    "and APP_VECTORSTORE_NAME matches the active backend"
+                )
+                logger.error(
+                    "   └─ First 3 with-filter doc IDs: %s",
+                    [(d.get("document_name", ""), d.get("chunk_id", "")) for d in docs_with_filter[:3]],
+                )
+                logger.error(
+                    "   └─ First 3 without-filter doc IDs: %s",
+                    [(d.get("document_name", ""), d.get("chunk_id", "")) for d in docs_without_filter[:3]],
+                )
                 return False
 
         # Verification 2: Documents with filter should match the criteria better

--- a/tests/unit/test_metadata_validation/test_es_filter_validator.py
+++ b/tests/unit/test_metadata_validation/test_es_filter_validator.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ElasticsearchFilterValidator."""
+
+import pytest
+
+from nvidia_rag.utils.configuration import MetadataConfig
+from nvidia_rag.utils.es_filter_validator import ElasticsearchFilterValidator
+from nvidia_rag.utils.metadata_validation import MetadataField, MetadataSchema
+
+
+@pytest.fixture
+def metadata_config():
+    return MetadataConfig()
+
+
+@pytest.fixture
+def schema():
+    return MetadataSchema(
+        schema=[
+            MetadataField(name="status", type="string"),
+            MetadataField(name="year", type="integer"),
+            MetadataField(name="rating", type="float"),
+            MetadataField(name="is_public", type="boolean"),
+            MetadataField(name="created_at", type="datetime"),
+            MetadataField(
+                name="tags", type="array", array_type="string", max_length=10
+            ),
+        ]
+    )
+
+
+@pytest.fixture
+def validator(schema, metadata_config):
+    return ElasticsearchFilterValidator(schema, metadata_config)
+
+
+class TestValidateFilter:
+    def test_simple_term_clause_string(self, validator):
+        clauses = [{"term": {"metadata.content_metadata.status.keyword": "approved"}}]
+        assert validator.validate_filter(clauses)["status"] is True
+
+    def test_term_without_keyword_suffix_validates(self, validator):
+        clauses = [{"term": {"metadata.content_metadata.status": "approved"}}]
+        assert validator.validate_filter(clauses)["status"] is True
+
+    def test_range_on_integer(self, validator):
+        clauses = [
+            {"range": {"metadata.content_metadata.year": {"gt": 2024, "lt": 2026}}}
+        ]
+        assert validator.validate_filter(clauses)["status"] is True
+
+    def test_range_on_string_rejected(self, validator):
+        clauses = [{"range": {"metadata.content_metadata.status": {"gt": "x"}}}]
+        result = validator.validate_filter(clauses)
+        assert result["status"] is False
+        assert "not compatible" in result["error_message"]
+
+    def test_unknown_field_rejected(self, validator):
+        clauses = [{"term": {"metadata.content_metadata.unknown_field": "x"}}]
+        result = validator.validate_filter(clauses)
+        assert result["status"] is False
+        assert "unknown_field" in result["error_message"]
+
+    def test_unknown_clause_type_rejected(self, validator):
+        clauses = [{"geo_distance": {"location": "0,0"}}]
+        result = validator.validate_filter(clauses)
+        assert result["status"] is False
+        assert "Unsupported clause type" in result["error_message"]
+
+    def test_bool_must_with_nested_clauses(self, validator):
+        clauses = [
+            {
+                "bool": {
+                    "must": [
+                        {
+                            "term": {
+                                "metadata.content_metadata.status.keyword": "approved"
+                            }
+                        },
+                        {"range": {"metadata.content_metadata.year": {"gte": 2024}}},
+                    ]
+                }
+            }
+        ]
+        assert validator.validate_filter(clauses)["status"] is True
+
+    def test_bool_should_and_must_not(self, validator):
+        clauses = [
+            {
+                "bool": {
+                    "should": [
+                        {"term": {"metadata.content_metadata.status.keyword": "draft"}},
+                        {
+                            "term": {
+                                "metadata.content_metadata.status.keyword": "review"
+                            }
+                        },
+                    ],
+                    "must_not": [
+                        {"term": {"metadata.content_metadata.is_public": False}}
+                    ],
+                }
+            }
+        ]
+        assert validator.validate_filter(clauses)["status"] is True
+
+    def test_bool_unknown_inner_key_rejected(self, validator):
+        clauses = [{"bool": {"unknown": []}}]
+        result = validator.validate_filter(clauses)
+        assert result["status"] is False
+        assert "Unsupported keys" in result["error_message"]
+
+    def test_datetime_iso_validates(self, validator):
+        clauses = [
+            {
+                "range": {
+                    "metadata.content_metadata.created_at": {
+                        "gte": "2024-01-01T00:00:00",
+                        "lt": "2025-01-01T00:00:00",
+                    }
+                }
+            }
+        ]
+        assert validator.validate_filter(clauses)["status"] is True
+
+    def test_datetime_invalid_iso_rejected(self, validator):
+        clauses = [
+            {"range": {"metadata.content_metadata.created_at": {"gte": "not-a-date"}}}
+        ]
+        result = validator.validate_filter(clauses)
+        assert result["status"] is False
+        assert "ISO 8601" in result["error_message"]
+
+    def test_terms_on_array_field(self, validator):
+        clauses = [
+            {"terms": {"metadata.content_metadata.tags.keyword": ["urgent", "review"]}}
+        ]
+        assert validator.validate_filter(clauses)["status"] is True
+
+    def test_terms_value_not_list_rejected(self, validator):
+        clauses = [{"terms": {"metadata.content_metadata.tags.keyword": "urgent"}}]
+        result = validator.validate_filter(clauses)
+        assert result["status"] is False
+        assert "must be an array" in result["error_message"]
+
+    def test_exists_clause(self, validator):
+        clauses = [{"exists": {"field": "metadata.content_metadata.status"}}]
+        assert validator.validate_filter(clauses)["status"] is True
+
+    def test_exists_clause_unknown_field_rejected(self, validator):
+        clauses = [{"exists": {"field": "metadata.content_metadata.nope"}}]
+        result = validator.validate_filter(clauses)
+        assert result["status"] is False
+
+    def test_wildcard_on_string(self, validator):
+        clauses = [{"wildcard": {"metadata.content_metadata.status": "appr*"}}]
+        assert validator.validate_filter(clauses)["status"] is True
+
+    def test_wildcard_on_integer_rejected(self, validator):
+        clauses = [{"wildcard": {"metadata.content_metadata.year": "20*"}}]
+        result = validator.validate_filter(clauses)
+        assert result["status"] is False
+
+    def test_system_managed_filterable_field_allowed(self, validator):
+        clauses = [{"term": {"metadata.content_metadata.filename.keyword": "doc.pdf"}}]
+        assert validator.validate_filter(clauses)["status"] is True
+
+    def test_system_managed_non_filterable_field_rejected(self, validator):
+        # `start_time` has support_dynamic_filtering=False
+        clauses = [{"term": {"metadata.content_metadata.start_time": 100}}]
+        result = validator.validate_filter(clauses)
+        assert result["status"] is False
+
+
+class TestProcessFilter:
+    def test_normalizes_keyword_suffix_for_string_term(self, validator):
+        clauses = [{"term": {"metadata.content_metadata.status": "approved"}}]
+        result = validator.process_filter(clauses)
+        assert result["status"] is True
+        normalized = result["processed_expression"]
+        assert "metadata.content_metadata.status.keyword" in normalized[0]["term"]
+
+    def test_preserves_existing_keyword(self, validator):
+        clauses = [{"term": {"metadata.content_metadata.status.keyword": "approved"}}]
+        result = validator.process_filter(clauses)
+        assert result["status"] is True
+        assert (
+            "metadata.content_metadata.status.keyword"
+            in result["processed_expression"][0]["term"]
+        )
+
+    def test_does_not_add_keyword_to_numeric(self, validator):
+        clauses = [{"range": {"metadata.content_metadata.year": {"gt": 2024}}}]
+        result = validator.process_filter(clauses)
+        assert result["status"] is True
+        assert (
+            "metadata.content_metadata.year"
+            in result["processed_expression"][0]["range"]
+        )
+        assert (
+            ".keyword" not in list(result["processed_expression"][0]["range"].keys())[0]
+        )
+
+    def test_invalid_filter_returns_status_false(self, validator):
+        clauses = [{"range": {"metadata.content_metadata.status": {"gt": "x"}}}]
+        result = validator.process_filter(clauses)
+        assert result["status"] is False
+        assert "error_message" in result
+
+    def test_input_clauses_not_mutated(self, validator):
+        clauses = [{"term": {"metadata.content_metadata.status": "approved"}}]
+        snapshot = [dict(c) for c in clauses]
+        validator.process_filter(clauses)
+        assert clauses == snapshot
+
+
+class TestDepthAndCount:
+    def test_deeply_nested_bool_rejected(self, validator):
+        # Construct a very deeply nested bool tree
+        clause = {"term": {"metadata.content_metadata.status.keyword": "x"}}
+        for _ in range(10):
+            clause = {"bool": {"must": [clause]}}
+        result = validator.validate_filter([clause])
+        assert result["status"] is False
+        assert "depth" in result["error_message"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_utils/test_common.py
+++ b/tests/unit/test_utils/test_common.py
@@ -564,6 +564,109 @@ class TestValidateFilterExpr:
         assert result["status"] is False
         assert "Unsupported vector store" in result["error_message"]
 
+    def test_validate_filter_es_schema_aware_valid(self):
+        """ES schema-aware validation passes a well-formed clause."""
+        mock_config = MagicMock()
+        mock_config.vector_store.name = "elasticsearch"
+        mock_config.metadata.allow_partial_filtering = False
+
+        metadata_schemas = {
+            "test": [
+                {"name": "category", "type": "string"},
+                {"name": "year", "type": "integer"},
+            ]
+        }
+        filter_expr = [{"term": {"metadata.content_metadata.category.keyword": "doc"}}]
+        result = validate_filter_expr(
+            filter_expr, ["test"], metadata_schemas, config=mock_config
+        )
+        assert result["status"] is True
+
+    def test_validate_filter_es_schema_aware_unknown_field(self):
+        """ES schema-aware validation rejects unknown field in strict mode."""
+        mock_config = MagicMock()
+        mock_config.vector_store.name = "elasticsearch"
+        mock_config.metadata.allow_partial_filtering = False
+
+        metadata_schemas = {
+            "test": [{"name": "category", "type": "string"}],
+        }
+        filter_expr = [{"term": {"metadata.content_metadata.unknown_field": "x"}}]
+        result = validate_filter_expr(
+            filter_expr, ["test"], metadata_schemas, config=mock_config
+        )
+        assert result["status"] is False
+        assert "unknown_field" in (result.get("error_message") or "") or any(
+            "unknown_field" in d for d in (result.get("details") or [])
+        )
+
+    def test_validate_filter_es_partial_filtering(self):
+        """ES partial filtering returns success when at least one collection passes."""
+        mock_config = MagicMock()
+        mock_config.vector_store.name = "elasticsearch"
+        mock_config.metadata.allow_partial_filtering = True
+
+        metadata_schemas = {
+            "good": [{"name": "category", "type": "string"}],
+            "bad": [{"name": "year", "type": "integer"}],
+        }
+        filter_expr = [{"term": {"metadata.content_metadata.category.keyword": "doc"}}]
+        result = validate_filter_expr(
+            filter_expr, ["good", "bad"], metadata_schemas, config=mock_config
+        )
+        assert result["status"] is True
+        assert "good" in result["validated_collections"]
+        assert "bad" not in result["validated_collections"]
+
+
+class TestProcessFilterEsSchemaAware:
+    """process_filter_expr ES branch with metadata schema."""
+
+    def test_process_filter_es_normalizes_keyword(self):
+        mock_config = MagicMock()
+        mock_config.vector_store.name = "elasticsearch"
+
+        metadata_schema_data = [{"name": "status", "type": "string"}]
+        filter_expr = [{"term": {"metadata.content_metadata.status": "approved"}}]
+        result = process_filter_expr(
+            filter_expr,
+            "test_collection",
+            metadata_schema_data,
+            config=mock_config,
+        )
+        assert isinstance(result, list)
+        assert "metadata.content_metadata.status.keyword" in result[0]["term"]
+
+    def test_process_filter_es_generated_failure_returns_empty(self):
+        mock_config = MagicMock()
+        mock_config.vector_store.name = "elasticsearch"
+
+        metadata_schema_data = [{"name": "status", "type": "string"}]
+        filter_expr = [{"range": {"metadata.content_metadata.status": {"gt": "x"}}}]
+        result = process_filter_expr(
+            filter_expr,
+            "test_collection",
+            metadata_schema_data,
+            is_generated_filter=True,
+            config=mock_config,
+        )
+        assert result == []
+
+    def test_process_filter_es_user_failure_raises(self):
+        mock_config = MagicMock()
+        mock_config.vector_store.name = "elasticsearch"
+
+        metadata_schema_data = [{"name": "status", "type": "string"}]
+        filter_expr = [{"range": {"metadata.content_metadata.status": {"gt": "x"}}}]
+        with pytest.raises(ValueError):
+            process_filter_expr(
+                filter_expr,
+                "test_collection",
+                metadata_schema_data,
+                is_generated_filter=False,
+                config=mock_config,
+            )
+
 
 class TestProcessFilterExpr:
     """Test process_filter_expr function"""

--- a/tests/unit/test_utils/test_filter_expression_generator.py
+++ b/tests/unit/test_utils/test_filter_expression_generator.py
@@ -23,6 +23,7 @@ import json
 import pytest
 
 from nvidia_rag.utils.filter_expression_generator import (
+    _extract_filter_expression_from_response,
     _format_metadata_schema_for_prompt,
 )
 
@@ -275,6 +276,88 @@ class TestFormatMetadataSchemaForPrompt:
         # Should use compact format (no spaces after separators)
         assert ", " not in result  # No space after comma
         assert ": " not in result  # No space after colon
+
+
+class TestExtractFilterExpressionStringFormat:
+    """Default Milvus string-output behavior."""
+
+    def test_returns_string_for_milvus(self):
+        result = _extract_filter_expression_from_response(
+            'content_metadata["x"] == "y"'
+        )
+        assert result == 'content_metadata["x"] == "y"'
+
+    def test_no_filter_returns_none(self):
+        assert _extract_filter_expression_from_response("NO_FILTER") is None
+
+    def test_unsupported_returns_none(self):
+        assert _extract_filter_expression_from_response("UNSUPPORTED") is None
+
+    def test_strips_thinking_tokens(self):
+        raw = '<think>reasoning</think>content_metadata["x"] == 1'
+        assert (
+            _extract_filter_expression_from_response(raw)
+            == 'content_metadata["x"] == 1'
+        )
+
+
+class TestExtractFilterExpressionJsonFormat:
+    """Elasticsearch JSON-output behavior."""
+
+    def test_parses_json_array(self):
+        raw = '[{"term": {"metadata.content_metadata.year": 2024}}]'
+        result = _extract_filter_expression_from_response(raw, output_format="json")
+        assert result == [{"term": {"metadata.content_metadata.year": 2024}}]
+
+    def test_parses_json_with_thinking_tokens(self):
+        raw = (
+            "<think>plan a filter</think>"
+            '[{"term": {"metadata.content_metadata.status.keyword": "approved"}}]'
+        )
+        result = _extract_filter_expression_from_response(raw, output_format="json")
+        assert result == [
+            {"term": {"metadata.content_metadata.status.keyword": "approved"}}
+        ]
+
+    def test_parses_json_inside_code_fence(self):
+        raw = '```json\n[{"term": {"metadata.content_metadata.year": 2024}}]\n```'
+        result = _extract_filter_expression_from_response(raw, output_format="json")
+        assert result == [{"term": {"metadata.content_metadata.year": 2024}}]
+
+    def test_no_filter_returns_none_for_json(self):
+        assert (
+            _extract_filter_expression_from_response("NO_FILTER", output_format="json")
+            is None
+        )
+
+    def test_unsupported_returns_none_for_json(self):
+        assert (
+            _extract_filter_expression_from_response(
+                "UNSUPPORTED", output_format="json"
+            )
+            is None
+        )
+
+    def test_malformed_json_returns_none(self):
+        assert (
+            _extract_filter_expression_from_response(
+                "[{not valid json", output_format="json"
+            )
+            is None
+        )
+
+    def test_non_array_json_returns_none(self):
+        assert (
+            _extract_filter_expression_from_response(
+                '{"term": {"x": 1}}', output_format="json"
+            )
+            is None
+        )
+
+    def test_empty_array_returns_none(self):
+        assert (
+            _extract_filter_expression_from_response("[]", output_format="json") is None
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Add Elasticsearch Dynamic Filter Generation

## Summary
- Add dynamic NL-to-filter generation support for Elasticsearch (alongside Milvus).
- Route prompts/output by backend: Milvus -> string DSL, Elasticsearch -> JSON Query DSL clauses.
- Add schema-aware Elasticsearch validation + normalization for generated/user filters.
- Update docs and tests for end-to-end Elasticsearch filter-generation behavior.

## Changes
- Added `filter_expression_generator_prompt_elasticsearch`; renamed Milvus prompt to `filter_expression_generator_prompt_milvus`.
- Updated `rag_server/main.py` for backend-aware prompt selection, output parsing, empty-filter handling, and improved filter logs.
- Added `src/nvidia_rag/utils/es_filter_validator.py` for ES clause/type checks, bool traversal, datetime range validation, and canonical field paths.
- Enhanced `validate_filter_expr` / `process_filter_expr` to apply schema-aware ES validation in strict and partial modes.
- Extended filter parser to accept JSON array output for Elasticsearch.

## Added Tests
- `tests/unit/test_metadata_validation/test_es_filter_validator.py`
- `tests/unit/test_utils/test_common.py`
- `tests/unit/test_utils/test_filter_expression_generator.py`
- `tests/integration/test_cases/custom_metadata.py`

## Checklist
- [X] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [X] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [X] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.