### PR TITLE
ci: add generic Run Branch Script dispatcher workflow

### DIFF
--- a/.github/workflows/run-branch-script.yml
+++ b/.github/workflows/run-branch-script.yml
@@ -1,0 +1,65 @@
+name: Run Branch Script
+
+# Generic dispatcher: checks out a specified branch and runs a script from it.
+# Lets us iterate on CI logic in feature branches without merging workflow
+# changes for every iteration. Especially useful for skill-eval/NV-BASE runs
+# where the script under ci/ does all the install + run logic.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch / tag / SHA to check out'
+        required: true
+        default: 'feat/nvbase-ci-smoke'
+      script:
+        description: 'Script path relative to repo root'
+        required: true
+        default: 'ci/run_nvbase_eval.sh'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: run-branch-script-${{ inputs.ref }}-${{ inputs.script }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    name: Run ${{ inputs.script }} on ${{ inputs.ref }}
+    runs-on: arc-runners-org-nvidia-ai-bp-2-gpu
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout target ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Run script
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVBASE_INFERENCE_API_KEY }}
+          NVIDIA_INFERENCE_KEY: ${{ secrets.NVBASE_INFERENCE_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.NVBASE_INFERENCE_API_KEY }}
+          NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
+          CI_NVSTAGING_BLUEPRINT_KEY: ${{ secrets.CI_NVSTAGING_BLUEPRINT_KEY }}
+          CLAUDE_CODE_DISABLE_THINKING: "1"
+        run: |
+          if [ ! -f "${{ inputs.script }}" ]; then
+            echo "Script not found at ${{ inputs.script }} on ref ${{ inputs.ref }}"
+            exit 1
+          fi
+          chmod +x "${{ inputs.script }}"
+          bash "${{ inputs.script }}"
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: branch-script-${{ github.run_id }}
+          path: |
+            eval-results/
+            **/evals/results/
+            ci-logs/
+          retention-days: 14
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

Adds a single generic workflow `.github/workflows/run-branch-script.yml` that:
- Takes a branch ref + script path as `workflow_dispatch` inputs
- Checks out the specified branch
- Runs the specified script with NV-BASE / NGC secrets injected
- Uploads any `eval-results/`, `**/evals/results/`, `ci-logs/` as artifacts

## Why

Lets us iterate on CI logic (e.g. NV-BASE skill-eval) in feature branches without merging workflow changes for every iteration. Once this dispatcher lands on \`develop\`, all subsequent CI script work happens on the feature branch — no more PRs to \`develop\` for each fix.

## Defaults

- \`ref\`: \`feat/nvbase-ci-smoke\`
- \`script\`: \`ci/run_nvbase_eval.sh\`

Both are overridable at trigger time.

## Test plan

- [ ] Merge this PR to \`develop\`
- [ ] Trigger via Actions → Run Branch Script → Run workflow
- [ ] Verify it checks out the target branch and runs the script
- [ ] Verify artifacts upload

🤖 Generated with [Claude Code](https://claude.ai/claude-code)