### PR TITLE
Added robust scan for ES search queries to prevent silent truncation of data

### DIFF
--- a/src/nvidia_rag/utils/vdb/elasticsearch/elastic_vdb.py
+++ b/src/nvidia_rag/utils/vdb/elasticsearch/elastic_vdb.py
@@ -63,6 +63,7 @@ import pandas as pd
 import requests
 from elastic_transport import ConnectionError as ESConnectionError
 from elasticsearch import Elasticsearch, ConflictError
+from elasticsearch.helpers import scan
 from elasticsearch.helpers.vectorstore import DenseVectorStrategy, VectorStore
 from langchain_core.documents import Document
 from langchain_core.runnables import RunnableAssign, RunnableLambda
@@ -607,9 +608,24 @@ class ElasticVDB(VDBRagIngest):
         Get the list of documents in a collection.
         """
         metadata_schema = self.get_metadata_schema(collection_name)
-        response = self._es_connection.search(
-            index=collection_name, body=get_unique_sources_query()
-        )
+
+        # Paginate the composite aggregation via after_key so collections with
+        # more unique sources than the per-request bucket limit are fully listed.
+        all_buckets: list[dict[str, Any]] = []
+        after_key: dict | None = None
+        while True:
+            response = self._es_connection.search(
+                index=collection_name,
+                body=get_unique_sources_query(after_key=after_key),
+            )
+            agg = response["aggregations"]["unique_sources"]
+            buckets = agg.get("buckets", [])
+            if not buckets:
+                break
+            all_buckets.extend(buckets)
+            after_key = agg.get("after_key")
+            if after_key is None:
+                break
 
         # Get all document info for the collection
         all_document_info = self._get_all_document_info(collection_name)
@@ -617,7 +633,7 @@ class ElasticVDB(VDBRagIngest):
 
         # Get the list of documents
         documents_list = []
-        for hit in response["aggregations"]["unique_sources"]["buckets"]:
+        for hit in all_buckets:
             source_name = hit["key"]["source_name"]
             metadata = (
                 hit["top_hit"]["hits"]["hits"][0]["_source"]
@@ -747,12 +763,17 @@ class ElasticVDB(VDBRagIngest):
         """
         Get the metadata schema for a collection in the Elasticsearch index.
         """
+        # Sort by _id desc and cap at 1 hit: in case duplicates exist due to a
+        # delete-then-insert race in add_metadata_schema, we get the most recent
+        # entry deterministically instead of an arbitrary one from the default page.
         query = get_metadata_schema_query(collection_name)
+        query["sort"] = [{"_id": {"order": "desc"}}]
+        query["size"] = 1
         response = self._es_connection.search(
             index=DEFAULT_METADATA_SCHEMA_COLLECTION, body=query
         )
         if len(response["hits"]["hits"]) > 0:
-            return response["hits"]["hits"][-1]["_source"]["metadata_schema"]
+            return response["hits"]["hits"][0]["_source"]["metadata_schema"]
         else:
             logging_message = (
                 f"No metadata schema found for the collection: {collection_name}."
@@ -793,13 +814,19 @@ class ElasticVDB(VDBRagIngest):
         Internal function to get the aggregated document info for a collection.
         """
         try:
-            # Get the aggregated document info for the collection
+            # Sort by _id desc and cap at 1 hit: if stale duplicates exist from a
+            # delete-then-insert race in add_document_info, this picks the most
+            # recent entry deterministically rather than an arbitrary one from
+            # the default page.
+            query = get_collection_document_info_query(
+                info_type="collection",
+                collection_name=collection_name,
+            )
+            query["sort"] = [{"_id": {"order": "desc"}}]
+            query["size"] = 1
             response = self._es_connection.search(
                 index=DEFAULT_DOCUMENT_INFO_COLLECTION,
-                body=get_collection_document_info_query(
-                    info_type="collection",
-                    collection_name=collection_name,
-                ),
+                body=query,
             )
             existing_info_value = response["hits"]["hits"][0]["_source"]["info_value"]
         except IndexError:
