### PR TITLE
Apply runtime model/llm_endpoint to all agentic roles; chain AGENTIC_LLM_* envs to APP_LLM_* in compose

### DIFF
--- a/deploy/compose/docker-compose-rag-server.yaml
+++ b/deploy/compose/docker-compose-rag-server.yaml
@@ -157,10 +157,10 @@ services:
       APP_VLM_APIKEY: ${APP_VLM_APIKEY:-""}
       SUMMARY_LLM_APIKEY: ${SUMMARY_LLM_APIKEY:-""}
       REFLECTION_LLM_APIKEY: ${REFLECTION_LLM_APIKEY:-""}
-      AGENTIC_PLANNER_LLM_APIKEY: ${AGENTIC_PLANNER_LLM_APIKEY:-""}
-      AGENTIC_TASK_LLM_APIKEY: ${AGENTIC_TASK_LLM_APIKEY:-""}
-      AGENTIC_SEED_GEN_LLM_APIKEY: ${AGENTIC_SEED_GEN_LLM_APIKEY:-""}
-      AGENTIC_SYNTHESIS_LLM_APIKEY: ${AGENTIC_SYNTHESIS_LLM_APIKEY:-""}
+      AGENTIC_PLANNER_LLM_APIKEY: ${AGENTIC_PLANNER_LLM_APIKEY:-${APP_LLM_APIKEY:-""}}
+      AGENTIC_TASK_LLM_APIKEY: ${AGENTIC_TASK_LLM_APIKEY:-${APP_LLM_APIKEY:-""}}
+      AGENTIC_SEED_GEN_LLM_APIKEY: ${AGENTIC_SEED_GEN_LLM_APIKEY:-${APP_LLM_APIKEY:-""}}
+      AGENTIC_SYNTHESIS_LLM_APIKEY: ${AGENTIC_SYNTHESIS_LLM_APIKEY:-${APP_LLM_APIKEY:-""}}
 
       # Number of document chunks to insert in LLM prompt, used only when ENABLE_RERANKER is set to True
       APP_RETRIEVER_TOPK: ${APP_RETRIEVER_TOPK:-10}
@@ -227,21 +227,25 @@ services:
       # === Agentic RAG (LangGraph plan-and-execute pipeline) ===
       ENABLE_AGENTIC_RAG: ${ENABLE_AGENTIC_RAG:-false}
 
+      # Per-role agentic LLM envs fall back through APP_LLM_* so a single
+      # APP_LLM_MODELNAME / APP_LLM_SERVERURL override propagates to all four
+      # roles unless a role-specific value is set. Runtime model / llm_endpoint
+      # in the /generate request overrides everything below.
       ##===Agentic Planner LLM configurations===
-      AGENTIC_PLANNER_LLM_SERVERURL: ${AGENTIC_PLANNER_LLM_SERVERURL-"nim-llm:8000"}
-      AGENTIC_PLANNER_LLM_MODEL: ${AGENTIC_PLANNER_LLM_MODEL:-"nvidia/nemotron-3-super-120b-a12b"}
+      AGENTIC_PLANNER_LLM_SERVERURL: ${AGENTIC_PLANNER_LLM_SERVERURL-${APP_LLM_SERVERURL-"nim-llm:8000"}}
+      AGENTIC_PLANNER_LLM_MODEL: ${AGENTIC_PLANNER_LLM_MODEL:-${APP_LLM_MODELNAME:-"nvidia/nemotron-3-super-120b-a12b"}}
 
       ##===Agentic Task LLM configurations===
-      AGENTIC_TASK_LLM_SERVERURL: ${AGENTIC_TASK_LLM_SERVERURL-"nim-llm:8000"}
-      AGENTIC_TASK_LLM_MODEL: ${AGENTIC_TASK_LLM_MODEL:-"nvidia/nemotron-3-super-120b-a12b"}
+      AGENTIC_TASK_LLM_SERVERURL: ${AGENTIC_TASK_LLM_SERVERURL-${APP_LLM_SERVERURL-"nim-llm:8000"}}
+      AGENTIC_TASK_LLM_MODEL: ${AGENTIC_TASK_LLM_MODEL:-${APP_LLM_MODELNAME:-"nvidia/nemotron-3-super-120b-a12b"}}
 
       ##===Agentic Seed Gen LLM configurations===
