### PR TITLE
Render agentic-RAG streaming reasoning trace in the chat UI

### DIFF
--- a/frontend/src/components/chat/ChatMessageBubble.tsx
+++ b/frontend/src/components/chat/ChatMessageBubble.tsx
@@ -18,6 +18,7 @@ import type { ChatMessage, MessageContent as MessageContentType } from "../../ty
 import { useStreamingStore } from "../../store/useStreamingStore";
 import { MessageContent } from "./MessageContent";
 import { StreamingIndicator } from "./StreamingIndicator";
+import { ReasoningPanel } from "./ReasoningPanel";
 import { CitationButton } from "../citations/CitationButton";
 import { 
   Block, 
@@ -93,14 +94,26 @@ const MessageContainer = ({
   </Flex>
 );
 
-const StreamingMessage = ({ content, isError = false }: { content: MessageContentType; isError?: boolean }) => {
-  const textContent = extractTextFromContent(content);
+const StreamingMessage = ({
+  msg,
+  isError = false,
+}: {
+  msg: ChatMessage;
+  isError?: boolean;
+}) => {
+  const textContent = extractTextFromContent(msg.content);
+  const reasoningSteps = msg.reasoning_steps;
   return (
     <MessageContainer role="assistant" isError={isError}>
-      <Flex align="center" gap="2">
-        <MessageContent content={textContent} />
-        {!textContent && <StreamingIndicator />}
-      </Flex>
+      <Stack gap="2">
+        {reasoningSteps && reasoningSteps.length > 0 && (
+          <ReasoningPanel steps={reasoningSteps} streaming />
+        )}
+        <Flex align="center" gap="2">
+          <MessageContent content={textContent} />
+          {!textContent && <StreamingIndicator />}
+        </Flex>
+      </Stack>
     </MessageContainer>
   );
 };
@@ -180,6 +193,9 @@ const RegularMessage = ({ msg }: { msg: ChatMessage }) => {
               ))}
             </Flex>
           )}
+          {msg.role === "assistant" && msg.reasoning_steps && msg.reasoning_steps.length > 0 && (
+            <ReasoningPanel steps={msg.reasoning_steps} />
+          )}
           {/* Always render text content block to maintain structure */}
           <Block>
             <MessageContent content={textContent} />
@@ -208,7 +224,7 @@ export default function ChatMessageBubble({ msg }: ChatMessageBubbleProps) {
   );
 
   if (isThisMessageStreaming) {
-    return <StreamingMessage content={msg.content} isError={msg.is_error} />;
+    return <StreamingMessage msg={msg} isError={msg.is_error} />;
   }
 
   return <RegularMessage msg={msg} />;