@@ -861,7 +888,12 @@ class ElasticVDB(VDBRagIngest):
     ) -> dict[str, Any]:
         """Get document info from a Elasticsearch index."""
         try:
+            # Sort by _id desc and cap at 1 hit: if duplicates exist for the same
+            # (info_type, collection_name, document_name) tuple from a delete-then-
+            # insert race, this picks the most recent deterministically.
             query = get_document_info_query(collection_name, document_name, info_type)
+            query["sort"] = [{"_id": {"order": "desc"}}]
+            query["size"] = 1
             response = self._es_connection.search(
                 index=DEFAULT_DOCUMENT_INFO_COLLECTION, body=query
             )
@@ -889,14 +921,17 @@ class ElasticVDB(VDBRagIngest):
                     "Skipping document info retrieval."
                     )
                 return []
+            # scan() pages through all matching hits, bypassing the 10-doc default size cap.
             query = get_all_document_info_query(collection_name)
-            response = self._es_connection.search(
-                index=DEFAULT_DOCUMENT_INFO_COLLECTION, body=query
-            )
-            if len(response["hits"]["hits"]) > 0:
-                return [hit["_source"] for hit in response["hits"]["hits"]]
-            else:
-                return []
+            return [
+                hit["_source"]
+                for hit in scan(
+                    self._es_connection,
+                    index=DEFAULT_DOCUMENT_INFO_COLLECTION,
+                    query=query,
+                    preserve_order=False,
+                )
+            ]
         except Exception as e:
             logger.error(f"Error getting all document info for collection {collection_name}: {e}")
             return []

--- a/src/nvidia_rag/utils/vdb/elasticsearch/es_queries.py
+++ b/src/nvidia_rag/utils/vdb/elasticsearch/es_queries.py
@@ -25,26 +25,34 @@ Provides pre-built query functions for document and metadata management in Elast
 """
 
 
-def get_unique_sources_query():
+def get_unique_sources_query(
+    after_key: dict | None = None,
+    page_size: int = 1000,
+):
     """