-      AGENTIC_SEED_GEN_LLM_SERVERURL: ${AGENTIC_SEED_GEN_LLM_SERVERURL-"nim-llm:8000"}
-      AGENTIC_SEED_GEN_LLM_MODEL: ${AGENTIC_SEED_GEN_LLM_MODEL:-"nvidia/nemotron-3-super-120b-a12b"}
+      AGENTIC_SEED_GEN_LLM_SERVERURL: ${AGENTIC_SEED_GEN_LLM_SERVERURL-${APP_LLM_SERVERURL-"nim-llm:8000"}}
+      AGENTIC_SEED_GEN_LLM_MODEL: ${AGENTIC_SEED_GEN_LLM_MODEL:-${APP_LLM_MODELNAME:-"nvidia/nemotron-3-super-120b-a12b"}}
 
       ##===Agentic Synthesis LLM configurations===
-      AGENTIC_SYNTHESIS_LLM_SERVERURL: ${AGENTIC_SYNTHESIS_LLM_SERVERURL-"nim-llm:8000"}
-      AGENTIC_SYNTHESIS_LLM_MODEL: ${AGENTIC_SYNTHESIS_LLM_MODEL:-"nvidia/nemotron-3-super-120b-a12b"}
+      AGENTIC_SYNTHESIS_LLM_SERVERURL: ${AGENTIC_SYNTHESIS_LLM_SERVERURL-${APP_LLM_SERVERURL-"nim-llm:8000"}}
+      AGENTIC_SYNTHESIS_LLM_MODEL: ${AGENTIC_SYNTHESIS_LLM_MODEL:-${APP_LLM_MODELNAME:-"nvidia/nemotron-3-super-120b-a12b"}}
 
       # Agent behaviour tuning
       AGENTIC_LOG_LEVEL: ${AGENTIC_LOG_LEVEL:-INFO}

--- a/src/nvidia_rag/rag_server/agentic_rag/agentic_rag.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/agentic_rag.py
@@ -88,7 +88,7 @@ class _LLMTransportConfig:
 
 @dataclass
 class _VerificationConfig:
-    enabled: bool = False # Disabled by default
+    enabled: bool = False  # Disabled by default
     max_tasks: int = 3
 
 
@@ -163,11 +163,22 @@ class AgenticRag:
         llm_config=None,
         verification_config=None,
         context_config=None,
+        rag_config=None,
     ):
-        self.planner_llm = planner_llm
-        self.task_llm = task_llm
-        self.seed_gen_llm = seed_gen_llm
-        self.synthesis_llm = synthesis_llm
+        # Cached default LLM clients (one per role) built at agent construction
+        # time from the AGENTIC_*_LLM_MODEL / _SERVERURL env-based config. These
+        # are served to every request that does NOT carry a runtime LLM
+        # override; if an override is present, the public role properties below
+        # build a fresh override client per request (cheap — just a LangChain
+        # client constructor, no LangGraph re-compilation).
+        self._default_planner_llm = planner_llm
+        self._default_task_llm = task_llm
+        self._default_seed_gen_llm = seed_gen_llm
+        self._default_synthesis_llm = synthesis_llm
+        # Stashed so per-request runtime-override LLMs can reuse non-model
+        # settings (model_engine, guardrails, parameters) when building a fresh
+        # client via get_llm().
+        self._rag_config = rag_config
         self.retriever_fn = retriever_fn
         self.graph = None
 
@@ -203,6 +214,57 @@ class AgenticRag:
         self._otel = otel_trace.get_tracer("agentic_rag")
 
         logger.info("%s Agent initialized (log_level=%s)", _P, log_level.upper())
