### PR TITLE
Helm chart for 2.6.0-rc1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,19 @@ Refer to the [full documentation](docs/readme.md) to learn about the following:
 
 
 
+## OpenShift Deployment
+
+The RAG Blueprint has been validated on Red Hat OpenShift. OpenShift support is built into the Helm chart behind an `openshift.enabled` flag — Routes, SCC RoleBindings, and secret creation are handled declaratively.
+
+```bash
+helm upgrade --install rag -n <namespace> deploy/helm/nvidia-blueprint-rag \
+  -f deploy/helm/nvidia-blueprint-rag/values-openshift.yaml \
+  --set imagePullSecret.password="$NGC_API_KEY" \
+  --set ngcApiSecret.password="$NGC_API_KEY"
+```
+
+For the full deployment runbook (prerequisites, NIM Operator setup, troubleshooting), see [`docs/deploy-helm-openshift.md`](docs/deploy-helm-openshift.md).
+
 ## Blog Posts
 
 - [NVIDIA NeMo Retriever Delivers Accurate Multimodal PDF Data Extraction 15x Faster](https://developer.nvidia.com/blog/nvidia-nemo-retriever-delivers-accurate-multimodal-pdf-data-extraction-15x-faster/)

--- a/deploy/helm/nvidia-blueprint-rag/Chart.lock
+++ b/deploy/helm/nvidia-blueprint-rag/Chart.lock
@@ -2,6 +2,9 @@ dependencies:
 - name: nv-ingest
   repository: https://helm.ngc.nvidia.com/nvidia/nemo-microservices
   version: 26.3.0
+- name: seaweedfs
+  repository: https://seaweedfs.github.io/seaweedfs/helm
+  version: 4.21.0
 - name: eck-elasticsearch
   repository: https://helm.elastic.co
   version: 0.18.0
@@ -14,5 +17,5 @@ dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
   version: 76.3.0
-digest: sha256:93f67a76bb31bd3ac6cfd3f7bb7ff15dff0f811d087bb1379e2e98fcfc80df39
-generated: "2026-04-10T09:12:09.489544077+05:30"
+digest: sha256:4de4cfcfb3d9c488f7eb6ef8f9e4e3f50211feba14d03668e3fa49f7914926a9
+generated: "2026-05-08T07:22:23.008882991Z"

--- a/deploy/helm/nvidia-blueprint-rag/templates/embedding-nim.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/templates/embedding-nim.yaml
@@ -12,6 +12,10 @@ spec:
       modelPuller: "{{ $nimModel.image.repository }}:{{ $nimModel.image.tag }}"
       pullSecret: {{ .Values.imagePullSecret.name }}
       authSecret: {{ .Values.ngcApiSecret.name }}
+  {{- with $nimModel.tolerations }}
+  tolerations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
   storage:
     pvc:
       create: {{ $nimModel.storage.pvc.create | default true }}

--- a/deploy/helm/nvidia-blueprint-rag/templates/openshift.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/templates/openshift.yaml
@@ -1,0 +1,117 @@
+{{- if .Values.openshift.enabled }}
+{{/*
+  OpenShift Routes — expose services via the OpenShift router.
+  Each route is individually toggleable via openshift.routes.<name>.enabled.
+*/}}
+
+{{- $routes := .Values.openshift.routes | default dict }}
+
+{{/* --- Route: rag-frontend --- */}}
+{{- $frontendRoute := $routes.frontend | default dict }}
+{{- if $frontendRoute.enabled }}
+{{- $frontendName := .Values.frontend.appName | default "rag-frontend" }}
+{{- $frontendTls := $frontendRoute.tls | default dict }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ $frontendName }}
+  labels:
+    {{- include "nvidia-blueprint-rag.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rag-frontend
+  {{- with $frontendRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $frontendRoute.host }}
+  host: {{ . }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ $frontendName }}
+    weight: 100
+  port:
+    targetPort: {{ .Values.frontend.service.port | default 3000 }}
+  {{- if $frontendTls }}
+  tls:
+    termination: {{ $frontendTls.termination | default "edge" }}
+    {{- with $frontendTls.insecureEdgeTerminationPolicy }}
+    insecureEdgeTerminationPolicy: {{ . }}
+    {{- end }}
+  {{- end }}
+  wildcardPolicy: None
+{{- end }}
+
+{{/* --- Route: rag-server (API) --- */}}
+{{- $ragServerRoute := $routes.ragServer | default dict }}
+{{- if $ragServerRoute.enabled }}
+{{- $ragServerTls := $ragServerRoute.tls | default dict }}
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "nvidia-blueprint-rag.fullname" . }}
+  labels:
+    {{- include "nvidia-blueprint-rag.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rag-server
+  annotations:
+    haproxy.router.openshift.io/timeout: {{ $ragServerRoute.timeout | default "300s" | quote }}
+    {{- with $ragServerRoute.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with $ragServerRoute.host }}
+  host: {{ . }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ include "nvidia-blueprint-rag.fullname" . }}
+    weight: 100
+  port:
+    targetPort: {{ .Values.service.port | default 8081 }}
+  {{- if $ragServerTls }}
+  tls:
+    termination: {{ $ragServerTls.termination | default "edge" }}
+    {{- with $ragServerTls.insecureEdgeTerminationPolicy }}
+    insecureEdgeTerminationPolicy: {{ . }}
+    {{- end }}
+  {{- end }}
+  wildcardPolicy: None
+{{- end }}
+
+{{/*
+  SCC RoleBinding — grants the anyuid SCC to service accounts that need it.
+  OpenShift's default restricted SCC assigns random UIDs that conflict with
+  many containers in this chart (NIM, nv-ingest, etcd, Zipkin).
+*/}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "nvidia-blueprint-rag.fullname" . }}-anyuid-scc
+  labels:
+    {{- include "nvidia-blueprint-rag.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:anyuid
+subjects:
+  - kind: ServiceAccount
+    name: default
+  - kind: ServiceAccount
+    name: {{ include "nvidia-blueprint-rag.serviceAccountName" . }}
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-nv-ingest
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-minio
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-redis-master
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-redis-replica
+  - kind: ServiceAccount
+    name: nim-cache-sa
+{{- if .Values.zipkin.enabled }}
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-zipkin
+{{- end }}
+{{- end }}

--- a/deploy/helm/nvidia-blueprint-rag/templates/reranking-nim.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/templates/reranking-nim.yaml
@@ -12,6 +12,10 @@ spec:
       modelPuller: "{{ $nimModel.image.repository }}:{{ $nimModel.image.tag }}"
       pullSecret: {{ .Values.imagePullSecret.name }}
       authSecret: {{ .Values.ngcApiSecret.name }}
+  {{- with $nimModel.tolerations }}
+  tolerations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
   storage:
     pvc:
       create: {{ $nimModel.storage.pvc.create | default true }}

--- a/deploy/helm/nvidia-blueprint-rag/values-openshift-test.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/values-openshift-test.yaml
@@ -1,0 +1,131 @@
+# OpenShift test override: NVIDIA-hosted LLM, self-hosted embedding/ranking/ingestion on L40S
+#
+# Usage:
+#   helm install rag . -f values-openshift.yaml -f values-openshift-test.yaml \
+#     --set imagePullSecret.password="$NGC_API_KEY" \
+#     --set ngcApiSecret.password="$NGC_API_KEY" \
+#     -n <namespace>
+#
+# Post-install (NIM Operator limitation — the SA it creates needs the pull secret):
+#   oc secrets link nim-cache-sa ngc-secret --for=pull -n <namespace>
+#   oc delete pod -l app.nvidia.com/nim-cache -n <namespace>
+
+openshift:
+  enabled: true
+  routes:
+    frontend:
+      enabled: true
+      tls:
+        termination: edge
+        insecureEdgeTerminationPolicy: Redirect
+    ragServer:
+      enabled: true
+      timeout: "300s"
+      tls:
+        termination: edge
+        insecureEdgeTerminationPolicy: Redirect
+
+# --- Disable self-hosted LLM NIM (use NVIDIA API Catalog instead) ---
+nimOperator:
+  nim-llm:
+    enabled: false
+  nvidia-nim-llama-32-nv-embedqa-1b-v2:
+    tolerations:
+      - key: "g6-gpu"
+        operator: Exists
+        effect: NoSchedule
+  nvidia-nim-llama-32-nv-rerankqa-1b-v2:
+    tolerations:
+      - key: "g6-gpu"
+        operator: Exists
+        effect: NoSchedule
+
+# --- Point LLM-related endpoints to NVIDIA-hosted (empty = API Catalog) ---
+envVars:
+  APP_LLM_SERVERURL: ""
+  APP_QUERYREWRITER_SERVERURL: ""
+  APP_FILTEREXPRESSIONGENERATOR_SERVERURL: ""
+  REFLECTION_LLM_SERVERURL: ""
+
+# --- Ingestor server ---
+ingestor-server:
+  envVars:
+    SUMMARY_LLM_SERVERURL: ""
+  resources:
+    limits:
+      memory: "8Gi"
+    requests:
+      memory: "4Gi"
+  tolerations:
+    - key: "g6-gpu"
+      operator: Exists
+      effect: NoSchedule
+  persistence:
+    storageClass: "gp3-csi"
+
+# --- NV-Ingest ---
+nv-ingest:
+  image:
+    repository: "nvcr.io/nvidia/nemo-microservices/nv-ingest"
+    tag: "26.3.0"
+  resources:
+    requests:
+      cpu: "2"
+      memory: "8Gi"
+      nvidia.com/gpu: "0"
+    limits:
+      cpu: "4"
+      memory: "16Gi"
+      nvidia.com/gpu: "0"
+  tolerations:
+    - key: "g6-gpu"
+      operator: Exists
+      effect: NoSchedule
+  nimOperator:
+    graphic_elements:
+      enabled: false
+    table_structure:
+      enabled: false
+    ocr:
+      tolerations:
+        - key: "g6-gpu"
+          operator: Exists
+          effect: NoSchedule
+    page_elements:
+      tolerations:
+        - key: "g6-gpu"
+          operator: Exists
+          effect: NoSchedule
+  milvus:
+    standalone:
+      resources:
+        requests: {}
+        limits: {}
+      tolerations:
+        - key: "g6-gpu"
+          operator: Exists
+          effect: NoSchedule
+      persistence:
+        storageClass: "gp3-csi"
+    etcd:
+      persistence:
+        storageClass: "gp3-csi"
+    minio:
+      persistence:
+        storageClass: "gp3-csi"
+
+# --- Disable observability stack ---
+eck-elasticsearch:
+  enabled: false
+
+serviceMonitor:
+  enabled: false
+
+opentelemetry-collector:
+  enabled: false
+
+zipkin:
+  enabled: false
+
+kube-prometheus-stack:
+  enabled: false

--- a/deploy/helm/nvidia-blueprint-rag/values-openshift.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/values-openshift.yaml
@@ -1,0 +1,22 @@
+# OpenShift overlay for the NVIDIA RAG Blueprint Helm chart.
+# Usage:
+#   helm install rag . -f values.yaml -f values-openshift.yaml -n <namespace>
+
+openshift:
+  enabled: true
+  routes:
+    frontend:
+      enabled: true
+      tls:
+        termination: edge
+        insecureEdgeTerminationPolicy: Redirect
+    ragServer:
+      enabled: true
+      tls:
+        termination: edge
+        insecureEdgeTerminationPolicy: Redirect
+
+# Override default NodePort to ClusterIP — Routes handle external access.
+frontend:
+  service:
+    type: ClusterIP

--- a/deploy/helm/nvidia-blueprint-rag/values.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/values.yaml
@@ -1,6 +1,12 @@
 # -- Global chart configuration
 nameOverride: ""
 fullnameOverride: "rag-server"
+
+# -- OpenShift / OKD support
+# When enabled, the chart creates Routes (instead of relying on manual oc commands)
+# and a RoleBinding granting the anyuid SCC to service accounts that need it.
+openshift:
+  enabled: false
 # subsection: rag-server
 # RAG Orchestrator Service
 # -- Kubernetes scheduling

--- a/deploy/helm/nvidia-blueprint-rag/values.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/values.yaml
@@ -124,10 +124,10 @@ envVars:
 
   ##===Vector DB specific configurations===
   # URL on which vectorstore is hosted
-  APP_VECTORSTORE_URL: "http://rag-eck-elasticsearch-es-default:9200" # Use "http://milvus:19530" for Milvus
-  # Type of vectordb used to store embedding supported type "milvus" or "elasticsearch"
+  APP_VECTORSTORE_URL: "http://rag-eck-elasticsearch-es-default:9200"
+  # Type of vectordb used to store embedding
   APP_VECTORSTORE_NAME: "elasticsearch"
-  # Index type (e.g., GPU_CAGRA); Milvus-oriented — Elasticsearch uses its own index mapping
+  # Index type used by the vectorstore (Elasticsearch uses its own index mapping)
   APP_VECTORSTORE_INDEXTYPE: "GPU_CAGRA"
   # Type of vectordb search to be used
   APP_VECTORSTORE_SEARCHTYPE: "dense"
@@ -137,7 +137,7 @@ envVars:
   APP_VECTORSTORE_DENSE_WEIGHT: "0.5"
   # Weight for sparse vector search in case of "weighted" Hybrid Search
   APP_VECTORSTORE_SPARSE_WEIGHT: "0.5"
-  # Enable GPU search. Milvus only — GPU search is not supported by Elasticsearch.
+  # GPU search is not supported by Elasticsearch.
   APP_VECTORSTORE_ENABLEGPUSEARCH: "False"
   # ef: Parameter controlling query time/accuracy trade-off. Higher ef leads to more accurate but slower search.
   APP_VECTORSTORE_EF: "100"
@@ -368,8 +368,8 @@ ingestor-server:
     # Absolute path to custom prompt.yaml file
     PROMPT_CONFIG_FILE: "/prompt.yaml"
     # === Vector Store Configurations ===
-    APP_VECTORSTORE_URL: "http://rag-eck-elasticsearch-es-default:9200" # Use "http://milvus:19530" for Milvus
-    APP_VECTORSTORE_NAME: "elasticsearch" # supported values: "milvus" or "elasticsearch"
+    APP_VECTORSTORE_URL: "http://rag-eck-elasticsearch-es-default:9200"
+    APP_VECTORSTORE_NAME: "elasticsearch"
     APP_VECTORSTORE_SEARCHTYPE: "dense"
     # Type of ranker to use for vector store in case of Hybrid Search
     APP_VECTORSTORE_RANKER_TYPE: "rrf" # Can be "rrf" or "weighted"
@@ -377,9 +377,9 @@ ingestor-server:
     APP_VECTORSTORE_DENSE_WEIGHT: "0.5"
     # Weight for sparse vector search in case of "weighted" Hybrid Search
     APP_VECTORSTORE_SPARSE_WEIGHT: "0.5"
-    # Enable GPU index building. Applies to both Milvus and Elasticsearch (requires GPU-capable image and license for ES).
+    # Enable GPU index building (requires GPU-capable Elasticsearch image and license).
     APP_VECTORSTORE_ENABLEGPUINDEX: "False"
-    # Enable GPU search. Milvus only — GPU search is not supported by Elasticsearch.
+    # GPU search is not supported by Elasticsearch.
     APP_VECTORSTORE_ENABLEGPUSEARCH: "False"
     # Username  for vector store authentication
     APP_VECTORSTORE_USERNAME: ""
@@ -435,7 +435,7 @@ ingestor-server:
 
     # === NV-Ingest save to disk configurations ===
     APP_NVINGEST_SAVETODISK: "False"
-    NVINGEST_OBJECTSTORE_BUCKET: "nv-ingest" # If this value is modified, ensure the corresponding Milvus bucketName is also updated
+    NVINGEST_OBJECTSTORE_BUCKET: "nv-ingest"
 
     # === NV-Ingest performance configurations ===
     APP_NVINGEST_ENABLE_PDF_SPLIT_PROCESSING: "False"
@@ -1150,54 +1150,8 @@ nv-ingest:
     AUDIO_GRPC_ENDPOINT: nv-ingest-riva-nim:50051
     AUDIO_INFER_PROTOCOL: grpc
 
-  # Disable the vendored Milvus dependency entirely for the Elasticsearch + SeaweedFS topology.
-  # NV-Ingest still uses SeaweedFS via MINIO_* env vars for S3-compatible artifact storage.
+  # NV-Ingest uses SeaweedFS via MINIO_* env vars for S3-compatible artifact storage.
   milvusDeployed: false
-  milvus:
-    # Uncomment this section to enable authentication for Milvus
-    # extraConfigFiles:
-    #   user.yaml: |+
-    #     common:
-    #       security:
-    #         authorizationEnabled: true
-    #         defaultRootPassword: Milvus
-    image:
-      all:
-        repository: docker.io/milvusdb/milvus
-        tag: v2.6.5-gpu
-      tools:
-        repository: docker.io/milvusdb/milvus-config-tool
-        tag: v0.1.2
-        pullPolicy: IfNotPresent
-    # These values are retained for reference only while the Milvus dependency is disabled.
-    cluster:
-      enabled: false
-    proxy:
-      enabled: false
-    rootCoordinator:
-      enabled: false
-    queryCoordinator:
-      enabled: false
-    queryNode:
-      enabled: false
-    indexCoordinator:
-      enabled: false
-    indexNode:
-      enabled: false
-    dataCoordinator:
-      enabled: false
-    dataNode:
-      enabled: false
-    etcd:
-      enabled: false
-      image:
-        repository: milvusdb/etcd
-        tag: "3.5.23-r2"
-    minio:
-      enabled: false
-      tls:
-        enabled: false
-    fullnameOverride: milvus
 
   # Redis Master
   redis:

--- a/deploy/helm/nvidia-blueprint-rag/values.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/values.yaml
@@ -878,9 +878,9 @@ nimOperator:
         timeoutSeconds: 5
 
 # subsection: nvidia-nim-llama-32-nv-embedqa-1b-v2
-# NIM Text Embedding
+# NIM Text Embedding (disabled by default; VLM embedding is the default — see nvidia-nim-llama-nemotron-embed-vl-1b-v2 below)
   nvidia-nim-llama-32-nv-embedqa-1b-v2:
-    enabled: true
+    enabled: false
     replicas: 1
     service:
       name: "nemotron-embedding-ms"
@@ -920,9 +920,9 @@ nimOperator:
         grpcPort: 8001
 
 # subsection: nvidia-nim-llama-nemotron-embed-vl-1b-v2
-# NIM VLM Embedding
+# NIM VLM Embedding (default embedding service; aligned with envVars.APP_EMBEDDINGS_SERVERURL)
   nvidia-nim-llama-nemotron-embed-vl-1b-v2:
-    enabled: false
+    enabled: true
     service:
       name: "nemotron-vlm-embedding-ms"
     image:
@@ -1101,8 +1101,8 @@ nv-ingest:
     
     APP_EMBEDDINGS_SERVERURL: "nemotron-vlm-embedding-ms:8000/v1"
     APP_EMBEDDINGS_MODELNAME: "nvidia/llama-nemotron-embed-vl-1b-v2"
-    EMBEDDING_NIM_ENDPOINT: "http://nemotron-embedding-ms:8000/v1"
-    EMBEDDING_NIM_MODEL_NAME: "nvidia/llama-nemotron-embed-1b-v2"
+    EMBEDDING_NIM_ENDPOINT: "http://nemotron-vlm-embedding-ms:8000/v1"
+    EMBEDDING_NIM_MODEL_NAME: "nvidia/llama-nemotron-embed-vl-1b-v2"
     MESSAGE_CLIENT_HOST: "rag-redis-master"
     MESSAGE_CLIENT_PORT: 6379
     MESSAGE_CLIENT_TYPE: "redis"

--- a/docs/deploy-helm-from-repo.md
+++ b/docs/deploy-helm-from-repo.md
@@ -80,6 +80,7 @@ If you are working directly with the source Helm chart, and you want to customiz
     helm repo add baidu-nim https://helm.ngc.nvidia.com/nim/baidu --username='$oauthtoken' --password=$NGC_API_KEY
     helm repo add bitnami https://charts.bitnami.com/bitnami
     helm repo add elastic https://helm.elastic.co
+    helm repo add seaweed https://seaweedfs.github.io/seaweedfs/helm
     helm repo add otel https://open-telemetry.github.io/opentelemetry-helm-charts
     helm repo add zipkin https://zipkin.io/zipkin-helm
     helm repo add prometheus https://prometheus-community.github.io/helm-charts

--- a/docs/deploy-helm-openshift.md
+++ b/docs/deploy-helm-openshift.md
@@ -1,0 +1,355 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025, 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+# Deploy NVIDIA RAG Blueprint on OpenShift with Helm
+
+Use the following documentation to deploy the [NVIDIA RAG Blueprint](readme.md) on a Red Hat OpenShift cluster by using Helm.
+
+- To deploy on standard Kubernetes (non-OpenShift), refer to [Deploy on Kubernetes with Helm](deploy-helm.md).
+- To deploy with MIG support, refer to [RAG Deployment with MIG Support](mig-deployment.md).
+- For other deployment options, refer to [Deployment Options](readme.md#deployment-options-for-rag-blueprint).
+
+The chart includes built-in OpenShift support gated behind an `openshift.enabled` flag.
+When enabled, the chart automatically creates OpenShift Routes with edge TLS and an `anyuid` SCC RoleBinding for all required ServiceAccounts — no manual `oc adm policy` commands are needed.
+
+
+## Prerequisites
+
+:::{important}
+Ensure you have at least 200GB of available disk space per node where NIMs will be deployed. This space is required for the following:
+- NIM model cache downloads (~100-150GB)
+- Container images (~20-30GB)
+- Persistent volumes for vector database and application data
+- Logs and temporary files
+:::
+
+1. [Get an API Key](api-key.md).
+
+2. Verify that you meet the [hardware requirements](support-matrix.md). The minimum GPU requirements depend on deployment mode:
+
+   | Deployment Mode | GPUs Required | Notes |
+   |----------------|--------------|-------|
+   | Full (self-hosted NIMs) | 8–10 | All NIM models running in-cluster |
+   | Minimal (no VLM, no optional NIMs) | 6–7 | Core pipeline without VLM or audio |
+   | API-hosted LLM | 4–6 | LLM via [build.nvidia.com](https://build.nvidia.com/); self-hosted embedding, reranking, and NV-Ingest NIMs |
+
+3. Verify that you have **OpenShift 4.14 or later** with cluster-admin access, and the `oc` CLI configured.
+
+4. Verify that you have **Helm 3** installed. To install Helm 3, follow the official [Helm installation instructions](https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3).
+
+5. Verify that you have the **NVIDIA GPU Operator** installed and functional. For details, see [GPU Operator documentation](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html).
+
+6. Verify that you have the **NVIDIA NIM Operator** v3.0.2+ installed. If not, install it:
+
+    ```sh
+    helm repo add nvidia https://helm.ngc.nvidia.com/nvidia \
+      --username='$oauthtoken' \
+      --password=$NGC_API_KEY
+    helm repo update
+    helm install nim-operator nvidia/k8s-nim-operator -n nim-operator --create-namespace
+    ```
+
+    For details, see [NIM Operator installation guide](https://docs.nvidia.com/nim-operator/latest/install.html).
+
+7. Verify that a **default StorageClass** with dynamic provisioning is available (e.g., `gp3-csi` on AWS):
+
+    ```sh
+    oc get storageclass
+    ```
+
+8. Check GPU node taints. GPU nodes on OpenShift clusters typically have taints that prevent non-GPU workloads from scheduling on them. You need the taint keys for the tolerations configuration:
+
+    ```sh
+    oc get nodes -l nvidia.com/gpu.present=true \
+      -o custom-columns="NODE:.metadata.name,TAINTS:.spec.taints[*].key"
+    ```
+
+9. Accept NIM licenses. Each NIM container image on NGC requires individually accepting a license agreement before your API key can pull it. Accept licenses for each NIM at [build.nvidia.com](https://build.nvidia.com/).
+
+
+## Deploy the RAG Helm Chart
+
+:::{important}
+When you use the Helm NIM Operator deployment, approximately 60 to 70 minutes is required for the entire pipeline to reach a running state on first deploy. Subsequent deployments are significantly faster (~10-15 minutes) because model caches are already populated.
+:::
+
+To deploy the RAG Blueprint on OpenShift, use the following procedure.
+
+1. Set your environment variables.
+
+    ```sh
+    export NGC_API_KEY="nvapi-..."
+    export NAMESPACE="rag"
+    ```
+
+2. Navigate to the chart directory and build dependencies.
+
+    ```sh
+    cd deploy/helm/nvidia-blueprint-rag
+
+    helm repo add nvidia-nemo https://helm.ngc.nvidia.com/nvidia/nemo-microservices \
+      --username '$oauthtoken' --password "$NGC_API_KEY"
+
+    helm dependency build
+    ```
+
+3. Create a namespace.
+
+    ```sh
+    oc new-project $NAMESPACE
+    ```
+
+4. Install the Helm chart with the OpenShift overlay.
+
+    ```sh
+    helm upgrade --install rag -n $NAMESPACE . \
+      -f values-openshift.yaml \
+      --set imagePullSecret.password="$NGC_API_KEY" \
+      --set ngcApiSecret.password="$NGC_API_KEY" \
+      --timeout 15m
+    ```
+
+    The `values-openshift.yaml` overlay enables the following:
+    - **OpenShift Routes** for the frontend and RAG server with edge TLS
+    - **anyuid SCC RoleBinding** for all ServiceAccounts that need it
+    - **ClusterIP** service type for the frontend (Routes handle external access)
+
+    :::{note}
+    If your GPU nodes have taints, you must add tolerations. Pass them on the command line with `--set-json` or create a values overlay file.
+    For example, if your GPU nodes have a `gpu-taint` taint:
+
+    ```sh
+    helm upgrade --install rag -n $NAMESPACE . \
+      -f values-openshift.yaml \
+      --set imagePullSecret.password="$NGC_API_KEY" \
+      --set ngcApiSecret.password="$NGC_API_KEY" \
+      --set-json 'nimOperator.nim-llm.tolerations=[{"key":"gpu-taint","operator":"Exists","effect":"NoSchedule"}]' \
+      --set-json 'nimOperator.nvidia-nim-llama-32-nv-embedqa-1b-v2.tolerations=[{"key":"gpu-taint","operator":"Exists","effect":"NoSchedule"}]' \
+      --set-json 'nimOperator.nvidia-nim-llama-32-nv-rerankqa-1b-v2.tolerations=[{"key":"gpu-taint","operator":"Exists","effect":"NoSchedule"}]' \
+      --set-json 'nv-ingest.nimOperator.ocr.tolerations=[{"key":"gpu-taint","operator":"Exists","effect":"NoSchedule"}]' \
+      --set-json 'nv-ingest.nimOperator.page_elements.tolerations=[{"key":"gpu-taint","operator":"Exists","effect":"NoSchedule"}]' \
+      --timeout 15m
+    ```
+
+    The chart also includes a `values-openshift-test.yaml` reference overlay that demonstrates tolerations, resource tuning, disabled observability, and API-hosted LLM mode. Edit the toleration keys to match your cluster and layer it on with `-f values-openshift-test.yaml`.
+    :::
+
+5. Link the NGC pull secret to the NIM Operator ServiceAccount.
+
+    The NIM Operator creates a `nim-cache-sa` ServiceAccount for model cache jobs. Link the pull secret so it can pull NIM model images:
+
+    ```sh
+    oc secrets link nim-cache-sa ngc-secret --for=pull -n $NAMESPACE
+    ```
+
+    If NIMCache pods are stuck in `ImagePullBackOff`, delete them so the operator recreates them with the linked secret:
+
+    ```sh
+    oc delete pod -l app.nvidia.com/nim-cache -n $NAMESPACE
+    ```
+
+
+## Verify a Deployment
+
+1. List the pods by running the following code.
+
+    ```sh
+    oc get pods -n $NAMESPACE
+    ```
+
+    You should see output similar to the following.
+
+    ```sh
+    NAME                                          READY   STATUS    AGE
+    ingestor-server-xxxxxxxxx-xxxxx               1/1     Running   5m
+    milvus-standalone-xxxxxxxxx-xxxxx             1/1     Running   5m
+    nemotron-embedding-ms-xxxxxxxxx-xxxxx         1/1     Running   10m
+    nemotron-ocr-v1-xxxxxxxxx-xxxxx               1/1     Running   10m
+    nemotron-page-elements-v3-xxxxxxxxx-xxxxx     1/1     Running   10m
+    nemotron-ranking-ms-xxxxxxxxx-xxxxx           1/1     Running   10m
+    nim-llm-xxxxxxxxx-xxxxx                       1/1     Running   15m
+    rag-etcd-0                                    1/1     Running   5m
+    rag-frontend-xxxxxxxxx-xxxxx                  1/1     Running   5m
+    rag-minio-xxxxxxxxx-xxxxx                     1/1     Running   5m
+    rag-nv-ingest-xxxxxxxxx-xxxxx                 1/1     Running   5m
+    rag-redis-master-0                            1/1     Running   5m
+    rag-server-xxxxxxxxx-xxxxx                    1/1     Running   5m
+    ```
+
+   :::{note}
+   Model downloads do not show detailed progress indicators in pod status. Pods may appear in "ContainerCreating" or "Init" state for extended periods while models download in the background.
+
+   You can monitor the deployment progress by running the following code.
+
+   ```sh
+   # Check NIMCache download status (shows if cache is ready)
+   oc get nimcache -n $NAMESPACE
+
+   # Check NIMService status
+   oc get nimservice -n $NAMESPACE
+
+   # Check events for detailed information
+   oc get events -n $NAMESPACE --sort-by='.lastTimestamp'
+
+   # Watch logs of a specific pod to see detailed progress
+   oc logs -f <pod-name> -n $NAMESPACE
+   ```
+   :::
+
+2. Verify OpenShift Routes are created.
+
+    ```sh
+    oc get routes -n $NAMESPACE
+    ```
+
+3. Get the application URLs.
+
+    ```sh
+    # Frontend URL
+    echo "https://$(oc get route rag-frontend -n $NAMESPACE -o jsonpath='{.spec.host}')"
+
+    # API URL
+    echo "https://$(oc get route rag-server -n $NAMESPACE -o jsonpath='{.spec.host}')"
+
+    # API health check
+    API_HOST=$(oc get route rag-server -n $NAMESPACE -o jsonpath='{.spec.host}')
+    curl -sk "https://${API_HOST}/health"
+    ```
+
+
+## Experiment with the Web User Interface
+
+Open a web browser and access the frontend URL from the previous step. You can start experimenting by uploading documents and asking questions. For details, see [User Interface for NVIDIA RAG Blueprint](user-interface.md).
+
+:::{note}
+Unlike standard Kubernetes deployments, OpenShift Routes provide external access directly — no `kubectl port-forward` is needed.
+:::
+
+
+## Using NVIDIA-Hosted Models (Reduced GPU Requirements)
+
+For clusters with limited GPU capacity, you can use NVIDIA-hosted model endpoints at [build.nvidia.com](https://build.nvidia.com/) for the LLM while keeping embedding, reranking, and NV-Ingest NIMs self-hosted.
+
+Set the LLM server URLs to empty strings and disable the self-hosted NIM LLM:
+
+```yaml
+nimOperator:
+  nim-llm:
+    enabled: false
+
+envVars:
+  APP_LLM_SERVERURL: ""
+  APP_QUERYREWRITER_SERVERURL: ""
+  APP_FILTEREXPRESSIONGENERATOR_SERVERURL: ""
+  REFLECTION_LLM_SERVERURL: ""
+
+ingestor-server:
+  envVars:
+    SUMMARY_LLM_SERVERURL: ""
+```
+
+The included `values-openshift-test.yaml` overlay implements this pattern. Layer it on with `-f values-openshift-test.yaml`.
+
+
+## Change a Deployment
+
+To change an existing deployment, after you modify the values files, run the following code.
+
+```sh
+helm upgrade rag -n $NAMESPACE . \
+  -f values-openshift.yaml \
+  --set imagePullSecret.password="$NGC_API_KEY" \
+  --set ngcApiSecret.password="$NGC_API_KEY"
+```
+
+
+## Uninstall a Deployment
+
+To uninstall a deployment, run the following code.
+
+```sh
+helm uninstall rag -n $NAMESPACE
+```
+
+Run the following code to remove the NIMCache and Persistent Volume Claims (PVCs) created by the chart which are not removed by default.
+
+```sh
+oc delete nimcache --all -n $NAMESPACE
+oc delete nimservice --all -n $NAMESPACE
+oc delete pvc --all -n $NAMESPACE
+```
+
+To delete the namespace entirely:
+
+```sh
+oc delete namespace $NAMESPACE
+```
+
+
+## OpenShift-Specific Troubleshooting
+
+### Security Context Constraints (SCC)
+
+**Symptom**: Pods fail with `CrashLoopBackOff` and logs show permission errors such as `mkdir: cannot create directory '/opt/nim/.cache': Permission denied`.
+
+**Why**: OpenShift's default `restricted` SCC assigns random UIDs. NIM containers and infrastructure services expect to run as specific users.
+
+**Fix**: The chart's `openshift.yaml` template automatically grants the `anyuid` SCC to required ServiceAccounts when `openshift.enabled` is `true`. If you are not using `values-openshift.yaml`, grant `anyuid` manually:
+
+```sh
+oc adm policy add-scc-to-user anyuid -z default -n $NAMESPACE
+```
+
+### GPU Node Scheduling and Tolerations
+
+**Symptom**: NIM pods stay in `Pending` state.
+
+**Why**: GPU nodes typically have taints. NIM workloads need matching tolerations.
+
+**Fix**: Discover your taint keys and set tolerations in your values file:
+
+```sh
+oc get nodes -l nvidia.com/gpu.present=true \
+  -o custom-columns="NODE:.metadata.name,TAINTS:.spec.taints[*].key"
+```
+
+Set matching tolerations for each NIM component via `--set-json` or a values overlay. The `values-openshift-test.yaml` file demonstrates the pattern.
+
+### NIM LLM VRAM Requirements
+
+**Symptom**: NIM LLM pod crashes during model loading with `torch.OutOfMemoryError`.
+
+**Fix**: For GPUs with limited VRAM, reduce `NIM_MAX_MODEL_LEN` or use NVIDIA-hosted models as described in [Using NVIDIA-Hosted Models](#using-nvidia-hosted-models-reduced-gpu-requirements).
+
+### Route Timeouts
+
+**Symptom**: Document ingestion or complex queries return `504 Gateway Timeout`.
+
+**Why**: OpenShift's default Route timeout is 30 seconds. The chart sets `haproxy.router.openshift.io/timeout: 300s` on the RAG server Route, but if you create Routes manually, set this annotation explicitly.
+
+### Common Issues
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| Pods stuck in `Pending` | Missing tolerations or insufficient GPU resources | Check taints; set tolerations in values |
+| `ImagePullBackOff` | Missing NGC secret or unaccepted NIM license | Verify `ngc-secret` exists; accept licenses at [build.nvidia.com](https://build.nvidia.com/) |
+| `CrashLoopBackOff` | SCC restrictions or insufficient memory | Enable `openshift.enabled`; check resource limits |
+| NIM LLM `OOMKilled` | Insufficient VRAM | Reduce `NIM_MAX_MODEL_LEN` or use NVIDIA-hosted LLM |
+| PVC `Pending` | StorageClass not found | Set correct `storageClass` in values or use `""` for default |
+| `504 Gateway Timeout` | Route timeout too low | Annotate route with `haproxy.router.openshift.io/timeout=300s` |
+| NIMCache `ImagePullBackOff` | Pull secret not linked to `nim-cache-sa` | Run `oc secrets link nim-cache-sa ngc-secret --for=pull` |
+
+
+## Troubleshooting Helm Issues
+
+For general troubleshooting issues with Helm deployment, refer to [Troubleshooting](troubleshooting.md).
+
+
+## Related Topics
+
+- [NVIDIA RAG Blueprint Documentation](readme.md)
+- [Deploy on Kubernetes with Helm](deploy-helm.md)
+- [Best Practices for Common Settings](accuracy_perf.md)
+- [User Interface](user-interface.md)
+- [Troubleshoot](troubleshooting.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,6 +52,7 @@ For detailed requirements, refer to [Support Matrix](support-matrix.md).
 - [Deploy on Kubernetes with Helm](deploy-helm.md)
 - [Deploy on Kubernetes with Helm from the repository](deploy-helm-from-repo.md)
 - [Deploy on Kubernetes with Helm and MIG Support](mig-deployment.md)
+- [Deploy on OpenShift with Helm](deploy-helm-openshift.md)
 - [Deploy Retrieval-Only Mode](retrieval-only-deployment.md)
 
 
@@ -187,6 +188,7 @@ After you deploy the RAG blueprint, you can customize it for your use cases.
    Deploy on Kubernetes with Helm <deploy-helm.md>
    Deploy on Kubernetes with Helm from the repository <deploy-helm-from-repo.md>
    Deploy on Kubernetes with Helm and MIG Support <mig-deployment.md>
+   Deploy on OpenShift with Helm <deploy-helm-openshift.md>
    Deploy Retrieval-Only Mode <retrieval-only-deployment.md>
 ```
 

--- a/tests/integration/test_cases/multimodal_query.py
+++ b/tests/integration/test_cases/multimodal_query.py
@@ -95,7 +95,7 @@ Helm Deployment:
 
     2. Deploy or upgrade the chart:
 
-        helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvidia/blueprint/charts/nvidia-blueprint-rag-v2.6.0-dev-rc1.tgz \\
+        helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0-rc1.tgz \\
           --username '$oauthtoken' \\
           --password "${NGC_API_KEY}" \\
           --set imagePullSecret.password=$NGC_API_KEY \\

--- a/tests/unit/test_deploy/test_seaweedfs_deploy_config.py
+++ b/tests/unit/test_deploy/test_seaweedfs_deploy_config.py
@@ -186,7 +186,6 @@ def test_helm_values_default_to_seaweedfs_and_persistence():
     assert values["nv-ingest"]["redis"]["fullnameOverride"] == "rag-redis"
     assert values["nv-ingest"]["envVars"]["YOLOX_PAGE_IMAGE_FORMAT"] == "JPEG"
     assert values["nv-ingest"]["milvusDeployed"] is False
-    assert values["nv-ingest"]["milvus"]["minio"]["enabled"] is False
 
 
 def test_helm_chart_uses_upstream_seaweedfs_dependency():


### PR DESCRIPTION
## Summary
- Updates rag-server, ingestor-server, and rag-frontend image tags to `nvcr.io/nvstaging/blueprint/...:2.6.0.rc1` in compose and helm; bumps the helm chart `appVersion`/`version` to `v2.6.0-rc1`.
- Aligns helm embedding NIM toggles with existing envVars: enables `nvidia-nim-llama-nemotron-embed-vl-1b-v2` (the VL embedding service the `APP_EMBEDDINGS_*` envVars already point at) and disables `nvidia-nim-llama-32-nv-embedqa-1b-v2`. Also fixes `nv-ingest.envVars.EMBEDDING_NIM_ENDPOINT` / `EMBEDDING_NIM_MODEL_NAME` to reference the VL embedding service/model. Matches the compose default profile, where `nemotron-vlm-embedding-ms` is in the default profile and the text embedding service is opt-in.
- Refreshes `Chart.lock` to include the seaweedfs dependency.

## Test plan
- [x] `helm dependency update` clean
- [x] `helm template` renders without errors
- [x] `helm upgrade --install` deploys on a fresh cluster (NIM Operator + ECK Operator prerequisites)
- [x] All 15 pods reach `Running` and `Ready` (rag-server, ingestor-server, rag-frontend, all 7 NIMServices, ES, redis-master/replicas, seaweedfs, nv-ingest)
- [x] End-to-end query against `rag-server:8081/v1/generate` returns expected output with `FILTER_THINK_TOKENS=true`
- [ ] CI green on `develop`

## Notes
- Tested with `nim-llm` overridden to `llama-3.3-nemotron-super-49b-v1.5:1.14.0` (1 GPU) since the test NGC key did not have org-context access to the gated `nemotron-3-super-120b-a12b` model. The chart default for `nim-llm` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)