--- a/frontend/src/components/chat/ReasoningPanel.tsx
+++ b/frontend/src/components/chat/ReasoningPanel.tsx
@@ -1,0 +1,214 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useCallback, useEffect, useState } from "react";
+import { Block, Flex, Stack, Text } from "@kui/react";
+import { AlertCircle, Brain, CheckCircle2, ChevronDown, ChevronRight, Loader2 } from "lucide-react";
+import type { ReasoningStep } from "../../types/chat";
+import { useCitationUtils } from "../../hooks/useCitationUtils";
+
+interface ReasoningPanelProps {
+  /** Reasoning trace from the agentic stream. */
+  steps: ReasoningStep[];
+  /** Whether the parent message is still streaming. */
+  streaming?: boolean;
+}
+
+const StepIcon = ({ status }: { status: ReasoningStep["status"] }) => {
+  if (status === "running") {
+    return (
+      <Loader2
+        size={14}
+        style={{
+          color: "var(--text-color-subtle)",
+          animation: "rag-reasoning-spin 1s linear infinite",
+        }}
+        aria-label="Step running"
+      />
+    );
+  }
+  if (status === "error") {
+    return (
+      <AlertCircle
+        size={14}
+        style={{ color: "var(--color-red-500)" }}
+        aria-label="Step errored"
+      />
+    );
+  }
+  return (
+    <CheckCircle2
+      size={14}
+      style={{ color: "var(--text-color-accent-green)" }}
+      aria-label="Step completed"
+    />
+  );
+};
+
+const StepRow = ({
+  step,
+  formatStage,
+}: {
+  step: ReasoningStep;
+  formatStage: (stage: string) => string;
+}) => {
+  const headline = step.summary ?? step.label;
+  return (
+    <Stack
+      gap="density-xs"
+      data-testid={`reasoning-step-${step.stage}`}
+      data-status={step.status}
+    >
+      <Flex align="center" gap="density-xs">
+        <StepIcon status={step.status} />
+        <Text kind="body/bold/sm">{formatStage(step.stage)}</Text>
+        {headline && (
+          <Text
+            kind="body/regular/sm"
+            style={{ color: "var(--text-color-subtle)" }}
+          >
+            — {headline}
+          </Text>
+        )}
+      </Flex>
+      {(step.reasoning || step.output) && (
+        <Block style={{ paddingLeft: "22px" }}>
+          {step.reasoning && (
+            <Text
+              kind="body/regular/sm"
+              style={{
+                color: "var(--text-color-subtle)",
+                whiteSpace: "pre-wrap",
+                fontFamily: "var(--font-family-mono, monospace)",
+                fontSize: "0.85em",
+              }}
+            >
+              {step.reasoning}
+            </Text>
+          )}
+          {step.output && (
+            <Text
+              kind="body/regular/sm"
+              style={{
+                color: "var(--text-color-subtle)",
+                whiteSpace: "pre-wrap",
+                fontFamily: "var(--font-family-mono, monospace)",
+                fontSize: "0.85em",
+              }}
+            >
+              {step.output}
+            </Text>
+          )}
+        </Block>
+      )}
+    </Stack>
+  );
+};
+
+/**
+ * Collapsible "Thinking" panel that renders the agentic-RAG reasoning
+ * trace above the assistant's final answer.
+ *
+ * - Hidden when there are no steps (standard non-agentic responses).
+ * - Auto-expanded while the message is streaming so users can watch the
+ *   agent work; collapses on completion to a "Thought for N steps" line.
+ * - Step labels are formatted via `useCitationUtils.formatStage` so any
+ *   future graph node renders without code changes.
+ */
+export const ReasoningPanel = ({ steps, streaming = false }: ReasoningPanelProps) => {
+  const { formatStage } = useCitationUtils();
+  const [open, setOpen] = useState<boolean>(streaming);
+  const [autoCollapsed, setAutoCollapsed] = useState<boolean>(false);
+
+  // Auto-collapse exactly once when streaming finishes.
+  useEffect(() => {
+    if (!streaming && !autoCollapsed) {
+      setOpen(false);
+      setAutoCollapsed(true);
+    }
+    if (streaming && autoCollapsed) {
+      setAutoCollapsed(false);
+    }
+  }, [streaming, autoCollapsed]);
+
+  const toggle = useCallback(() => setOpen((prev) => !prev), []);
+
+  if (!steps || steps.length === 0) return null;
+
+  const stepCount = steps.length;
+  const headerLabel = streaming
+    ? `Thinking (${stepCount} step${stepCount === 1 ? "" : "s"})`
+    : `Thought for ${stepCount} step${stepCount === 1 ? "" : "s"}`;
+
+  return (
+    <Block
+      data-testid="reasoning-panel"
+      data-streaming={streaming ? "true" : "false"}
+      data-open={open ? "true" : "false"}
+      style={{
+        borderLeft: "2px solid var(--text-color-subtle)",
+        paddingLeft: "8px",
+        marginBottom: "8px",
+      }}
+    >
+      <style>{
+        "@keyframes rag-reasoning-spin{from{transform:rotate(0)}to{transform:rotate(360deg)}}"
+      }</style>
+      <Flex
+        align="center"
+        gap="density-xs"
+        role="button"
+        tabIndex={0}
+        aria-expanded={open}
+        aria-label={open ? "Hide reasoning trace" : "Show reasoning trace"}
+        onClick={toggle}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            toggle();
+          }
+        }}
+        data-testid="reasoning-panel-toggle"
+        style={{ cursor: "pointer", userSelect: "none" }}
+      >
+        {open ? (
+          <ChevronDown size={14} style={{ color: "var(--text-color-subtle)" }} />
+        ) : (
+          <ChevronRight size={14} style={{ color: "var(--text-color-subtle)" }} />
+        )}
+        <Brain size={14} style={{ color: "var(--text-color-subtle)" }} aria-hidden />
+        <Text
+          kind="body/bold/sm"
+          style={{ color: "var(--text-color-subtle)" }}
+        >
+          {headerLabel}
+        </Text>
+      </Flex>
+      {open && (
+        <Block style={{ paddingTop: "8px" }}>
+          <Stack gap="density-sm">
+            {steps.map((step, index) => (
+              <StepRow
+                key={`${step.stage}-${index}`}
+                step={step}
+                formatStage={formatStage}
+              />
+            ))}
+          </Stack>
+        </Block>
+      )}
+    </Block>
+  );
+};

--- a/frontend/src/components/chat/ReasoningPanel.tsx
+++ b/frontend/src/components/chat/ReasoningPanel.tsx
@@ -14,8 +14,8 @@
 // limitations under the License.
 
 import { useCallback, useEffect, useState } from "react";
-import { Block, Flex, Stack, Text } from "@kui/react";
-import { AlertCircle, Brain, CheckCircle2, ChevronDown, ChevronRight, Loader2 } from "lucide-react";
+import { AnimatedChevron, Block, Flex, Stack, Text } from "@kui/react";
+import { AlertCircle, Brain, CheckCircle2, Loader2 } from "lucide-react";
 import type { ReasoningStep } from "../../types/chat";
 import { useCitationUtils } from "../../hooks/useCitationUtils";
 