+
+    # =========================================================================
+    # PER-REQUEST LLM OVERRIDE (runtime model / endpoint from RAG API)
+    # =========================================================================
+
+    def _resolve_role_llm(self, default_llm: BaseChatModel) -> BaseChatModel:
+        """Return either the per-request override LLM or the cached default.
+
+        Looks up ``_agentic_llm_overrides`` ContextVar (set by main._agentic_chain
+        before graph.ainvoke).  When an override is in effect, all four role
+        properties return the same override-built LLM client — the first access
+        constructs it via get_llm() and caches it on the override dataclass for
+        the remainder of the request.
+
+        ContextVar isolation guarantees concurrent requests see independent
+        override state, so the per-request cache cannot leak across requests.
+        """
+        # Local import: avoids a circular import between agentic_rag and builder
+        # at module load time.
+        from nvidia_rag.rag_server.agentic_rag.builder import _agentic_llm_overrides
+
+        overrides = _agentic_llm_overrides.get()
+        if overrides is None or not (overrides.model or overrides.llm_endpoint):
+            return default_llm
+
+        if overrides._built_llm is None:
+            from nvidia_rag.utils.llm import get_llm
+
+            overrides._built_llm = get_llm(
+                config=self._rag_config,
+                model=overrides.model,
+                llm_endpoint=overrides.llm_endpoint,
+                api_key=overrides.api_key,
+            )
+        return overrides._built_llm
+
+    @property
+    def planner_llm(self) -> BaseChatModel:
+        return self._resolve_role_llm(self._default_planner_llm)
+
+    @property
+    def task_llm(self) -> BaseChatModel:
+        return self._resolve_role_llm(self._default_task_llm)
+
+    @property
+    def seed_gen_llm(self) -> BaseChatModel:
+        return self._resolve_role_llm(self._default_seed_gen_llm)
+
+    @property
+    def synthesis_llm(self) -> BaseChatModel:
+        return self._resolve_role_llm(self._default_synthesis_llm)
 
     @contextmanager
     def _otel_and_trace(self, span_name: str, span_kind: str = "CHAIN"):
@@ -1271,9 +1333,7 @@ class AgenticRag:
                     end_key = "plan.end.with_tasks"
                 else:
                     end_key = "plan.end.no_tasks"
-                writer(
-                    make_stage_end("plan", key=end_key, task_count=len(task_ids))
-                )
+                writer(make_stage_end("plan", key=end_key, task_count=len(task_ids)))
 
                 return {
                     "retrieval_plan": plan,
@@ -1467,7 +1527,9 @@ class AgenticRag:
         writer(
             make_stage_start(
                 "synthesize",
-                key="synthesize.start.refining" if is_verification_pass else "synthesize.start",
+                key="synthesize.start.refining"
+                if is_verification_pass
+                else "synthesize.start",
             )
         )
         with self._otel_and_trace(synth_label) as ospan:
@@ -1761,7 +1823,9 @@ class AgenticRag:
                 writer(
                     make_stage_end(
                         "verify",
-                        key="verify.end.failed" if issue_count > 0 else "verify.end.failed_unspecified",
+                        key="verify.end.failed"
+                        if issue_count > 0
+                        else "verify.end.failed_unspecified",
                         issues=issue_count,
                     )
                 )
@@ -1798,7 +1862,9 @@ class AgenticRag:
                 "input.value", json.dumps([t.get("id", "") for t in (v_tasks or [])])
             )
             if not v_tasks:
