### PR TITLE
Emit Elasticsearch-shaped filter_expr when the deployment uses ES

### DIFF
--- a/frontend/src/hooks/useMessageSubmit.ts
+++ b/frontend/src/hooks/useMessageSubmit.ts
@@ -21,10 +21,58 @@ import { useCollectionsStore } from "../store/useCollectionsStore";
 import { useStreamingStore } from "../store/useStreamingStore";
 import { useImageAttachmentStore } from "../store/useImageAttachmentStore";
 import { useCollections } from "../api/useCollectionsApi";
+import { useHealthStatus } from "../api/useHealthApi";
 import { useUUID } from "./useUUID";
 import type { GenerateRequest } from "../types/requests";
 import type { ChatMessage, Filter, MessageContent, TextContent, ImageContent } from "../types/chat";
 import type { Collection } from "../types/collections";
+import {
+  buildFieldTypeMap,
+  compileElasticsearchFilter,
+  compileMilvusFilter,
+  vectorStoreFromHealthService,
+} from "../utils/filterExpression";
+
+/**
+ * Build the per-request `filter_expr` value in the wire format the
+ * configured backend expects (Milvus string vs. Elasticsearch list-of-dicts).
+ *
+ * The deployment is mono-store: we pick the backend from the first
+ * `/health.databases[].service` entry. If health hasn't loaded yet (or the
+ * label is unrecognized), we default to Milvus to preserve pre-existing
+ * behavior.
+ *
+ * Exported for direct unit testing of the wire-format contract.
+ */
+export function buildFilterExpression(
+  filters: Filter[],
+  selectedCollections: string[],
+  allCollections: Collection[],
+  healthServiceLabel: string | undefined
+): GenerateRequest["filter_expr"] {
+  if (!filters.length) return undefined;
+
+  const schemas = selectedCollections
+    .map(
+      (name) =>
+        allCollections.find((c) => c.collection_name === name)
+          ?.metadata_schema ?? []
+    )
+    .map((schema) =>
+      schema.map((field) => ({
+        name: field.name,
+        type: field.type as string,
+        array_type: field.array_type ?? undefined,
+      }))
+    );
+  const fieldTypes = buildFieldTypeMap(schemas);
+
+  const backend = vectorStoreFromHealthService(healthServiceLabel) ?? "milvus";
+  if (backend === "elasticsearch") {
+    return compileElasticsearchFilter(filters);
+  }
+  return compileMilvusFilter(filters, fieldTypes);
+}
 
 /**
  * Utility function to remove undefined, null, empty string, and empty array values from a request object.
@@ -94,6 +142,10 @@ export const useMessageSubmit = () => {
   const { selectedCollections } = useCollectionsStore();
   const { attachedImages, clearAllImages } = useImageAttachmentStore();
   const { data: allCollections = [] } = useCollections();
+  // The deployment is mono-store (Milvus or Elasticsearch). We pull the
+  // backend label from /health.databases[0].service and translate that
+  // into the wire format for filter_expr below.
+  const { data: health } = useHealthStatus();
   const settings = useSettingsStore();
   const { generateUUID } = useUUID();
   const { shouldDisableHealthFeatures, isHealthLoading } = useHealthDependentFeatures();
@@ -139,80 +191,17 @@ export const useMessageSubmit = () => {
       stop: settings.stopTokens,
       confidence_threshold: settings.confidenceScoreThreshold,
       agentic,
-      filter_expr: filters.length
-        ? filters
-            .map((f: Filter, index: number) => {
-              // Create a map of field names to their types and array_types from selected collections
-              const fieldTypeMap = new Map<string, string>();
-              const fieldArrayTypeMap = new Map<string, string>();
-              selectedCollections.forEach(collectionName => {
-                const collection = allCollections.find((col: Collection) => col.collection_name === collectionName);
-                if (collection?.metadata_schema) {
-                  collection.metadata_schema.forEach((field: { name: string; type: string; description: string; array_type?: string }) => {
-                    fieldTypeMap.set(field.name, field.type);
-                    if (field.array_type) {
-                      fieldArrayTypeMap.set(field.name, field.array_type);
-                    }
-                  });
-                }
-              });
-              
-              const isArrayField = fieldTypeMap.get(f.field) === 'array';
-              const arrayElementType = fieldArrayTypeMap.get(f.field);
-              
-              const formatValue = (value: string | number | boolean | (string | number | boolean)[], isArrayField = false): string => {
-                if (Array.isArray(value)) {
-                  // Handle array values for operators like "in", "not in", "=", "!="
-                  const formattedItems = value.map(item => {
-                    if (typeof item === 'boolean' || typeof item === 'number') {
-                      return String(item);
-                    }
-                    // For array fields, check the array_type to determine if we should quote string values
-                    if (isArrayField && arrayElementType) {
-                      // Don't quote if array elements are numeric or boolean types
-                      if (['integer', 'float', 'number', 'boolean'].includes(arrayElementType)) {
-                        return String(item);
-                      }
-                    }
-                    // Quote string values (default behavior)
-                    return `"${item}"`;
-                  }).join(', ');
-                  return `[${formattedItems}]`;
-                }
-                if (typeof value === 'boolean' || typeof value === 'number') {
-                  return String(value); // true/false/numbers without quotes
-                }
-                return `"${value}"`; // strings with quotes
-              };
-
-              let filterExpression = '';
-              // Handle special operators
-              switch (f.operator) {
-                case 'array_contains':
-                case 'array_contains_all':
-                case 'array_contains_any':
-                  // Use function call syntax: array_contains(field, value)
-                  filterExpression = `${f.operator}(content_metadata["${f.field}"], ${formatValue(f.value, isArrayField)})`;
-                  break;
-                default:
-                  filterExpression = `content_metadata["${f.field}"] ${f.operator} ${formatValue(f.value, isArrayField)}`;
-              }
-              
-              // Add logical operator prefix for all filters except the first one
-              if (index > 0) {
-                const logicalOp = f.logicalOperator || 'OR'; // Default to OR if not specified
-                return ` ${logicalOp.toLowerCase()} ${filterExpression}`;
-              }
-              
-              return filterExpression;
-            })
-            .join('')
-        : undefined
+      filter_expr: buildFilterExpression(
+        filters,
+        selectedCollections,
+        allCollections,
+        health?.databases?.[0]?.service
+      ),
     };
     
     // Clean the request object to remove undefined/empty values
     return cleanRequestObject(rawRequest);
-  }, [selectedCollections, allCollections, settings, filters]);
+  }, [selectedCollections, allCollections, settings, filters, health?.databases]);
 
   const handleSubmit = useCallback(async () => {
     // Allow submit if there's text OR attached images

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -74,7 +74,7 @@ export interface ChatMessage {
  */
 export interface Filter {
   field: string;
-  operator: "=" | "!=" | ">" | "<" | ">=" | "<=" | "in" | "includes" | "does not include" | "like" | "not in" | "before" | "after" | "array_contains" | "array_contains_all" | "array_contains_any";
+  operator: "==" | "=" | "!=" | ">" | "<" | ">=" | "<=" | "in" | "includes" | "does not include" | "like" | "not in" | "before" | "after" | "array_contains" | "array_contains_all" | "array_contains_any";
   value: string | number | boolean | (string | number | boolean)[];
   // Logical operator to join this filter with the previous one (undefined for first filter)
   logicalOperator?: "AND" | "OR";

--- a/frontend/src/types/requests.ts
+++ b/frontend/src/types/requests.ts
@@ -53,8 +53,14 @@ export interface GenerateRequest {
   vlm_endpoint?: string;
   vdb_endpoint?: string;
   
-  // Optional other fields
-  filter_expr?: string;
+  // Optional other fields.
+  //
+  // `filter_expr` shape depends on the configured vector store:
+  //  - Milvus  → string expression (`content_metadata["x"] op v`).
+  //  - Elasticsearch → list of dicts (Elasticsearch Query DSL with field
+  //    paths in the form `metadata.content_metadata.<name>.keyword`).
+  // See docs/custom-metadata.md for the full contract.
+  filter_expr?: string | Array<Record<string, unknown>>;
   stop?: string[];
 
   /**

--- a/frontend/src/utils/__tests__/filterExpression.test.ts
+++ b/frontend/src/utils/__tests__/filterExpression.test.ts
@@ -1,0 +1,413 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from "vitest";
+import type { Filter } from "../../types/chat";
+import {
+  buildFieldTypeMap,
+  compileElasticsearchFilter,
+  compileMilvusFilter,
+  vectorStoreFromHealthService,
+} from "../filterExpression";
+
+const emptyTypes = buildFieldTypeMap([]);
+
+describe("vectorStoreFromHealthService", () => {
+  it.each([
+    ["Elasticsearch", "elasticsearch"],
+    ["elasticsearch", "elasticsearch"],
+    ["ES", "elasticsearch"],
+    ["Milvus", "milvus"],
+    ["milvus", "milvus"],
+  ])("normalizes %s to %s", (label, expected) => {
+    expect(vectorStoreFromHealthService(label)).toBe(expected);
+  });
+
+  it("returns undefined for unrecognized labels", () => {
+    expect(vectorStoreFromHealthService(undefined)).toBeUndefined();
+    expect(vectorStoreFromHealthService("")).toBeUndefined();
+    expect(vectorStoreFromHealthService("postgres")).toBeUndefined();
+  });
+});
+
+describe("buildFieldTypeMap", () => {
+  it("flattens schemas across multiple collections, last write wins", () => {
+    const result = buildFieldTypeMap([
+      [{ name: "a", type: "string" }],
+      [{ name: "b", type: "array", array_type: "integer" }],
+    ]);
+    expect(result.fieldType.get("a")).toBe("string");
+    expect(result.fieldType.get("b")).toBe("array");
+    expect(result.arrayElementType.get("b")).toBe("integer");
+    expect(result.arrayElementType.has("a")).toBe(false);
+  });
+});
+
+// =============================================================================
+// MILVUS — REGRESSION: behavior must match the pre-PR implementation exactly,
+// since callers that hit a Milvus deployment must continue to receive the same
+// filter_expr string they always have.
+// =============================================================================
+
+describe("compileMilvusFilter", () => {
+  it("returns undefined for an empty list", () => {
+    expect(compileMilvusFilter([], emptyTypes)).toBeUndefined();
+  });
+
+  it("emits Milvus syntax for a string equality clause", () => {
+    const filters: Filter[] = [
+      { field: "category", operator: "==", value: "AI" },
+    ];
+    expect(compileMilvusFilter(filters, emptyTypes)).toBe(
+      'content_metadata["category"] == "AI"'
+    );
+  });
+
+  it("does not quote numeric values", () => {
+    const filters: Filter[] = [
+      { field: "priority", operator: ">", value: 5 },
+    ];
+    expect(compileMilvusFilter(filters, emptyTypes)).toBe(
+      'content_metadata["priority"] > 5'
+    );
+  });
+
+  it("formats array values with proper element quoting", () => {
+    const filters: Filter[] = [
+      { field: "tags", operator: "in", value: ["ai", "ml"] },
+    ];
+    expect(compileMilvusFilter(filters, emptyTypes)).toBe(
+      'content_metadata["tags"] in ["ai", "ml"]'
+    );
+  });
+
+  it("leaves numeric array elements unquoted when the field is array<integer>", () => {
+    const types = buildFieldTypeMap([
+      [{ name: "scores", type: "array", array_type: "integer" }],
+    ]);
+    const filters: Filter[] = [
+      { field: "scores", operator: "in", value: [1, 2, 3] },
+    ];
+    expect(compileMilvusFilter(filters, types)).toBe(
+      'content_metadata["scores"] in [1, 2, 3]'
+    );
+  });
+
+  it("uses function-call syntax for array_contains family operators", () => {
+    const filters: Filter[] = [
+      { field: "tags", operator: "array_contains", value: "engineering" },
+    ];
+    expect(compileMilvusFilter(filters, emptyTypes)).toBe(
+      'array_contains(content_metadata["tags"], "engineering")'
+    );
+  });
+
+  it("joins multiple clauses with the per-filter logical operator (default OR)", () => {
+    const filters: Filter[] = [
+      { field: "category", operator: "==", value: "AI" },
+      {
+        field: "priority",
+        operator: ">",
+        value: 5,
+        logicalOperator: "AND",
+      },
+      { field: "category", operator: "==", value: "ML" },
+    ];
+    expect(compileMilvusFilter(filters, emptyTypes)).toBe(
+      'content_metadata["category"] == "AI" and content_metadata["priority"] > 5 or content_metadata["category"] == "ML"'
+    );
+  });
+});
+
+// =============================================================================
+// ELASTICSEARCH — new behavior. Must match the contract documented in
+// docs/custom-metadata.md#elasticsearch-filter-example.
+// =============================================================================
+
+describe("compileElasticsearchFilter", () => {
+  it("returns undefined for an empty list", () => {
+    expect(compileElasticsearchFilter([])).toBeUndefined();
+  });
+
+  it("emits a `term` clause for string equality with the .keyword field path", () => {
+    expect(
+      compileElasticsearchFilter([
+        { field: "category", operator: "==", value: "AI" },
+      ])
+    ).toEqual([
+      { term: { "metadata.content_metadata.category.keyword": "AI" } },
+    ]);
+  });
+
+  it("alias `=` produces the same `term` clause as `==`", () => {
+    expect(
+      compileElasticsearchFilter([
+        { field: "category", operator: "=", value: "AI" },
+      ])
+    ).toEqual([
+      { term: { "metadata.content_metadata.category.keyword": "AI" } },
+    ]);
+  });
+
+  it("wraps inequality in bool.must_not", () => {
+    expect(
+      compileElasticsearchFilter([
+        { field: "status", operator: "!=", value: "draft" },
+      ])
+    ).toEqual([
+      {
+        bool: {
+          must_not: [
+            { term: { "metadata.content_metadata.status.keyword": "draft" } },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it.each([
+    [">", "gt"],
+    [">=", "gte"],
+    ["<", "lt"],
+    ["<=", "lte"],
+  ] as const)(
+    "maps numeric comparison %s to range.%s",
+    (operator, esKey) => {
+      const result = compileElasticsearchFilter([
+        { field: "priority", operator, value: 5 },
+      ]);
+      expect(result).toEqual([
+        { range: { "metadata.content_metadata.priority.keyword": { [esKey]: 5 } } },
+      ]);
+    }
+  );
+
+  it("maps relative datetime operators to range with gt/lt", () => {
+    expect(
+      compileElasticsearchFilter([
+        { field: "created", operator: "after", value: "2025-01-01" },
+      ])
+    ).toEqual([
+      {
+        range: {
+          "metadata.content_metadata.created.keyword": { gt: "2025-01-01" },
+        },
+      },
+    ]);
+    expect(
+      compileElasticsearchFilter([
+        { field: "created", operator: "before", value: "2025-01-01" },
+      ])
+    ).toEqual([
+      {
+        range: {
+          "metadata.content_metadata.created.keyword": { lt: "2025-01-01" },
+        },
+      },
+    ]);
+  });
+
+  it("maps `in` to terms and `not in` to bool.must_not.terms", () => {
+    expect(
+      compileElasticsearchFilter([
+        { field: "tags", operator: "in", value: ["ai", "ml"] },
+      ])
+    ).toEqual([
+      {
+        terms: {
+          "metadata.content_metadata.tags.keyword": ["ai", "ml"],
+        },
+      },
+    ]);
+    expect(
+      compileElasticsearchFilter([
+        { field: "tags", operator: "not in", value: ["deprecated"] },
+      ])
+    ).toEqual([
+      {
+        bool: {
+          must_not: [
+            {
+              terms: {
+                "metadata.content_metadata.tags.keyword": ["deprecated"],
+              },
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it("translates Milvus `like` wildcards (% → *, _ → ?) to ES `wildcard`", () => {
+    expect(
+      compileElasticsearchFilter([
+        { field: "title", operator: "like", value: "policy_%" },
+      ])
+    ).toEqual([
+      {
+        wildcard: {
+          "metadata.content_metadata.title.keyword": "policy?*",
+        },
+      },
+    ]);
+  });
+
+  it("emits term for array_contains and bool.must of terms for array_contains_all", () => {
+    expect(
+      compileElasticsearchFilter([
+        { field: "tags", operator: "array_contains", value: "engineering" },
+      ])
+    ).toEqual([
+      {
+        term: {
+          "metadata.content_metadata.tags.keyword": "engineering",
+        },
+      },
+    ]);
+    expect(
+      compileElasticsearchFilter([
+        {
+          field: "tags",
+          operator: "array_contains_all",
+          value: ["tech", "ai"],
+        },
+      ])
+    ).toEqual([
+      {
+        bool: {
+          must: [
+            { term: { "metadata.content_metadata.tags.keyword": "tech" } },
+            { term: { "metadata.content_metadata.tags.keyword": "ai" } },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it("emits terms for array_contains_any / includes; bool.must_not for `does not include`", () => {
+    expect(
+      compileElasticsearchFilter([
+        {
+          field: "tags",
+          operator: "array_contains_any",
+          value: ["tech", "ai"],
+        },
+      ])
+    ).toEqual([
+      {
+        terms: { "metadata.content_metadata.tags.keyword": ["tech", "ai"] },
+      },
+    ]);
+    expect(
+      compileElasticsearchFilter([
+        { field: "tags", operator: "includes", value: ["alpha"] },
+      ])
+    ).toEqual([
+      { terms: { "metadata.content_metadata.tags.keyword": ["alpha"] } },
+    ]);
+    expect(
+      compileElasticsearchFilter([
+        {
+          field: "tags",
+          operator: "does not include",
+          value: ["deprecated"],
+        },
+      ])
+    ).toEqual([
+      {
+        bool: {
+          must_not: [
+            {
+              terms: {
+                "metadata.content_metadata.tags.keyword": ["deprecated"],
+              },
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  // Grouping rules ----------------------------------------------------------
+
+  it("produces a flat list when all filters are AND-joined (matches doc example)", () => {
+    expect(
+      compileElasticsearchFilter([
+        { field: "category", operator: "==", value: "AI" },
+        {
+          field: "priority",
+          operator: ">",
+          value: 5,
+          logicalOperator: "AND",
+        },
+      ])
+    ).toEqual([
+      { term: { "metadata.content_metadata.category.keyword": "AI" } },
+      {
+        range: {
+          "metadata.content_metadata.priority.keyword": { gt: 5 },
+        },
+      },
+    ]);
+  });
+
+  it("wraps once in bool.should when all subsequent joins are OR", () => {
+    const result = compileElasticsearchFilter([
+      { field: "category", operator: "==", value: "AI" },
+      {
+        field: "category",
+        operator: "==",
+        value: "ML",
+        logicalOperator: "OR",
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        bool: {
+          should: [
+            { term: { "metadata.content_metadata.category.keyword": "AI" } },
+            { term: { "metadata.content_metadata.category.keyword": "ML" } },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it("groups AND-runs inside bool.should for mixed AND/OR (default Milvus precedence)", () => {
+    // (a==1) OR (b==2 AND c==3) — the AND-run after the OR is one group.
+    const result = compileElasticsearchFilter([
+      { field: "a", operator: "==", value: 1 },
+      { field: "b", operator: "==", value: 2, logicalOperator: "OR" },
+      { field: "c", operator: "==", value: 3, logicalOperator: "AND" },
+    ]);
+    expect(result).toEqual([
+      {
+        bool: {
+          should: [
+            { term: { "metadata.content_metadata.a.keyword": 1 } },
+            {
+              bool: {
+                must: [
+                  { term: { "metadata.content_metadata.b.keyword": 2 } },
+                  { term: { "metadata.content_metadata.c.keyword": 3 } },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ]);
+  });
+});

--- a/frontend/src/utils/filterExpression.ts
+++ b/frontend/src/utils/filterExpression.ts
@@ -1,0 +1,284 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Filter } from "../types/chat";
+
+/**
+ * Vector-store backends the UI knows how to serialize filters for. Detected
+ * from `/health.databases[].service` (Elasticsearch | Milvus).
+ */
+export type VectorStoreKind = "milvus" | "elasticsearch";
+
+/** Per-field type info needed to format values correctly (quoting, etc.). */
+export interface FieldTypeMap {
+  /** field name -> type ("string" | "integer" | "float" | "number" | "boolean" | "datetime" | "array") */
+  fieldType: Map<string, string>;
+  /** field name -> array element type (set only when fieldType === "array") */
+  arrayElementType: Map<string, string>;
+}
+
+/** Pre-build field type maps from the selected collections' metadata schema. */
+export const buildFieldTypeMap = (
+  schemas: Array<
+    Array<{
+      name: string;
+      type: string;
+      array_type?: string | null | undefined;
+    }>
+  >
+): FieldTypeMap => {
+  const fieldType = new Map<string, string>();
+  const arrayElementType = new Map<string, string>();
+  for (const schema of schemas) {
+    for (const field of schema) {
+      fieldType.set(field.name, field.type);
+      if (field.array_type) {
+        arrayElementType.set(field.name, field.array_type);
+      }
+    }
+  }
+  return { fieldType, arrayElementType };
+};
+
+/**
+ * Identify a backend from the `/health.databases[].service` string. The BE
+ * uses the human-readable label ("Elasticsearch" / "Milvus"), so we
+ * normalize case-insensitively.
+ */
+export const vectorStoreFromHealthService = (
+  service: string | undefined
+): VectorStoreKind | undefined => {
+  if (!service) return undefined;
+  const lower = service.toLowerCase();
+  if (lower.includes("elasticsearch") || lower === "es") return "elasticsearch";
+  if (lower.includes("milvus")) return "milvus";
+  return undefined;
+};
+
+// =============================================================================
+// MILVUS FILTER COMPILER
+// =============================================================================
+// Milvus filter_expr is a single string expression using
+// `content_metadata["field"] op value` syntax with AND/OR (flat, default
+// precedence). See docs/custom-metadata.md "Filter Expression Syntax".
+
+const formatMilvusValue = (
+  value: Filter["value"],
+  isArrayField: boolean,
+  arrayElementType: string | undefined
+): string => {
+  if (Array.isArray(value)) {
+    const items = value.map((item) => {
+      if (typeof item === "boolean" || typeof item === "number") {
+        return String(item);
+      }
+      // For array-typed fields, leave numeric/boolean array elements
+      // unquoted — quoting them would break Milvus's type coercion.
+      if (
+        isArrayField &&
+        arrayElementType &&
+        ["integer", "float", "number", "boolean"].includes(arrayElementType)
+      ) {
+        return String(item);
+      }
+      return `"${item}"`;
+    });
+    return `[${items.join(", ")}]`;
+  }
+  if (typeof value === "boolean" || typeof value === "number") {
+    return String(value);
+  }
+  return `"${value}"`;
+};
+
+const compileMilvusClause = (
+  f: Filter,
+  fieldTypes: FieldTypeMap
+): string => {
+  const isArrayField = fieldTypes.fieldType.get(f.field) === "array";
+  const arrayElementType = fieldTypes.arrayElementType.get(f.field);
+  const formatted = formatMilvusValue(f.value, isArrayField, arrayElementType);
+
+  switch (f.operator) {
+    case "array_contains":
+    case "array_contains_all":
+    case "array_contains_any":
+      return `${f.operator}(content_metadata["${f.field}"], ${formatted})`;
+    default:
+      return `content_metadata["${f.field}"] ${f.operator} ${formatted}`;
+  }
+};
+
+/**
+ * Compile a list of UI filters to a Milvus `filter_expr` string. Returns
+ * `undefined` for an empty input (so the caller can omit the field).
+ *
+ * Logical operators apply between clauses with default Milvus precedence
+ * (no parenthesization), matching pre-existing behavior.
+ */
+export const compileMilvusFilter = (
+  filters: Filter[],
+  fieldTypes: FieldTypeMap
+): string | undefined => {
+  if (filters.length === 0) return undefined;
+  return filters
+    .map((f, index) => {
+      const clause = compileMilvusClause(f, fieldTypes);
+      if (index === 0) return clause;
+      const op = (f.logicalOperator || "OR").toLowerCase();
+      return ` ${op} ${clause}`;
+    })
+    .join("");
+};
+
+// =============================================================================
+// ELASTICSEARCH FILTER COMPILER
+// =============================================================================
+// ES filter_expr is a list of dicts using Elasticsearch Query DSL with field
+// paths in the form `metadata.content_metadata.<name>.keyword`. See
+// docs/custom-metadata.md#elasticsearch-filter-example.
+
+/** ES Query DSL clause. Kept loose because ES accepts arbitrary shapes. */
+export type ESClause = Record<string, unknown>;
+
+const esField = (name: string): string =>
+  `metadata.content_metadata.${name}.keyword`;
+
+/** Convert Milvus-style `%` wildcards to ES `*`/`?`. */
+const milvusLikeToEsWildcard = (pattern: string): string =>
+  pattern.replace(/%/g, "*").replace(/_/g, "?");
+
+const negate = (clause: ESClause): ESClause => ({
+  bool: { must_not: [clause] },
+});
+
+const compileEsClause = (f: Filter): ESClause => {
+  const path = esField(f.field);
+
+  switch (f.operator) {
+    case "=":
+    case "==":
+      return { term: { [path]: f.value } };
+
+    case "!=":
+      return negate({ term: { [path]: f.value } });
+
+    case ">":
+      return { range: { [path]: { gt: f.value } } };
+    case ">=":
+      return { range: { [path]: { gte: f.value } } };
+    case "<":
+      return { range: { [path]: { lt: f.value } } };
+    case "<=":
+      return { range: { [path]: { lte: f.value } } };
+
+    case "after":
+      return { range: { [path]: { gt: f.value } } };
+    case "before":
+      return { range: { [path]: { lt: f.value } } };
+
+    case "in":
+      return {
+        terms: { [path]: Array.isArray(f.value) ? f.value : [f.value] },
+      };
+    case "not in":
+      return negate({
+        terms: { [path]: Array.isArray(f.value) ? f.value : [f.value] },
+      });
+
+    case "like":
+      return {
+        wildcard: {
+          [path]: milvusLikeToEsWildcard(String(f.value)),
+        },
+      };
+
+    // ES `term` already does set-membership for stored arrays, so a single
+    // value matches any element of the array.
+    case "array_contains":
+      return { term: { [path]: f.value } };
+
+    // "all of" — emit one `term` per requested value, ANDed together.
+    case "array_contains_all": {
+      const values = Array.isArray(f.value) ? f.value : [f.value];
+      return {
+        bool: { must: values.map((v) => ({ term: { [path]: v } })) },
+      };
+    }
+
+    // "any of" — `terms` is a built-in OR-of-values match.
+    case "array_contains_any":
+    case "includes":
+      return {
+        terms: { [path]: Array.isArray(f.value) ? f.value : [f.value] },
+      };
+    case "does not include":
+      return negate({
+        terms: { [path]: Array.isArray(f.value) ? f.value : [f.value] },
+      });
+
+    default: {
+      // Exhaustiveness guard — if the Filter operator union grows without
+      // a corresponding case here, TypeScript will flag it. At runtime we
+      // fall back to a `term` query so we still produce a valid request.
+      const _exhaustive: never = f.operator;
+      void _exhaustive;
+      return { term: { [path]: f.value } };
+    }
+  }
+};
+
+/**
+ * Compile a list of UI filters to an Elasticsearch `filter_expr` (list of
+ * dicts) per docs/custom-metadata.md.
+ *
+ * Grouping rules (match the Milvus flat-precedence behavior):
+ *
+ * - All-AND or single filter → flat list of clauses (matches the doc
+ *   example: `[{term: ...}, {range: ...}]`).
+ * - Any OR → group consecutive AND-joined clauses, then OR the groups
+ *   together via a single top-level `bool.should` envelope.
+ *
+ * Returns `undefined` for empty input (so the caller can omit the field).
+ */
+export const compileElasticsearchFilter = (
+  filters: Filter[]
+): ESClause[] | undefined => {
+  if (filters.length === 0) return undefined;
+
+  // Split into AND-groups separated by OR boundaries. The first filter
+  // always opens the first group. Subsequent filters extend the current
+  // group on AND, or open a new group on OR.
+  const groups: ESClause[][] = [[]];
+  filters.forEach((f, index) => {
+    const op = index === 0 ? "AND" : f.logicalOperator || "OR";
+    if (op === "OR" && groups[groups.length - 1].length > 0) {
+      groups.push([]);
+    }
+    groups[groups.length - 1].push(compileEsClause(f));
+  });
+
+  if (groups.length === 1) {
+    // All-AND or single → flat list. Matches the documented contract.
+    return groups[0];
+  }
+
+  // Mixed / OR — wrap once in bool.should so the entire request still
+  // satisfies the "list of dicts" shape (a single-element list).
+  const shouldClauses = groups.map((g) =>
+    g.length === 1 ? g[0] : { bool: { must: g } }
+  );
+  return [{ bool: { should: shouldClauses } }];
+};

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -12,7 +12,8 @@ export default mergeConfig(
         'src/pages/**/*.{test,spec}.{ts,tsx}',
         'src/components/**/*.{test,spec}.{ts,tsx}',
         'src/hooks/**/*.{test,spec}.{ts,tsx}',
-        'src/store/**/*.{test,spec}.{ts,tsx}'
+        'src/store/**/*.{test,spec}.{ts,tsx}',
+        'src/utils/**/*.{test,spec}.{ts,tsx}'
       ],
       // Handle CSS imports from KUI components
       css: {
@@ -31,7 +32,8 @@ export default mergeConfig(
           'src/pages/**/*.{ts,tsx}',
           'src/components/**/*.{ts,tsx}',
           'src/hooks/**/*.{ts,tsx}',
-          'src/store/**/*.{ts,tsx}'
+          'src/store/**/*.{ts,tsx}',
+          'src/utils/**/*.{ts,tsx}'
         ],
         exclude: [
           'node_modules/',


### PR DESCRIPTION
## Summary

<img width="1798" height="898" alt="Screenshot 2026-05-08 at 12 15 02 PM" src="https://github.com/user-attachments/assets/c3a7fc4f-e7b8-4536-acf7-fd835b1e8a4b" />

The chat UI used to compile `filter_expr` into a Milvus-only string expression. This PR teaches the request builder **both** wire formats and routes between them based on the configured vector store, picked up from the existing `/health.databases[].service` signal.

- **`utils/filterExpression.ts`** (new) — pure module with two compilers:
  - `compileMilvusFilter(filters, fieldTypes)` → string. Behavior is byte-for-byte identical to the previous inline code path (string equality, numeric no-quoting, array-element quoting respecting `array<integer|float|number|boolean>`, `array_contains` function-call syntax, multi-clause AND/OR joining).
  - `compileElasticsearchFilter(filters)` → `Array<Record<string, unknown>>` per `docs/custom-metadata.md#elasticsearch-filter-example`:
    - Field paths rewritten to `metadata.content_metadata.<name>.keyword`
    - Operator mapping: `==/=` → `term`; `!=` → `bool.must_not.term`; `>/>=/</<=/before/after` → `range` (`gt/gte/lt/lte`); `in/not in` → `terms`/`bool.must_not.terms`; `like` → `wildcard` (Milvus `%`/`_` translated to ES `*`/`?`); `array_contains` → `term`; `array_contains_all` → `bool.must` of `term`s; `array_contains_any`/`includes` → `terms`; `does not include` → `bool.must_not.terms`
    - Grouping that mirrors Milvus's flat default precedence: all-AND → flat list (matches the doc example exactly); any OR → wrapped once under a single top-level `bool.should` envelope
- **`useMessageSubmit.ts`** — the inline filter serializer is replaced with a `buildFilterExpression()` helper that picks the compiler from `useHealthStatus().databases[0].service`. Single-deployment assumption matches reality today; Milvus is the safe default when health hasn't loaded yet or the label is unrecognized, preserving prior behavior.
- **`types/requests.ts`** — widen `GenerateRequest.filter_expr` to `string | Array<Record<string, unknown>>`. `cleanRequestObject` already passes non-empty arrays through unchanged.
- **`vitest.config.ts`** — extend the test/coverage globs to include `src/utils/**`, which had no tests before.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm run lint` — clean (no new warnings)
- [x] `pnpm run test:run` — 713/713 pass (was 683 + 30 new)
- [x] **Milvus regression** (unit) — 7 dedicated tests assert the byte-for-byte string output for: string equality, numeric no-quoting, array values incl. `array<integer>` no-quote rule, `array_contains*` function syntax, multi-clause AND/OR joining
- [x] **Elasticsearch wire format** (unit) — 23 tests covering each operator branch + flat-list / `bool.should` / mixed AND+OR grouping cases
- [x] **End-to-end (ES)** — verified on an Elasticsearch-backed dev box: chat UI submits a filter, request payload contains the list-of-dicts shape, BE returns 200 OK with citations and a real answer
- [x] **End-to-end (no filter)** — when no filter rows are configured, `filter_expr` is omitted entirely (unchanged behavior)

## Related

- Slack thread: "RAG-UI support for Elasticsearch based filter_expr"
- Docs: `docs/custom-metadata.md` — `Filter Expression Syntax` (Milvus) and `Elasticsearch Filter Example` are the contracts both compilers target.