### PR TITLE
ci: add Run Branch Script dispatcher workflow

### DIFF
--- a/.github/workflows/run-branch-script.yml
+++ b/.github/workflows/run-branch-script.yml
@@ -1,0 +1,65 @@
+name: Run Branch Script
+
+# Generic dispatcher: checks out a specified branch and runs a script from it.
+# Lets us iterate on CI logic in feature branches without merging workflow
+# changes for every iteration. Especially useful for skill-eval/NV-BASE runs
+# where the script under ci/ does all the install + run logic.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch / tag / SHA to check out'
+        required: true
+        default: 'feat/nvbase-ci-smoke'
+      script:
+        description: 'Script path relative to repo root'
+        required: true
+        default: 'ci/run_nvbase_eval.sh'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: run-branch-script-${{ inputs.ref }}-${{ inputs.script }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    name: Run ${{ inputs.script }} on ${{ inputs.ref }}
+    runs-on: arc-runners-org-nvidia-ai-bp-2-gpu
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout target ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Run script
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVBASE_INFERENCE_API_KEY }}
+          NVIDIA_INFERENCE_KEY: ${{ secrets.NVBASE_INFERENCE_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.NVBASE_INFERENCE_API_KEY }}
+          NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
+          CI_NVSTAGING_BLUEPRINT_KEY: ${{ secrets.CI_NVSTAGING_BLUEPRINT_KEY }}
+          CLAUDE_CODE_DISABLE_THINKING: "1"
+        run: |
+          if [ ! -f "${{ inputs.script }}" ]; then
+            echo "Script not found at ${{ inputs.script }} on ref ${{ inputs.ref }}"
+            exit 1
+          fi
+          chmod +x "${{ inputs.script }}"
+          bash "${{ inputs.script }}"
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: branch-script-${{ github.run_id }}
+          path: |
+            eval-results/
+            **/evals/results/
+            ci-logs/
+          retention-days: 14
+          if-no-files-found: ignore


### PR DESCRIPTION
Adds a generic workflow_dispatch workflow that checks out any branch and runs a specified script on the self-hosted GPU runner. Enables iterating on NV-BASE eval CI (feat/nvbase-ci-smoke) without merging workflow changes to main for every iteration.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.