-                writer(make_stage_end("verify_execute", key="verify_execute.end.no_tasks"))
+                writer(
+                    make_stage_end("verify_execute", key="verify_execute.end.no_tasks")
+                )
                 return {"verification_results": {}}
 
             logger.info(

--- a/src/nvidia_rag/rag_server/agentic_rag/builder.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/builder.py
@@ -79,6 +79,39 @@ logger = logging.getLogger(__name__)
 
 
 # =============================================================================
+# PER-REQUEST LLM OVERRIDES
+# =============================================================================
+
+
+@dataclass
+class AgenticLLMOverrides:
+    """Per-request LLM overrides applied across all 4 agentic roles.
+
+    When the /generate API receives a non-None ``model`` or ``llm_endpoint``,
+    the value is propagated to planner / task / seed_gen / synthesis LLMs via
+    this dataclass on the ``_agentic_llm_overrides`` ContextVar.
+
+    ``_built_llm`` is a per-request cache: the first role-property access builds
+    the override LLM client; subsequent accesses (other roles, same request)
+    reuse it.  Safe because asyncio Tasks own their own Context, so one request
+    can't pollute another's cached client.
+    """
+
+    model: str | None = None
+    llm_endpoint: str | None = None
+    api_key: str | None = None
+    # Mutable cache slot; not part of equality / hashing.
+    _built_llm: Any = field(default=None, repr=False, compare=False)
+
+
+# ContextVar holding per-request LLM overrides.
+# Default of None means "no override — use the cached default LLMs built at agent build time".
+_agentic_llm_overrides: contextvars.ContextVar[AgenticLLMOverrides | None] = (
+    contextvars.ContextVar("_agentic_llm_overrides", default=None)
+)
+
+
+# =============================================================================
 # PER-REQUEST SEARCH PARAMETERS
 # =============================================================================
 
@@ -122,8 +155,8 @@ class AgenticSearchParams:
 # ContextVar holding per-request search params.
 # No mutable default is stored here (B039). Callers use .get(AgenticSearchParams()) so
 # each fallback access creates a fresh instance rather than sharing one mutable object.
-_agentic_search_params: contextvars.ContextVar[AgenticSearchParams] = contextvars.ContextVar(
-    "_agentic_search_params"
+_agentic_search_params: contextvars.ContextVar[AgenticSearchParams] = (
+    contextvars.ContextVar("_agentic_search_params")
 )
 
 # ContextVar holding per-stage citations for the current agentic request.
@@ -142,7 +175,7 @@ _agentic_all_citations: contextvars.ContextVar[OrderedDict[str, list[SourceResul
 
 
 def make_retriever_fn(
-    nvidia_rag: "NvidiaRAG",
+    nvidia_rag: NvidiaRAG,
     default_reranker_top_k: int,
 ) -> Callable[[str], Any]:
     """Return an async retriever function backed by NvidiaRAG.search().
@@ -175,7 +208,9 @@ def make_retriever_fn(
             citations = await nvidia_rag.search(
                 query=query,
                 collection_names=p.collection_names,
-                reranker_top_k=p.reranker_top_k if p.reranker_top_k is not None else default_reranker_top_k,
+                reranker_top_k=p.reranker_top_k
+                if p.reranker_top_k is not None
+                else default_reranker_top_k,
                 vdb_top_k=p.vdb_top_k,
                 vdb_endpoint=p.vdb_endpoint,
                 vdb_auth_token=p.vdb_auth_token,
@@ -200,9 +235,7 @@ def make_retriever_fn(
                 pass  # Not in an agentic request context (e.g. direct search() call)
             return citations.model_dump()
         except Exception as ex:
-            logger.warning(
-                "Agentic retriever failed for query %r: %s", query[:80], ex
-            )
+            logger.warning("Agentic retriever failed for query %r: %s", query[:80], ex)
             return None
 
     return retriever_fn
@@ -214,9 +247,9 @@ def make_retriever_fn(
 
 
 def _make_role_llm(
-    role_cfg: "AgenticAnyLLMConfig",
-    fallback_cfg: "AgenticAnyLLMConfig",
-    rag_config: "NvidiaRAGConfig",
+    role_cfg: AgenticAnyLLMConfig,
+    fallback_cfg: AgenticAnyLLMConfig,
+    rag_config: NvidiaRAGConfig,
 ) -> Any:
     """Construct a LangChain LLM for one agentic role.
 
@@ -253,7 +286,7 @@ def _make_role_llm(
 
 
 async def build_agentic_rag_agent(
-    nvidia_rag: "NvidiaRAG",
+    nvidia_rag: NvidiaRAG,
 ) -> tuple[AgenticRag, Any]:
     """Build and compile an AgenticRag from a NvidiaRAG instance.
 
@@ -298,6 +331,7 @@ async def build_agentic_rag_agent(
         llm_config=cfg.llm,
         verification_config=cfg.verification,
         context_config=cfg.context,
+        rag_config=rag_config,
     )
 
     graph = await agent.build_graph()

--- a/src/nvidia_rag/rag_server/agentic_rag/runner.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/runner.py
@@ -59,8 +59,10 @@ from typing import TYPE_CHECKING, Any
 
 from nvidia_rag.rag_server.agentic_rag.agentic_rag import AgenticRAGGraphState
 from nvidia_rag.rag_server.agentic_rag.builder import (
+    AgenticLLMOverrides,
     AgenticSearchParams,
     _agentic_all_citations,
+    _agentic_llm_overrides,
     _agentic_search_params,
 )
 from nvidia_rag.rag_server.agentic_rag.streaming import translate_graph_stream
@@ -140,6 +142,9 @@ async def run_agentic_pipeline(
     enable_streaming: bool = True,
     rag_start_time_sec: float | None = None,
     metrics: OtelMetrics | None = None,
+    runtime_model_override: str | None = None,
+    runtime_llm_endpoint_override: str | None = None,
+    runtime_api_key_override: str | None = None,
 ) -> RAGResponse:
     """Run the compiled agentic RAG graph for one request and return a RAGResponse.
 
@@ -191,6 +196,9 @@ async def run_agentic_pipeline(
             collection_name=collection_name,
             rag_start_time_sec=rag_start_time_sec,
             metrics=metrics,
+            runtime_model_override=runtime_model_override,
+            runtime_llm_endpoint_override=runtime_llm_endpoint_override,
+            runtime_api_key_override=runtime_api_key_override,
         )
 
     # ------------------------------------------------------------------
@@ -201,6 +209,15 @@ async def run_agentic_pipeline(
     trace_token = _current_trace.set(trace)
     params_token = _agentic_search_params.set(search_params)
     citations_token = _agentic_all_citations.set(citations_acc)
+    override_token = None
+    if runtime_model_override or runtime_llm_endpoint_override:
+        override_token = _agentic_llm_overrides.set(
+            AgenticLLMOverrides(
+                model=runtime_model_override,
+                llm_endpoint=runtime_llm_endpoint_override,
+                api_key=runtime_api_key_override,
+            )
+        )
 
     try:
         with tracer.start_as_current_span("agentic_rag_query") as root_span:
@@ -272,6 +289,8 @@ async def run_agentic_pipeline(
         _current_trace.reset(trace_token)
         _agentic_search_params.reset(params_token)
         _agentic_all_citations.reset(citations_token)
+        if override_token is not None:
+            _agentic_llm_overrides.reset(override_token)
 
 
 async def _run_streaming(
@@ -289,6 +308,9 @@ async def _run_streaming(
     collection_name: str,
     rag_start_time_sec: float | None,
     metrics: OtelMetrics | None,
+    runtime_model_override: str | None = None,
+    runtime_llm_endpoint_override: str | None = None,
+    runtime_api_key_override: str | None = None,
 ) -> RAGResponse:
     """Build a RAGResponse whose generator delegates to ``translate_graph_stream``.
 
@@ -319,6 +341,15 @@ async def _run_streaming(
         trace_token = _current_trace.set(trace)
         params_token = _agentic_search_params.set(search_params)
         citations_token = _agentic_all_citations.set(citations_acc)
+        override_token = None
+        if runtime_model_override or runtime_llm_endpoint_override:
+            override_token = _agentic_llm_overrides.set(
+                AgenticLLMOverrides(
+                    model=runtime_model_override,
+                    llm_endpoint=runtime_llm_endpoint_override,
+                    api_key=runtime_api_key_override,
+                )
+            )
         try:
             with tracer.start_as_current_span("agentic_rag_query") as root_span:
                 root_span.set_attribute("openinference.span.kind", "CHAIN")
@@ -349,6 +380,8 @@ async def _run_streaming(
                 _current_trace.reset(trace_token)
                 _agentic_search_params.reset(params_token)
                 _agentic_all_citations.reset(citations_token)
+                if override_token is not None:
+                    _agentic_llm_overrides.reset(override_token)
             except Exception as cex:  # noqa: BLE001
                 # Should not happen now that set/reset share a context, but
                 # keep a defensive guard so a stray context mismatch never

--- a/src/nvidia_rag/rag_server/main.py
+++ b/src/nvidia_rag/rag_server/main.py
@@ -568,6 +568,11 @@ class NvidiaRAG:
             if enable_filter_generator is not None
             else self.config.filter_expression_generator.enable_filter_generator
         )
+        # Capture raw runtime overrides BEFORE applying config defaults so the
+        # agentic path can distinguish "client omitted the field" (use per-role
+        # env defaults) from "client passed a value" (override all roles).
+        runtime_model_override = model
+        runtime_llm_endpoint_override = llm_endpoint
         model = model if model is not None else self.config.llm.model_name
         llm_endpoint = (
             llm_endpoint if llm_endpoint is not None else self.config.llm.server_url
@@ -722,6 +727,8 @@ class NvidiaRAG:
                     enable_streaming=enable_streaming,
                     rag_start_time_sec=rag_start_time_sec,
                     metrics=metrics,
+                    runtime_model_override=runtime_model_override,
+                    runtime_llm_endpoint_override=runtime_llm_endpoint_override,
                 )
             logger.info("=" * 80)
             logger.info("PIPELINE MODE: RAG Chain (with knowledge base)")
@@ -1204,9 +1211,7 @@ class NvidiaRAG:
                     logger.info("STAGE: Dynamic Filter Expression Generation")
                     logger.info("=" * 80)
                     logger.info("Configuration:")
-                    logger.info(
-                        "  - Vector Store: %s", self.config.vector_store.name
-                    )
+                    logger.info("  - Vector Store: %s", self.config.vector_store.name)
                     logger.info("  - Prompt: %s", prompt_key)
                     logger.info("  - Output Format: %s", output_format)
                     logger.info(
@@ -2221,6 +2226,8 @@ class NvidiaRAG:
         enable_streaming: bool,
         rag_start_time_sec: float | None,
         metrics: Any | None,
+        runtime_model_override: str | None = None,
+        runtime_llm_endpoint_override: str | None = None,
     ) -> RAGResponse:
         """Orchestrate one agentic RAG request.
 
@@ -2350,6 +2357,18 @@ class NvidiaRAG:
             reranker_top_k,
         )
 
+        # Per-request LLM override (FR-1527): forwarded into run_agentic_pipeline
+        # so the ContextVar set lives alongside the other request-scoped
+        # ContextVars (search params, trace, citations) and stays active for the
+        # full lifetime of the streaming RAGResponse generator — not just until
+        # this function returns.
+        if runtime_model_override or runtime_llm_endpoint_override:
+            logger.info(
+                "  - runtime LLM override: model=%s, endpoint=%s",
+                runtime_model_override,
+                runtime_llm_endpoint_override or "(api-catalog)",
+            )
+
         return await run_agentic_pipeline(
             agent=agent,
             graph=graph,
@@ -2363,6 +2382,9 @@ class NvidiaRAG:
             enable_streaming=enable_streaming,
             rag_start_time_sec=rag_start_time_sec,
             metrics=metrics,
+            runtime_model_override=runtime_model_override,
+            runtime_llm_endpoint_override=runtime_llm_endpoint_override,
+            runtime_api_key_override=self.config.llm.get_api_key(),
         )
 
     async def _rag_chain(
@@ -2789,9 +2811,7 @@ class NvidiaRAG:
                             ErrorCodeMapping.SERVICE_UNAVAILABLE,
                         )
 
-                    is_es_agentic = (
-                        self.config.vector_store.name == "elasticsearch"
-                    )
+                    is_es_agentic = self.config.vector_store.name == "elasticsearch"
                     prompt_key_agentic = (
                         "filter_expression_generator_prompt_elasticsearch"
                         if is_es_agentic
@@ -2803,9 +2823,7 @@ class NvidiaRAG:
                     logger.info("STAGE: Dynamic Filter Expression Generation")
                     logger.info("=" * 80)
                     logger.info("Configuration:")
-                    logger.info(
-                        "  - Vector Store: %s", self.config.vector_store.name
-                    )
+                    logger.info("  - Vector Store: %s", self.config.vector_store.name)
                     logger.info("  - Prompt: %s", prompt_key_agentic)
                     logger.info("  - Output Format: %s", output_format_agentic)
                     logger.info(

--- a/src/nvidia_rag/rag_server/server.py
+++ b/src/nvidia_rag/rag_server/server.py
@@ -487,15 +487,30 @@ class Prompt(BaseModel):
         description="Enable or disable automatic filter expression generation from natural language.",
         default=CONFIG.filter_expression_generator.enable_filter_generator,
     )
-    model: str = Field(
-        description="Name of NIM LLM model to be used for inference.",
-        default=CONFIG.llm.model_name.strip('"'),
+    model: str | None = Field(
+        description=(
+            "Name of NIM LLM model to be used for inference. "
+            "When omitted, the server-side default is used (APP_LLM_MODELNAME "
+            "for the standard RAG path, or the AGENTIC_*_LLM_MODEL per-role envs "
+            "for agentic RAG)."
+        ),
+        default=None,
+        # Swagger UI uses the first example as its request-body sample. Without
+        # this, the regex `[\s\S]*` causes Swagger's generator to emit random
+        # characters; with it, users see the currently-configured default.
+        examples=[CONFIG.llm.model_name.strip('"')],
         max_length=4096,
         pattern=r"[\s\S]*",
     )
-    llm_endpoint: str = Field(
-        description="Endpoint URL for the llm model server.",
-        default=CONFIG.llm.server_url.strip('"'),
+    llm_endpoint: str | None = Field(
+        description=(
+            "Endpoint URL for the llm model server. "
+            "When omitted, the server-side default is used (APP_LLM_SERVERURL "
+            "for the standard RAG path, or the AGENTIC_*_LLM_SERVERURL per-role envs "
+            "for agentic RAG)."
+        ),
+        default=None,
+        examples=[CONFIG.llm.server_url.strip('"')],
         max_length=2048,  # URLs can be long, but 4096 is excessive
     )
     embedding_model: str = Field(

--- a/tests/unit/test_rag_server/test_agentic_rag.py
+++ b/tests/unit/test_rag_server/test_agentic_rag.py
@@ -36,7 +36,9 @@ from nvidia_rag.rag_server.agentic_rag import (
 from nvidia_rag.rag_server.agentic_rag import runner as agentic_runner
 from nvidia_rag.rag_server.agentic_rag.agentic_rag import AgenticRag
 from nvidia_rag.rag_server.agentic_rag.builder import (
+    AgenticLLMOverrides,
     _agentic_all_citations,
+    _agentic_llm_overrides,
     _agentic_search_params,
 )
 from nvidia_rag.rag_server.agentic_rag.prompt import build_prompts
@@ -513,7 +515,6 @@ class TestRunAgenticPipeline:
             f"expected substituted task_count, got: {stage_end_labels}"
         )
 
-
     @pytest.mark.asyncio
     async def test_streaming_buffers_parallel_tokens_per_run(self) -> None:
         """Tokens from parallel-task nodes (execute, verify_execute) must be
@@ -807,6 +808,115 @@ class TestRunAgenticPipeline:
 
         # Trailing finish chunk still terminates the stream.
         assert parsed[-1]["choices"][0]["finish_reason"] == "stop"
+
+
+class TestAgenticLLMOverrides:
+    """Runtime LLM override (FR-1527): model / llm_endpoint passed in the
+    /generate request flow into all 4 agentic role properties via the
+    ``_agentic_llm_overrides`` ContextVar — preserving the cached default
+    LLMs when no override is set and isolating concurrent requests."""
+
+    def test_no_override_returns_cached_default_llms(self) -> None:
+        agent = _minimal_agent()
+        # All 4 role properties return the per-role cached defaults.
+        assert agent.planner_llm is agent._default_planner_llm
+        assert agent.task_llm is agent._default_task_llm
+        assert agent.seed_gen_llm is agent._default_seed_gen_llm
+        assert agent.synthesis_llm is agent._default_synthesis_llm
+
+    def test_override_replaces_all_four_role_llms_with_same_client(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Stub get_llm so we don't touch real LangChain / NIM endpoints.
+        built = MagicMock(name="override-llm")
+        get_llm_calls: list[dict] = []
+
+        def fake_get_llm(**kwargs):
+            get_llm_calls.append(kwargs)
+            return built
+
+        monkeypatch.setattr("nvidia_rag.utils.llm.get_llm", fake_get_llm)
+
+        agent = _minimal_agent()
+        token = _agentic_llm_overrides.set(
+            AgenticLLMOverrides(
+                model="custom/model-x",
+                llm_endpoint="https://endpoint-x:8000",
+                api_key="key-abc",
+            )
+        )
+        try:
+            # All four role properties yield the override-built client …
+            assert agent.planner_llm is built
+            assert agent.task_llm is built
+            assert agent.seed_gen_llm is built
+            assert agent.synthesis_llm is built
+        finally:
+            _agentic_llm_overrides.reset(token)
+
+        # … and the override client is built exactly once per request even
+        # though four roles asked for it (per-request cache on the dataclass).
+        assert len(get_llm_calls) == 1
+        assert get_llm_calls[0]["model"] == "custom/model-x"
+        assert get_llm_calls[0]["llm_endpoint"] == "https://endpoint-x:8000"
+        assert get_llm_calls[0]["api_key"] == "key-abc"
+
+    def test_override_with_empty_fields_falls_back_to_defaults(self) -> None:
+        agent = _minimal_agent()
+        # AgenticLLMOverrides with both fields empty/None is treated as "no
+        # override" — defaults still apply.  Defensive guard for callers that
+        # set the ContextVar unconditionally.
+        token = _agentic_llm_overrides.set(
+            AgenticLLMOverrides(model=None, llm_endpoint=None, api_key="key")
+        )
+        try:
+            assert agent.planner_llm is agent._default_planner_llm
+            assert agent.task_llm is agent._default_task_llm
+        finally:
+            _agentic_llm_overrides.reset(token)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_requests_see_independent_overrides(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two coroutines on the same event loop, each with its own override,
+        must observe their own client — proves no ContextVar leakage."""
+        import asyncio
+
+        # Per-request, get_llm is called once and returns a unique stub.  We
+        # key the stub by the model name so each coroutine can assert it got
+        # the right one.
+        def fake_get_llm(**kwargs):
+            stub = MagicMock(name=f"llm-{kwargs['model']}")
+            stub.model_name = kwargs["model"]
+            return stub
+
+        monkeypatch.setattr("nvidia_rag.utils.llm.get_llm", fake_get_llm)
+
+        agent = _minimal_agent()
+
+        async def one_request(model_name: str) -> str:
+            token = _agentic_llm_overrides.set(
+                AgenticLLMOverrides(model=model_name, llm_endpoint="https://x")
+            )
+            try:
+                # Yield control so the other coroutine can run with its own
+                # override set — this is the real concurrency stress.
+                await asyncio.sleep(0)
+                # All four roles must see this coroutine's model.
+                assert agent.planner_llm.model_name == model_name
+                assert agent.task_llm.model_name == model_name
+                assert agent.seed_gen_llm.model_name == model_name
+                assert agent.synthesis_llm.model_name == model_name
+                return agent.planner_llm.model_name
+            finally:
+                _agentic_llm_overrides.reset(token)
+
+        results = await asyncio.gather(
+            one_request("model-A"),
+            one_request("model-B"),
+        )
+        assert sorted(results) == ["model-A", "model-B"]
 
 
 class TestBuildAgenticRagAgentSignature:


### PR DESCRIPTION
# Apply runtime model/llm_endpoint to all agentic roles

## Summary

- Per-request `model` / `llm_endpoint` from the `/generate` API now propagate to **all four** agentic LLM roles (planner, task, seed-gen, synthesis), not just one.
- Compose envs `AGENTIC_*_LLM_SERVERURL` / `_MODEL` / `_APIKEY` fall back through `APP_LLM_*`, so a single `APP_LLM_*` override fans out to every role unless a role-specific value is set.

## How it works

- `server.py` — `Prompt.model` / `Prompt.llm_endpoint` become `Optional[str]` (default `None`). The server can now distinguish "client omitted" (use per-role env defaults) from "client passed a value" (override every role).
- `main.py` — captures the raw client-supplied `model` / `llm_endpoint` **before** config defaults are applied and forwards them to `run_agentic_pipeline`.
- `builder.py` — new `AgenticLLMOverrides` dataclass on the `_agentic_llm_overrides` ContextVar (with a per-request `_built_llm` cache slot); each role-LLM property consults it before falling back to its `AGENTIC_*_LLM_*` config.
- `runner.py` — binds the override ContextVar for the request lifetime alongside the other request-scoped ContextVars. Set/reset live in the same context on both branches (inside `_stream()` for streaming, inside the same try frame for non-streaming) — no cross-context reset warnings.
- `docker-compose-rag-server.yaml` — chains `${AGENTIC_*_LLM_*:-${APP_LLM_*}}` so the existing `APP_LLM_*` knob now drives the agentic pipeline by default.

No breaking change: omitting `model` / `llm_endpoint` keeps today's per-role-env behaviour.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [X] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [X] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.