@@ -33,7 +33,7 @@ const StepIcon = ({ status }: { status: ReasoningStep["status"] }) => {
         size={14}
         style={{
           color: "var(--text-color-subtle)",
-          animation: "rag-reasoning-spin 1s linear infinite",
+          animation: "var(--animate-spin)",
         }}
         aria-label="Step running"
       />
@@ -43,7 +43,7 @@ const StepIcon = ({ status }: { status: ReasoningStep["status"] }) => {
     return (
       <AlertCircle
         size={14}
-        style={{ color: "var(--color-red-500)" }}
+        style={{ color: "var(--text-color-feedback-danger)" }}
         aria-label="Step errored"
       />
     );
@@ -51,7 +51,7 @@ const StepIcon = ({ status }: { status: ReasoningStep["status"] }) => {
   return (
     <CheckCircle2
       size={14}
-      style={{ color: "var(--text-color-accent-green)" }}
+      style={{ color: "var(--text-color-feedback-success)" }}
       aria-label="Step completed"
     />
   );
@@ -91,7 +91,7 @@ const StepRow = ({
               style={{
                 color: "var(--text-color-subtle)",
                 whiteSpace: "pre-wrap",
-                fontFamily: "var(--font-family-mono, monospace)",
+                fontFamily: "var(--font-mono)",
                 fontSize: "0.85em",
               }}
             >
@@ -104,7 +104,7 @@ const StepRow = ({
               style={{
                 color: "var(--text-color-subtle)",
                 whiteSpace: "pre-wrap",
-                fontFamily: "var(--font-family-mono, monospace)",
+                fontFamily: "var(--font-mono)",
                 fontSize: "0.85em",
               }}
             >
@@ -155,17 +155,14 @@ export const ReasoningPanel = ({ steps, streaming = false }: ReasoningPanelProps
   return (
     <Block
       data-testid="reasoning-panel"
+      data-state={open ? "open" : "closed"}
       data-streaming={streaming ? "true" : "false"}
-      data-open={open ? "true" : "false"}
       style={{
         borderLeft: "2px solid var(--text-color-subtle)",
         paddingLeft: "8px",
         marginBottom: "8px",
       }}
     >
-      <style>{
-        "@keyframes rag-reasoning-spin{from{transform:rotate(0)}to{transform:rotate(360deg)}}"
-      }</style>
       <Flex
         align="center"
         gap="density-xs"
@@ -183,11 +180,7 @@ export const ReasoningPanel = ({ steps, streaming = false }: ReasoningPanelProps
         data-testid="reasoning-panel-toggle"
         style={{ cursor: "pointer", userSelect: "none" }}
       >
-        {open ? (
-          <ChevronDown size={14} style={{ color: "var(--text-color-subtle)" }} />
-        ) : (
-          <ChevronRight size={14} style={{ color: "var(--text-color-subtle)" }} />
-        )}
+        <AnimatedChevron state={open ? "open" : "closed"} />
         <Brain size={14} style={{ color: "var(--text-color-subtle)" }} aria-hidden />
         <Text
           kind="body/bold/sm"

--- a/frontend/src/components/chat/__tests__/ReasoningPanel.test.tsx
+++ b/frontend/src/components/chat/__tests__/ReasoningPanel.test.tsx
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '../../../test/utils';
+import { ReasoningPanel } from '../ReasoningPanel';
+import type { ReasoningStep } from '../../../types/chat';
+
+const buildStep = (overrides: Partial<ReasoningStep> = {}): ReasoningStep => ({
+  stage: 'plan',
+  reasoning: '',
+  output: '',
+  status: 'done',
+  ...overrides,
+});
+
+describe('ReasoningPanel', () => {
+  it('renders nothing when there are no steps', () => {
+    const { container } = render(<ReasoningPanel steps={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows "Thought for N steps" header when not streaming', () => {
+    render(
+      <ReasoningPanel
+        steps={[
+          buildStep({ stage: 'plan', label: 'Planning…', summary: 'Done.' }),
+          buildStep({ stage: 'execute', label: 'Running tasks…' }),
+        ]}
+      />
+    );
+    expect(screen.getByTestId('reasoning-panel-toggle')).toHaveTextContent(
+      'Thought for 2 steps'
+    );
+  });
+
+  it('shows live "Thinking" header while streaming', () => {
+    render(
+      <ReasoningPanel
+        streaming
+        steps={[buildStep({ stage: 'plan', status: 'running' })]}
+      />
+    );
+    expect(screen.getByTestId('reasoning-panel-toggle')).toHaveTextContent(
+      'Thinking (1 step)'
+    );
+  });
+
+  it('formats the stage identifier into a human-readable label without code change', () => {
+    render(
+      <ReasoningPanel
+        streaming
+        steps={[buildStep({ stage: 'verify_execute', status: 'running' })]}
+      />
+    );
+    expect(screen.getByTestId('reasoning-step-verify_execute')).toHaveTextContent(
+      'Verify execute'
+    );
+  });
+
+  it('auto-expands while streaming and shows step content', () => {
+    const steps: ReasoningStep[] = [
+      buildStep({
+        stage: 'plan',
+        label: 'Planning…',
+        reasoning: 'Step 1: scope.',
+        status: 'running',
+      }),
+    ];
+    render(<ReasoningPanel streaming steps={steps} />);
+    expect(screen.getByTestId('reasoning-panel')).toHaveAttribute(
+      'data-open',
+      'true'
+    );
+    expect(screen.getByTestId('reasoning-step-plan')).toHaveTextContent(
+      'Step 1: scope.'
+    );
+  });
+
+  it('starts collapsed when not streaming and toggles on click', () => {
+    render(
+      <ReasoningPanel
+        steps={[buildStep({ stage: 'plan', label: 'Planning…' })]}
+      />
+    );
+    expect(screen.getByTestId('reasoning-panel')).toHaveAttribute(
+      'data-open',
+      'false'
+    );
+    fireEvent.click(screen.getByTestId('reasoning-panel-toggle'));
+    expect(screen.getByTestId('reasoning-panel')).toHaveAttribute(
+      'data-open',
+      'true'
+    );
+  });
+
+  it('exposes step status via data-status for downstream styling', () => {
+    render(
+      <ReasoningPanel
+        streaming
+        steps={[
+          buildStep({ stage: 'plan', status: 'running' }),
+          buildStep({ stage: 'execute', status: 'error' }),
+          buildStep({ stage: 'synthesize', status: 'done' }),
+        ]}
+      />
+    );
+    expect(screen.getByTestId('reasoning-step-plan')).toHaveAttribute(
+      'data-status',
+      'running'
+    );
+    expect(screen.getByTestId('reasoning-step-execute')).toHaveAttribute(
+      'data-status',
+      'error'
+    );
+    expect(screen.getByTestId('reasoning-step-synthesize')).toHaveAttribute(
+      'data-status',
+      'done'
+    );
+  });
+
+  it('renders both reasoning and output blocks when both are present', () => {
+    render(
+      <ReasoningPanel
+        streaming
+        steps={[
+          buildStep({
+            stage: 'execute',
+            reasoning: 'thinking text',
+            output: '{"task": 1}',
+            status: 'running',
+          }),
+        ]}
+      />
+    );
+    const stepEl = screen.getByTestId('reasoning-step-execute');
+    expect(stepEl).toHaveTextContent('thinking text');
+    expect(stepEl).toHaveTextContent('{"task": 1}');
+  });
+
+  it('toggle is keyboard accessible (Enter / Space)', () => {
+    render(
+      <ReasoningPanel
+        steps={[buildStep({ stage: 'plan', label: 'Planning…' })]}
+      />
+    );
+    const toggle = screen.getByTestId('reasoning-panel-toggle');
+    expect(screen.getByTestId('reasoning-panel')).toHaveAttribute(
+      'data-open',
+      'false'
+    );
+    fireEvent.keyDown(toggle, { key: 'Enter' });
+    expect(screen.getByTestId('reasoning-panel')).toHaveAttribute(
+      'data-open',
+      'true'
+    );
+    fireEvent.keyDown(toggle, { key: ' ' });
+    expect(screen.getByTestId('reasoning-panel')).toHaveAttribute(
+      'data-open',
+      'false'
+    );
+  });
+});

--- a/frontend/src/components/chat/__tests__/ReasoningPanel.test.tsx
+++ b/frontend/src/components/chat/__tests__/ReasoningPanel.test.tsx
@@ -81,8 +81,8 @@ describe('ReasoningPanel', () => {
     ];
     render(<ReasoningPanel streaming steps={steps} />);
     expect(screen.getByTestId('reasoning-panel')).toHaveAttribute(
-      'data-open',
-      'true'
+      'data-state',
+      'open'
     );
     expect(screen.getByTestId('reasoning-step-plan')).toHaveTextContent(
       'Step 1: scope.'
@@ -96,13 +96,13 @@ describe('ReasoningPanel', () => {
       />
     );
     expect(screen.getByTestId('reasoning-panel')).toHaveAttribute(
-      'data-open',
-      'false'
+      'data-state',
+      'closed'
     );
     fireEvent.click(screen.getByTestId('reasoning-panel-toggle'));
     expect(screen.getByTestId('reasoning-panel')).toHaveAttribute(
-      'data-open',
-      'true'
+      'data-state',
+      'open'
     );
   });
 
@@ -158,18 +158,18 @@ describe('ReasoningPanel', () => {
     );
     const toggle = screen.getByTestId('reasoning-panel-toggle');
     expect(screen.getByTestId('reasoning-panel')).toHaveAttribute(
-      'data-open',
-      'false'
+      'data-state',
+      'closed'
     );
     fireEvent.keyDown(toggle, { key: 'Enter' });
     expect(screen.getByTestId('reasoning-panel')).toHaveAttribute(
-      'data-open',
-      'true'
+      'data-state',
+      'open'
     );
     fireEvent.keyDown(toggle, { key: ' ' });
     expect(screen.getByTestId('reasoning-panel')).toHaveAttribute(
-      'data-open',
-      'false'
+      'data-state',
+      'closed'
     );
   });
 });

--- a/frontend/src/hooks/__tests__/useChatStream.test.ts
+++ b/frontend/src/hooks/__tests__/useChatStream.test.ts
@@ -67,6 +67,33 @@ describe('useChatStream — legacy non-agentic path (regression)', () => {
     expect(last.reasoning_steps).toBeUndefined();
   });
 
+  // Regression: the live BE actually emits `event_type: null` (not omitted)
+  // for every standard (non-agentic) chunk. A `??` chain in the parser
+  // previously left `eventType` as `null` instead of `undefined`, which
+  // routed the chunk into the forward-compat branch and silently dropped
+  // `delta.content`. The bubble showed sources but no answer.
+  it('treats explicit event_type: null as legacy, not as an unknown event', async () => {
+    const { last } = await drain([
+      {
+        choices: [{ delta: { content: 'Hello, ' } }],
+        event_type: null,
+        stage: null,
+      },
+      {
+        choices: [{ delta: { content: 'world.' } }],
+        event_type: null,
+        stage: null,
+      },
+      {
+        choices: [{ delta: {}, finish_reason: 'stop' }],
+        event_type: null,
+        stage: null,
+      },
+    ]);
+    expect(last.content).toBe('Hello, world.');
+    expect(last.reasoning_steps).toBeUndefined();
+  });
+
   it('extracts citations from sources/results without event_type', async () => {
     const { last } = await drain([
       {

--- a/frontend/src/hooks/__tests__/useChatStream.test.ts
+++ b/frontend/src/hooks/__tests__/useChatStream.test.ts
@@ -1,0 +1,380 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useChatStream } from '../useChatStream';
+import type { ChatMessage } from '../../types/chat';
+
+/**
+ * Build a fake `Response` with a body that yields the supplied SSE chunks.
+ * Each chunk is JSON-stringified and prefixed with `data: ` (server contract).
+ */
+const buildResponse = (chunks: object[], status = 200): Response => {
+  const lines = chunks.map((c) => `data: ${JSON.stringify(c)}\n`).join('');
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(lines));
+      controller.close();
+    },
+  });
+  return new Response(stream, { status });
+};
+
+/**
+ * Drain processStream against a fake stream, accumulating every
+ * updateMessage call so tests can inspect the final assistant payload.
+ */
+const drain = async (chunks: object[], status = 200) => {
+  const { result } = renderHook(() => useChatStream());
+  const updates: Array<Partial<ChatMessage>> = [];
+  const updateMessage = vi.fn(
+    (_id: string, update: Partial<ChatMessage>) => {
+      updates.push({ ...update });
+    }
+  );
+  await act(async () => {
+    result.current.startStream();
+    await result.current.processStream(
+      buildResponse(chunks, status),
+      'assistant-1',
+      updateMessage
+    );
+  });
+  return { updates, last: updates[updates.length - 1] };
+};
+
+describe('useChatStream — legacy non-agentic path (regression)', () => {
+  it('concatenates delta.content when chunks have no event_type', async () => {
+    const { last } = await drain([
+      { choices: [{ delta: { content: 'Hello, ' } }] },
+      { choices: [{ delta: { content: 'world.' } }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+    expect(last.content).toBe('Hello, world.');
+    expect(last.reasoning_steps).toBeUndefined();
+  });
+
+  it('extracts citations from sources/results without event_type', async () => {
+    const { last } = await drain([
+      {
+        choices: [{ delta: { content: 'Answer' } }],
+        citations: {
+          results: [
+            {
+              content: 'snippet',
+              document_name: 'a.pdf',
+              document_type: 'text',
+              score: 0.9,
+              stage: 'rag',
+            },
+          ],
+        },
+      },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+    expect(last.citations).toHaveLength(1);
+    expect(last.citations?.[0]).toMatchObject({
+      source: 'a.pdf',
+      stage: 'rag',
+    });
+  });
+});
+
+describe('useChatStream — agentic streaming path (PR #512)', () => {
+  it('routes final_answer chunks to content and other events to reasoning steps', async () => {
+    const { last } = await drain([
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'stage_start',
+              stage: 'plan',
+              reasoning_content: 'Planning the retrieval strategy…',
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'intermediate_reasoning',
+              stage: 'plan',
+              reasoning_content: 'Step 1: scope discovery. ',
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'intermediate_reasoning',
+              stage: 'plan',
+              reasoning_content: 'Step 2: focused retrieval.',
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'stage_end',
+              stage: 'plan',
+              reasoning_content: 'Plan ready.',
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'stage_start',
+              stage: 'synthesize',
+              reasoning_content: 'Composing the final answer…',
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'final_answer',
+              stage: 'synthesize',
+              content: 'The lion ',
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'final_answer',
+              stage: 'synthesize',
+              content: 'is the king.',
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'stage_end',
+              stage: 'synthesize',
+              reasoning_content: 'Done.',
+            },
+          },
+        ],
+      },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+
+    expect(last.content).toBe('The lion is the king.');
+    expect(last.reasoning_steps).toHaveLength(2);
+    const [planStep, synthStep] = last.reasoning_steps!;
+    expect(planStep).toMatchObject({
+      stage: 'plan',
+      label: 'Planning the retrieval strategy…',
+      summary: 'Plan ready.',
+      status: 'done',
+    });
+    expect(planStep.reasoning).toBe(
+      'Step 1: scope discovery. Step 2: focused retrieval.'
+    );
+    expect(synthStep.stage).toBe('synthesize');
+    expect(synthStep.status).toBe('done');
+  });
+
+  it('attaches citations + metrics when they arrive on the first final_answer chunk', async () => {
+    const { last } = await drain([
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'final_answer',
+              stage: 'synthesize',
+              content: 'ok',
+            },
+          },
+        ],
+        citations: {
+          results: [
+            {
+              content: 'snippet',
+              document_name: 'doc.pdf',
+              document_type: 'text',
+              score: 0.7,
+              stage: 'verify_execute',
+            },
+          ],
+        },
+        metrics: {
+          rag_ttft_ms: 120,
+          llm_ttft_ms: 80,
+          llm_generation_time_ms: 1500,
+        },
+      },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+
+    expect(last.citations?.[0].stage).toBe('verify_execute');
+    expect(last.metrics).toEqual({
+      rag_ttft_ms: 120,
+      llm_ttft_ms: 80,
+      llm_generation_time_ms: 1500,
+    });
+  });
+
+  it('lazy-creates a step when reasoning_content arrives without stage_start', async () => {
+    const { last } = await drain([
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'intermediate_reasoning',
+              stage: 'execute',
+              reasoning_content: 'orphan token',
+            },
+          },
+        ],
+      },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+    expect(last.reasoning_steps).toHaveLength(1);
+    expect(last.reasoning_steps?.[0]).toMatchObject({
+      stage: 'execute',
+      reasoning: 'orphan token',
+      status: 'done',
+    });
+  });
+
+  it('routes intermediate_output to step.output, distinct from reasoning', async () => {
+    const { last } = await drain([
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'stage_start',
+              stage: 'execute',
+              reasoning_content: 'Running tasks…',
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'intermediate_output',
+              stage: 'execute',
+              reasoning_content: '{"tasks":[{"id":1}]}',
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'stage_end',
+              stage: 'execute',
+              reasoning_content: 'Found 4 results.',
+            },
+          },
+        ],
+      },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+    expect(last.reasoning_steps?.[0].output).toBe('{"tasks":[{"id":1}]}');
+    expect(last.reasoning_steps?.[0].reasoning).toBe('');
+  });
+
+  it('marks the message as errored on event_type=error and stops accumulating answer', async () => {
+    const { last } = await drain([
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'stage_start',
+              stage: 'plan',
+              reasoning_content: 'Planning…',
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'error',
+              stage: 'plan',
+              content: 'pipeline failed',
+              reasoning_content: 'detail: timeout',
+            },
+          },
+        ],
+      },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+    expect(last.is_error).toBe(true);
+    expect(last.content).toBe('pipeline failed');
+    const step = last.reasoning_steps?.[0];
+    expect(step?.status).toBe('error');
+    expect(step?.output).toContain('timeout');
+  });
+
+  it('forward-compat: agent_event / unknown event types preserve reasoning_content', async () => {
+    const { last } = await drain([
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'agent_event',
+              stage: 'execute',
+              reasoning_content: 'mid-stage update',
+            },
+          },
+        ],
+      },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+    expect(last.reasoning_steps?.[0].reasoning).toBe('mid-stage update');
+  });
+
+  it('closes any still-running step when the trailing finish_reason chunk arrives', async () => {
+    const { last } = await drain([
+      {
+        choices: [
+          {
+            delta: {
+              event_type: 'stage_start',
+              stage: 'execute',
+              reasoning_content: 'Running tasks…',
+            },
+          },
+        ],
+      },
+      // No matching stage_end — server may drop one if pipeline interrupts.
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+    expect(last.reasoning_steps?.[0].status).toBe('done');
+  });
+});

--- a/frontend/src/hooks/useChatStream.ts
+++ b/frontend/src/hooks/useChatStream.ts
@@ -14,7 +14,12 @@
 // limitations under the License.
 
 import { useState, useRef } from "react";
-import type { ChatMessage, Citation } from "../types/chat";
+import type {
+  AgenticMetrics,
+  ChatMessage,
+  Citation,
+  ReasoningStep,
+} from "../types/chat";
 
 /**
  * Interface representing the state of a chat stream.
@@ -26,19 +31,105 @@ export interface StreamState {
   isTyping: boolean;
 }
 
+/** Server-emitted `event_type` discriminators (see PR #512). */
+type AgenticEventType =
+  | "stage_start"
+  | "stage_end"
+  | "intermediate_reasoning"
+  | "intermediate_output"
+  | "final_reasoning"
+  | "final_answer"
+  | "agent_event"
+  | "error";
+
+const STAGE_START_EVENT: AgenticEventType = "stage_start";
+const STAGE_END_EVENT: AgenticEventType = "stage_end";
+const FINAL_ANSWER_EVENT: AgenticEventType = "final_answer";
+const ERROR_EVENT: AgenticEventType = "error";
+const OUTPUT_EVENT: AgenticEventType = "intermediate_output";
+
+/** Lazy-create or reuse the open step for an incoming chunk's stage. */
+const ensureOpenStep = (
+  steps: ReasoningStep[],
+  stage: string | undefined
+): ReasoningStep => {
+  const last = steps[steps.length - 1];
+  if (last && last.status === "running" && (!stage || last.stage === stage)) {
+    return last;
+  }
+  const next: ReasoningStep = {
+    stage: stage ?? "unknown",
+    reasoning: "",
+    output: "",
+    status: "running",
+  };
+  steps.push(next);
+  return next;
+};
+
+const closeRunningSteps = (
+  steps: ReasoningStep[],
+  status: "done" | "error" = "done"
+) => {
+  for (const step of steps) {
+    if (step.status === "running") step.status = status;
+  }
+};
+
+const parseSources = (raw: unknown): ChatMessage["citations"] => {
+  if (!Array.isArray(raw)) return undefined;
+  const scored: ChatMessage["citations"] = raw.map(
+    (src: Record<string, unknown>) => {
+      const score =
+        typeof src.score === "string" || typeof src.score === "number"
+          ? src.score
+          : typeof src.confidence_score === "string" ||
+              typeof src.confidence_score === "number"
+            ? src.confidence_score
+            : typeof src.similarity_score === "string" ||
+                typeof src.similarity_score === "number"
+              ? src.similarity_score
+              : undefined;
+      const stage =
+        typeof src.stage === "string" && src.stage.length > 0
+          ? src.stage
+          : undefined;
+      return {
+        text: String(src.content || src.text || ""),
+        source: String(
+          src.document_name || src.source || src.title || "Unknown"
+        ),
+        document_type: (src.document_type as Citation["document_type"]) || "text",
+        score,
+        stage,
+      };
+    }
+  );
+  return scored;
+};
+
 /**
  * Custom hook for managing chat streaming functionality.
- * 
- * Provides utilities to start, process, and stop streaming chat responses.
- * Handles streaming text content, citations, and error states.
- * 
+ *
+ * Handles two SSE contracts on `/generate`:
+ *
+ * 1. **Standard / non-agentic** (and `agentic` with `enable_streaming=false`):
+ *    chunks have no `event_type`; `delta.content` is concatenated into the
+ *    user-facing answer; citations attach on the final chunk.
+ *
+ * 2. **Agentic streaming** (PR #512): each chunk carries an `event_type`
+ *    that discriminates whether the payload is final-answer text, reasoning
+ *    trace, intermediate output, or a stage boundary. The hook builds a
+ *    `reasoning_steps[]` trace alongside the final answer; citations and
+ *    metrics arrive on the first `final_answer` chunk.
+ *
  * @returns An object containing stream state and control functions
- * 
+ *
  * @example
  * ```tsx
  * const { streamState, startStream, processStream, stopStream } = useChatStream();
  * const controller = startStream();
- * await processStream(response, messageId, updateMessage, threshold);
+ * await processStream(response, messageId, updateMessage);
  * ```
  */
 export const useChatStream = () => {
@@ -79,9 +170,20 @@ export const useChatStream = () => {
     let buffer = "";
     let content = "";
     let latestCitations: ChatMessage["citations"] = [];
-    
-    // Detect if this is an error response based on HTTP status code
-    const isError = response.status >= 400;
+    const steps: ReasoningStep[] = [];
+    let metrics: AgenticMetrics | undefined;
+    let isError = response.status >= 400;
+
+    const emit = () => {
+      updateMessage(assistantId, {
+        content,
+        citations:
+          latestCitations && latestCitations.length ? latestCitations : undefined,
+        is_error: isError,
+        reasoning_steps: steps.length ? [...steps] : undefined,
+        metrics,
+      });
+    };
 
     try {
       while (true) {
@@ -96,49 +198,109 @@ export const useChatStream = () => {
           if (!line.startsWith("data: ")) continue;
 
           const json = JSON.parse(line.slice(6));
-          const delta = json.choices?.[0]?.delta?.content;
-          if (delta) content += delta;
+          const choice = json.choices?.[0];
+          const delta = choice?.delta ?? {};
+          const eventType: AgenticEventType | undefined =
+            (delta.event_type as AgenticEventType | undefined) ??
+            (choice?.message?.event_type as AgenticEventType | undefined) ??
+            (json.event_type as AgenticEventType | undefined);
+          const stage: string | undefined =
+            (typeof delta.stage === "string" ? delta.stage : undefined) ??
+            (typeof choice?.message?.stage === "string"
+              ? choice.message.stage
+              : undefined) ??
+            (typeof json.stage === "string" ? json.stage : undefined);
 
-          // Extract citations from any expected location
+          const reasoningContent: string | undefined =
+            typeof delta.reasoning_content === "string"
+              ? delta.reasoning_content
+              : undefined;
+          const deltaContent: string | undefined =
+            typeof delta.content === "string" ? delta.content : undefined;
+
+          // Branch on event_type. When event_type is absent (standard /
+          // non-agentic stream, or pre-#512 backend), fall through the
+          // legacy path: append delta.content to the answer.
+          if (eventType === STAGE_START_EVENT) {
+            closeRunningSteps(steps);
+            steps.push({
+              stage: stage ?? "unknown",
+              label: reasoningContent || undefined,
+              reasoning: "",
+              output: "",
+              status: "running",
+            });
+          } else if (eventType === STAGE_END_EVENT) {
+            const open = steps[steps.length - 1];
+            if (open && open.status === "running") {
+              if (reasoningContent) open.summary = reasoningContent;
+              open.status = "done";
+            }
+          } else if (
+            eventType === "intermediate_reasoning" ||
+            eventType === "final_reasoning"
+          ) {
+            if (reasoningContent) {
+              const step = ensureOpenStep(steps, stage);
+              step.reasoning += reasoningContent;
+            }
+          } else if (eventType === OUTPUT_EVENT) {
+            if (reasoningContent) {
+              const step = ensureOpenStep(steps, stage);
+              step.output += reasoningContent;
+            }
+          } else if (eventType === ERROR_EVENT) {
+            isError = true;
+            if (deltaContent) content += deltaContent;
+            if (reasoningContent) {
+              const step = ensureOpenStep(steps, stage);
+              step.output += reasoningContent;
+              step.status = "error";
+            } else {
+              closeRunningSteps(steps, "error");
+            }
+          } else if (eventType === FINAL_ANSWER_EVENT) {
+            if (deltaContent) content += deltaContent;
+          } else if (eventType !== undefined) {
+            // agent_event or future / unknown event types:
+            // forward-compat — capture any reasoning_content into the
+            // current step so we don't lose information.
+            if (reasoningContent) {
+              const step = ensureOpenStep(steps, stage);
+              step.reasoning += reasoningContent;
+            }
+          } else {
+            // Legacy non-agentic chunk: no event_type discriminator.
+            if (deltaContent) content += deltaContent;
+          }
+
+          // Citations and metrics may arrive on any agentic chunk, but the
+          // server contract pins them to the first `final_answer` chunk.
+          // We accept whichever arrives first / most recent.
           const sources =
             json.citations?.results ??
             json.sources?.results ??
-            json.choices?.[0]?.message?.citations ??
-            json.choices?.[0]?.message?.sources ??
+            choice?.message?.citations ??
+            choice?.message?.sources ??
             [];
+          const parsed = parseSources(sources);
+          if (parsed && parsed.length) latestCitations = parsed;
 
-          if (Array.isArray(sources)) {
-            const scored: ChatMessage["citations"] = sources.map((src: Record<string, unknown>) => {
-              const score = typeof src.score === 'string' || typeof src.score === 'number' ? src.score :
-                           typeof src.confidence_score === 'string' || typeof src.confidence_score === 'number' ? src.confidence_score :
-                           typeof src.similarity_score === 'string' || typeof src.similarity_score === 'number' ? src.similarity_score :
-                           undefined;
-              // `stage` is propagated as an opaque string so future agentic
-              // pipeline stages render without requiring frontend changes.
-              const stage = typeof src.stage === 'string' && src.stage.length > 0
-                ? src.stage
-                : undefined;
-              return {
-                text: String(src.content || src.text || ""),
-                source: String(src.document_name || src.source || src.title || "Unknown"),
-                document_type: (src.document_type as Citation["document_type"]) || "text",
-                score,
-                stage,
-              };
-            });
-
-            // Backend already filters by confidence threshold, so no need to filter here
-            latestCitations = scored;
+          if (json.metrics && typeof json.metrics === "object") {
+            metrics = { ...(metrics ?? {}), ...(json.metrics as AgenticMetrics) };
           }
 
-          updateMessage(assistantId, {
-            content,
-            citations: latestCitations && latestCitations.length ? latestCitations : undefined,
-            is_error: isError,
-          });
+          emit();
 
-          if (json.choices?.[0]?.finish_reason === "stop") {
-            setStreamState({ content, citations: latestCitations, error: null, isTyping: false });
+          if (choice?.finish_reason === "stop") {
+            closeRunningSteps(steps);
+            emit();
+            setStreamState({
+              content,
+              citations: latestCitations,
+              error: null,
+              isTyping: false,
+            });
             return;
           }
         }

--- a/frontend/src/hooks/useChatStream.ts
+++ b/frontend/src/hooks/useChatStream.ts
@@ -200,10 +200,19 @@ export const useChatStream = () => {
           const json = JSON.parse(line.slice(6));
           const choice = json.choices?.[0];
           const delta = choice?.delta ?? {};
+          // Standard (non-agentic) responses ship `event_type: null` on
+          // every chunk; we collapse that to `undefined` so the dispatch
+          // below routes them through the legacy path that concatenates
+          // `delta.content` into the assistant message.
+          const rawEventType =
+            (delta.event_type as AgenticEventType | null | undefined) ??
+            (choice?.message?.event_type as
+              | AgenticEventType
+              | null
+              | undefined) ??
+            (json.event_type as AgenticEventType | null | undefined);
           const eventType: AgenticEventType | undefined =
-            (delta.event_type as AgenticEventType | undefined) ??
-            (choice?.message?.event_type as AgenticEventType | undefined) ??
-            (json.event_type as AgenticEventType | undefined);
+            rawEventType ?? undefined;
           const stage: string | undefined =
             (typeof delta.stage === "string" ? delta.stage : undefined) ??
             (typeof choice?.message?.stage === "string"

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -58,6 +58,50 @@ export interface ImageContent {
 export type MessageContent = string | (TextContent | ImageContent)[];
 
 /**
+ * One node-level entry in the agentic-RAG reasoning trace.
+ *
+ * Built incrementally by `useChatStream` from `event_type` chunks of an
+ * agentic `/generate` SSE stream. Standard (non-agentic) responses leave
+ * `reasoning_steps` undefined.
+ *
+ * The `stage` is treated as an opaque string (e.g. `"plan"`, `"execute"`,
+ * `"synthesize"`, `"verify"`, `"verify_execute"`, `"initial_retrieval"`),
+ * so any future graph node renders without code changes.
+ */
+export interface ReasoningStep {
+  /** Graph node identifier supplied by the server's `stage` field. */
+  stage: string;
+  /** One-liner from the matching `stage_start` chunk. */
+  label?: string;
+  /** One-liner from the matching `stage_end` chunk. */
+  summary?: string;
+  /**
+   * Concatenated `reasoning_content` from `intermediate_reasoning` and
+   * `final_reasoning` chunks for this stage.
+   */
+  reasoning: string;
+  /**
+   * Concatenated `reasoning_content` from `intermediate_output` chunks
+   * for this stage (planner / verifier JSON, per-task answers, ...).
+   */
+  output: string;
+  /** Lifecycle: open between `stage_start` and `stage_end`. */
+  status: "running" | "done" | "error";
+}
+
+/**
+ * TTFT-style timings emitted on the trailing `finish_reason: "stop"` chunk.
+ * All fields are optional so future metrics added by the server flow
+ * through unchanged.
+ */
+export interface AgenticMetrics {
+  rag_ttft_ms?: number;
+  llm_ttft_ms?: number;
+  llm_generation_time_ms?: number;
+  [key: string]: number | undefined;
+}
+
+/**
  * Represents a message in the chat conversation.
  */
 export interface ChatMessage {
@@ -67,6 +111,13 @@ export interface ChatMessage {
   timestamp: string;
   citations?: Citation[];
   is_error?: boolean;
+  /**
+   * Agentic-RAG reasoning trace, populated only when the server emits
+   * `event_type` chunks (see PR #512). Undefined for standard responses.
+   */
+  reasoning_steps?: ReasoningStep[];
+  /** Trailing-chunk metrics from agentic streaming. */
+  metrics?: AgenticMetrics;
 }
 
 /**


### PR DESCRIPTION
## Summary

<img width="2156" height="1163" alt="screenshot2" src="https://github.com/user-attachments/assets/6e026105-382b-4165-9e81-7120ae3babee" />

<img width="2156" height="2856" alt="screenshot1 (1)" src="https://github.com/user-attachments/assets/cc1ea2e8-4124-47a4-929c-edf447fb33e9" />

Adds frontend support for the Agentic RAG streaming contract introduced in #512: `delta.reasoning_content` and `event_type` are parsed alongside the existing `delta.content`, then rendered as a collapsible "Thinking / Steps" panel above the assistant's answer. Standard (non-agentic) responses are unchanged.

- **`useChatStream` parser** — branches on `event_type` (`stage_start`, `stage_end`, `intermediate_reasoning`, `intermediate_output`, `final_reasoning`, `final_answer`, `error`, `agent_event`) and builds a `reasoning_steps[]` trace on the assistant message. Citations and metrics still attach on the first `final_answer` chunk per the spec. Forward-compat path for unknown event types preserves their `reasoning_content`. Legacy non-agentic chunks (no `event_type`) keep the OpenAI-style "concat `delta.content`" behavior.
- **`ReasoningPanel`** — new component, auto-expands while streaming, collapses to "Thought for N steps" on completion, click/keyboard re-expand. Stage labels pass through `useCitationUtils.formatStage` so any future graph node renders without code changes. Per-step running/done/error states with the corresponding icon.
- **`ChatMessageBubble`** — wires the panel into both the live (`StreamingMessage`) and persisted (`RegularMessage`) paths for assistant messages.
- **KUI alignment** (#ca4952fd) — uses `AnimatedChevron`, `var(--animate-spin)`, `var(--font-mono)`, and the semantic `text-color-feedback-{success,danger}` tokens instead of hand-rolled CSS.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm run test:run` — 701/701 pass; new coverage for the parser (8 tests, both agentic + legacy paths) and the panel (9 tests, render / collapse / a11y / unknown-stage formatting)
- [x] End-to-end against #512: planner emits `intermediate_reasoning`+`intermediate_output`, synthesize emits `final_reasoning`+`final_answer`, panel renders all four stages with summaries, answer streams into the bubble, panel auto-collapses on `finish_reason: "stop"`
- [x] Standard (non-agentic) regression: chunks without `event_type` still concat into the answer; no panel rendered

## Related

- Backend: #512 (Agentic RAG streaming, `event_type` / `reasoning_content` contract)
- UI baseline: #514 (agentic toggle + citation `stage` field) — merged