-    Generate aggregation query to retrieve all unique document sources.
+    Generate aggregation query to retrieve unique document sources.
+
+    Composite aggregations cap at ``search.max_buckets`` (default 65,536) per
+    request, so callers must paginate by passing the previous response's
+    ``after_key`` to walk past that ceiling.
     """
+    composite: dict = {
+        "size": page_size,
+        "sources": [
+            {
+                "source_name": {
+                    "terms": {"field": "metadata.source.source_name.keyword"}
+                }
+            }
+        ],
+    }
+    if after_key is not None:
+        composite["after"] = after_key
     query_unique_sources = {
         "size": 0,
         "aggs": {
             "unique_sources": {
-                "composite": {
-                    "size": 65536,  # Adjust size depending on number of unique values
-                    "sources": [
-                        {
-                            "source_name": {
-                                "terms": {
-                                    "field": "metadata.source.source_name.keyword"
-                                }
-                            }
-                        }
-                    ],
-                },
+                "composite": composite,
                 "aggs": {
                     "top_hit": {
                         "top_hits": {

--- a/tests/unit/test_utils/test_vdb/test_elastic_vdb.py
+++ b/tests/unit/test_utils/test_vdb/test_elastic_vdb.py
@@ -521,11 +521,12 @@ class TestElasticVDB(unittest.TestCase):
         self.assertEqual(mock_es_connection.delete_by_query.call_count, 4)
         mock_logger.info.assert_called_with(f"Collections deleted: {collection_names}")
 
+    @patch("nvidia_rag.utils.vdb.elasticsearch.elastic_vdb.scan")
     @patch("nvidia_rag.utils.vdb.elasticsearch.elastic_vdb.Elasticsearch")
     @patch("nvidia_rag.utils.vdb.elasticsearch.elastic_vdb.VectorStore")
     @patch("nvidia_rag.utils.vdb.elasticsearch.elastic_vdb.get_unique_sources_query")
     def test_get_documents(
-        self, mock_sources_query, mock_vector_store, mock_elasticsearch
+        self, mock_sources_query, mock_vector_store, mock_elasticsearch, mock_scan
     ):
         """Test get_documents method."""
         # Setup mocks
@@ -536,7 +537,8 @@ class TestElasticVDB(unittest.TestCase):
         mock_es_connection = Mock()
         mock_elasticsearch.return_value = mock_es_connection
 
-        # Mock search response
+        # Mock composite-agg pagination: one page with both docs, no after_key
+        # → loop terminates after one iteration.
         mock_search_response = {
             "aggregations": {
                 "unique_sources": {
@@ -579,37 +581,29 @@ class TestElasticVDB(unittest.TestCase):
                             },
                         },
                     ]
+                    # No after_key → pagination loop exits after this page.
                 }
             }
         }
-        mock_document_info_search_response = {
-            "hits": {
-                "hits": [
-                    {
-                        "_source": {
-                            "document_name": "doc1.pdf",
-                            "info_value": {
-                                "total_pages": 5,
-                                "total_chunks": 50,
-                            },
-                        }
-                    },
-                    {
-                        "_source": {
-                            "document_name": "doc2.pdf",
-                            "info_value": {
-                                "total_pages": 10,
-                                "total_chunks": 100,
-                            },
-                        }
-                    },
-                ]
-            }
-        }
-        mock_es_connection.search.side_effect = [
-            mock_search_response,
-            mock_document_info_search_response,
-        ]
+        # _get_all_document_info now uses scan() instead of search(), so we
+        # mock it to yield the per-document info hits.
+        mock_scan.return_value = iter(
+            [
+                {
+                    "_source": {
+                        "document_name": "doc1.pdf",
+                        "info_value": {"total_pages": 5, "total_chunks": 50},
+                    }
+                },
+                {
+                    "_source": {
+                        "document_name": "doc2.pdf",
+                        "info_value": {"total_pages": 10, "total_chunks": 100},
+                    }
+                },
+            ]
+        )
+        mock_es_connection.search.return_value = mock_search_response
         mock_es_connection.indices.exists.return_value = True
         mock_sources_query.return_value = {"query": "test_query"}
 
@@ -637,13 +631,12 @@ class TestElasticVDB(unittest.TestCase):
         ]
 
         self.assertEqual(result, expected_result)
-        self.assertEqual(mock_es_connection.search.call_count, 2)
-        mock_es_connection.search.assert_has_calls(
-            [
-                call(index="test_collection", body={"query": "test_query"}),
-                call(index="document_info", body=ANY),
-            ]
+        # One search call for the composite-agg page; doc-info is fetched via scan().
+        mock_es_connection.search.assert_called_once_with(
+            index="test_collection", body={"query": "test_query"}
         )
+        mock_scan.assert_called_once()
+        mock_sources_query.assert_called_once_with(after_key=None)
 
     @patch("nvidia_rag.utils.vdb.elasticsearch.elastic_vdb.Elasticsearch")
     @patch("nvidia_rag.utils.vdb.elasticsearch.elastic_vdb.VectorStore")
@@ -856,8 +849,15 @@ class TestElasticVDB(unittest.TestCase):
         expected_result = [{"name": "title", "type": "string"}]
         self.assertEqual(result, expected_result)
 
+        # get_metadata_schema now sorts by _id desc with size=1 to deterministically
+        # pick the most recent entry if duplicates exist.
         mock_es_connection.search.assert_called_once_with(
-            index="metadata_schema", body={"query": "schema_query"}
+            index="metadata_schema",
+            body={
+                "query": "schema_query",
+                "sort": [{"_id": {"order": "desc"}}],
+                "size": 1,
+            },
         )
 
     @patch("nvidia_rag.utils.vdb.elasticsearch.elastic_vdb.Elasticsearch")
@@ -1925,9 +1925,10 @@ class TestEsQueries(unittest.TestCase):
         self.assertIn("composite", unique_sources)
         self.assertIn("aggs", unique_sources)
 
-        # Verify composite aggregation
+        # Verify composite aggregation (paginated, no after_key by default)
         composite = unique_sources["composite"]
-        self.assertEqual(composite["size"], 65536)
+        self.assertEqual(composite["size"], 1000)
+        self.assertNotIn("after", composite)
         self.assertIn("sources", composite)
 
         # Verify source field configuration
@@ -1940,6 +1941,15 @@ class TestEsQueries(unittest.TestCase):
         top_hit = unique_sources["aggs"]["top_hit"]
         self.assertIn("top_hits", top_hit)
         self.assertEqual(top_hit["top_hits"]["size"], 1)
+
+    def test_get_unique_sources_query_with_after_key(self):
+        """after_key threads the composite agg cursor for pagination."""
+        after = {"source_name": "/path/to/last.pdf"}
+        result = es_queries.get_unique_sources_query(after_key=after, page_size=250)
+
+        composite = result["aggs"]["unique_sources"]["composite"]
+        self.assertEqual(composite["size"], 250)
+        self.assertEqual(composite["after"], after)
 
     def test_get_delete_metadata_schema_query(self):
         """Test get_delete_metadata_schema_query function with collection name."""

--- a/tests/unit/test_utils/test_vdb/test_elasticsearch/test_es_queries.py
+++ b/tests/unit/test_utils/test_vdb/test_elasticsearch/test_es_queries.py
@@ -30,14 +30,23 @@ class TestGetUniqueSourcesQuery:
         assert query["size"] == 0
         assert "aggs" in query
         assert "unique_sources" in query["aggs"]
-        assert query["aggs"]["unique_sources"]["composite"]["size"] == 65536
+        composite = query["aggs"]["unique_sources"]["composite"]
+        assert composite["size"] == 1000
+        assert "after" not in composite
         assert "top_hit" in query["aggs"]["unique_sources"]["aggs"]
         assert (
-            query["aggs"]["unique_sources"]["composite"]["sources"][0]["source_name"][
-                "terms"
-            ]["field"]
+            composite["sources"][0]["source_name"]["terms"]["field"]
             == "metadata.source.source_name.keyword"
         )
+
+    def test_get_unique_sources_query_with_after_key(self):
+        """Test that after_key is forwarded into the composite agg for pagination."""
+        after = {"source_name": "/path/to/doc42.pdf"}
+        query = es_queries.get_unique_sources_query(after_key=after, page_size=500)
+
+        composite = query["aggs"]["unique_sources"]["composite"]
+        assert composite["size"] == 500
+        assert composite["after"] == after
 
 
 class TestGetDeleteMetadataSchemaQuery:


### PR DESCRIPTION
# Scan for ES search queries to prevent silent truncation of data

`src/nvidia_rag/utils/vdb/elasticsearch/elastic_vdb.py`
  - `_get_all_document_info`: switch from `search()` to `helpers.scan()` so all document-info entries are returned regardless of count.
  - `get_metadata_schema`: add `sort: [{_id: desc}]` + `size: 1` so the most recent schema is picked deterministically if a delete-then-insert race leaves stragglers.
  - `_get_aggregated_document_info`: same sort/size pattern for the `info_type=='collection'` lookup.
  - `get_document_info`: same sort/size pattern for per-document lookups.
  - `get_documents`: paginate the composite aggregation via `after_key` until exhausted, lifting the previous 65 536-unique-source ceiling.

  `src/nvidia_rag/utils/vdb/elasticsearch/es_queries.py`
  - `get_unique_sources_query(after_key=None, page_size=1000)`: accepts a paging cursor and a configurable per-page bucket count (default reduced from 65 536 to 1000 since callers now paginate).

  `tests/unit/test_utils/test_vdb/`
  - Updated `test_get_documents` to mock `scan()` and the composite-agg pagination loop.
  - Updated `test_get_metadata_schema_found` to assert the new sort/size body.
  - Updated `test_get_unique_sources_query` (both variants) for the new default page size and added coverage for `after_key` threading.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [X] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [X] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.