### PR TITLE
fix(es-filter): strip invalid  from non-string fields in UI, backend and LLM prompt

### DIFF
--- a/deploy/helm/nvidia-blueprint-rag/files/prompt.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/files/prompt.yaml
@@ -302,8 +302,19 @@ filter_expression_generator_prompt_elasticsearch:
     ### Field Path Convention ###
 
     - Always prefix field names with `metadata.content_metadata.` — e.g. for schema field `status`, target `metadata.content_metadata.status`.
-    - For `string` fields used in exact-match clauses (`term`, `terms`), append `.keyword` — e.g. `metadata.content_metadata.status.keyword`.
-    - Do NOT append `.keyword` for `wildcard`, `match`, `range`, or numeric/datetime/boolean fields.
+    - For `string` (or `array<string>`) fields used in exact-match clauses (`term`, `terms`, `prefix`), append `.keyword` — e.g. `metadata.content_metadata.status.keyword`.
+    - **Do NOT append `.keyword` for `wildcard`, `match`, `match_phrase`, `range`, or for any non-string field type (`integer`, `float`, `number`, `datetime`, `boolean`).**
+      The `.keyword` sub-field only exists on string-typed fields. Appending it to a numeric, datetime, or boolean field targets a non-existent ES mapping and silently returns zero hits.
+
+    #### Correct vs. incorrect — non-string fields ####
+
+    | Field type | ✅ Correct | ❌ Incorrect |
+    | --- | --- | --- |
+    | `integer` (e.g. `priority`) | `{{"term": {{"metadata.content_metadata.priority": 2}}}}` | `{{"term": {{"metadata.content_metadata.priority.keyword": 2}}}}` |
+    | `integer` range (e.g. `year`) | `{{"range": {{"metadata.content_metadata.year": {{"gte": 2024}}}}}}` | `{{"range": {{"metadata.content_metadata.year.keyword": {{"gte": 2024}}}}}}` |
+    | `datetime` (e.g. `created_at`) | `{{"range": {{"metadata.content_metadata.created_at": {{"gte": "2024-01-01T00:00:00"}}}}}}` | `{{"range": {{"metadata.content_metadata.created_at.keyword": {{...}}}}}}` |
+    | `boolean` (e.g. `is_public`) | `{{"term": {{"metadata.content_metadata.is_public": true}}}}` | `{{"term": {{"metadata.content_metadata.is_public.keyword": true}}}}` |
+    | `string` (e.g. `status`) | `{{"term": {{"metadata.content_metadata.status.keyword": "approved"}}}}` | `{{"term": {{"metadata.content_metadata.status": "approved"}}}}` (missing `.keyword`) |
 
     ### Output Format ###
 

--- a/docs/custom-metadata.md
+++ b/docs/custom-metadata.md
@@ -491,9 +491,11 @@ For Elasticsearch, filters must be provided as a list of dictionaries using Elas
 
 ```python
 # Elasticsearch filter example
+# `.keyword` is appended only for exact-match clauses on string fields;
+# numeric/datetime/boolean fields and `range` clauses use the bare path.
 filter_expr = [
     {"term": {"metadata.content_metadata.category.keyword": "AI"}},
-    {"range": {"metadata.content_metadata.priority.keyword": {"gt": 5}}}
+    {"range": {"metadata.content_metadata.priority": {"gt": 5}}}
 ]
 ```
 

--- a/frontend/src/hooks/useMessageSubmit.ts
+++ b/frontend/src/hooks/useMessageSubmit.ts
@@ -69,7 +69,10 @@ export function buildFilterExpression(
 
   const backend = vectorStoreFromHealthService(healthServiceLabel) ?? "milvus";
   if (backend === "elasticsearch") {
-    return compileElasticsearchFilter(filters);
+    // Pass `fieldTypes` so non-string-typed fields (integer / float /
+    // datetime / boolean) get the bare field path. Appending `.keyword`
+    // to those targets a non-existent ES sub-field and returns zero hits.
+    return compileElasticsearchFilter(filters, fieldTypes);
   }
   return compileMilvusFilter(filters, fieldTypes);
 }

--- a/frontend/src/types/requests.ts
+++ b/frontend/src/types/requests.ts
@@ -57,8 +57,12 @@ export interface GenerateRequest {
   //
   // `filter_expr` shape depends on the configured vector store:
   //  - Milvus  → string expression (`content_metadata["x"] op v`).
-  //  - Elasticsearch → list of dicts (Elasticsearch Query DSL with field
-  //    paths in the form `metadata.content_metadata.<name>.keyword`).
+  //  - Elasticsearch → list of dicts (Elasticsearch Query DSL). Field paths
+  //    are `metadata.content_metadata.<name>`. A `.keyword` suffix is
+  //    appended ONLY for exact-match clauses (term/terms/prefix/wildcard/
+  //    match) on string-typed (or array<string>) fields — `.keyword` only
+  //    exists as a multi-field on string mappings. Numeric, datetime,
+  //    and boolean fields, plus all `range` clauses, use the bare path.
   // See docs/custom-metadata.md for the full contract.
   filter_expr?: string | Array<Record<string, unknown>>;
   stop?: string[];

--- a/frontend/src/utils/__tests__/filterExpression.test.ts
+++ b/frontend/src/utils/__tests__/filterExpression.test.ts
@@ -183,18 +183,18 @@ describe("compileElasticsearchFilter", () => {
     ["<", "lt"],
     ["<=", "lte"],
   ] as const)(
-    "maps numeric comparison %s to range.%s",
+    "maps numeric comparison %s to range.%s without .keyword (range never carries .keyword)",
     (operator, esKey) => {
       const result = compileElasticsearchFilter([
         { field: "priority", operator, value: 5 },
       ]);
       expect(result).toEqual([
-        { range: { "metadata.content_metadata.priority.keyword": { [esKey]: 5 } } },
+        { range: { "metadata.content_metadata.priority": { [esKey]: 5 } } },
       ]);
     }
   );
 
-  it("maps relative datetime operators to range with gt/lt", () => {
+  it("maps relative datetime operators to range with gt/lt, bare path", () => {
     expect(
       compileElasticsearchFilter([
         { field: "created", operator: "after", value: "2025-01-01" },
@@ -202,7 +202,7 @@ describe("compileElasticsearchFilter", () => {
     ).toEqual([
       {
         range: {
-          "metadata.content_metadata.created.keyword": { gt: "2025-01-01" },
+          "metadata.content_metadata.created": { gt: "2025-01-01" },
         },
       },
     ]);
@@ -213,7 +213,7 @@ describe("compileElasticsearchFilter", () => {
     ).toEqual([
       {
         range: {
-          "metadata.content_metadata.created.keyword": { lt: "2025-01-01" },
+          "metadata.content_metadata.created": { lt: "2025-01-01" },
         },
       },
     ]);
@@ -357,7 +357,7 @@ describe("compileElasticsearchFilter", () => {
       { term: { "metadata.content_metadata.category.keyword": "AI" } },
       {
         range: {
-          "metadata.content_metadata.priority.keyword": { gt: 5 },
+          "metadata.content_metadata.priority": { gt: 5 },
         },
       },
     ]);
@@ -409,5 +409,144 @@ describe("compileElasticsearchFilter", () => {
         },
       },
     ]);
+  });
+
+  // --- Type-aware path selection ------------------------------------------
+  // `.keyword` is an ES multi-field that only exists on string mappings.
+  // Targeting `<numeric_field>.keyword` returns zero hits silently. The
+  // compiler must consult the schema and omit `.keyword` for non-string
+  // fields. Regression coverage for the case reported by the user where
+  // an integer `priority` filter from the UI matched nothing.
+
+  describe("type-aware field paths from schema", () => {
+    it("omits .keyword for integer term equality (the reported bug)", () => {
+      const types = buildFieldTypeMap([
+        [{ name: "priority", type: "integer" }],
+      ]);
+      const result = compileElasticsearchFilter(
+        [{ field: "priority", operator: "==", value: 2 }],
+        types
+      );
+      expect(result).toEqual([
+        { term: { "metadata.content_metadata.priority": 2 } },
+      ]);
+    });
+
+    it("omits .keyword for float term equality", () => {
+      const types = buildFieldTypeMap([
+        [{ name: "rating", type: "float" }],
+      ]);
+      const result = compileElasticsearchFilter(
+        [{ field: "rating", operator: "==", value: 4.5 }],
+        types
+      );
+      expect(result).toEqual([
+        { term: { "metadata.content_metadata.rating": 4.5 } },
+      ]);
+    });
+
+    it("omits .keyword for boolean term equality", () => {
+      const types = buildFieldTypeMap([
+        [{ name: "is_public", type: "boolean" }],
+      ]);
+      const result = compileElasticsearchFilter(
+        [{ field: "is_public", operator: "==", value: true }],
+        types
+      );
+      expect(result).toEqual([
+        { term: { "metadata.content_metadata.is_public": true } },
+      ]);
+    });
+
+    it("omits .keyword for datetime range", () => {
+      const types = buildFieldTypeMap([
+        [{ name: "created_at", type: "datetime" }],
+      ]);
+      const result = compileElasticsearchFilter(
+        [{ field: "created_at", operator: "after", value: "2025-01-01" }],
+        types
+      );
+      expect(result).toEqual([
+        {
+          range: {
+            "metadata.content_metadata.created_at": { gt: "2025-01-01" },
+          },
+        },
+      ]);
+    });
+
+    it("omits .keyword for integer terms (in)", () => {
+      const types = buildFieldTypeMap([
+        [{ name: "year", type: "integer" }],
+      ]);
+      const result = compileElasticsearchFilter(
+        [{ field: "year", operator: "in", value: [2024, 2025] }],
+        types
+      );
+      expect(result).toEqual([
+        {
+          terms: {
+            "metadata.content_metadata.year": [2024, 2025],
+          },
+        },
+      ]);
+    });
+
+    it("keeps .keyword for string term equality when schema is known", () => {
+      const types = buildFieldTypeMap([
+        [{ name: "status", type: "string" }],
+      ]);
+      const result = compileElasticsearchFilter(
+        [{ field: "status", operator: "==", value: "approved" }],
+        types
+      );
+      expect(result).toEqual([
+        { term: { "metadata.content_metadata.status.keyword": "approved" } },
+      ]);
+    });
+
+    it("keeps .keyword for array<string> terms (in)", () => {
+      const types = buildFieldTypeMap([
+        [{ name: "tags", type: "array", array_type: "string" }],
+      ]);
+      const result = compileElasticsearchFilter(
+        [{ field: "tags", operator: "in", value: ["ai", "ml"] }],
+        types
+      );
+      expect(result).toEqual([
+        {
+          terms: { "metadata.content_metadata.tags.keyword": ["ai", "ml"] },
+        },
+      ]);
+    });
+
+    it("omits .keyword for array<integer> terms (in)", () => {
+      const types = buildFieldTypeMap([
+        [{ name: "scores", type: "array", array_type: "integer" }],
+      ]);
+      const result = compileElasticsearchFilter(
+        [{ field: "scores", operator: "in", value: [1, 2, 3] }],
+        types
+      );
+      expect(result).toEqual([
+        { terms: { "metadata.content_metadata.scores": [1, 2, 3] } },
+      ]);
+    });
+
+    it("defaults to string-like (keep .keyword) when the field is missing from the schema", () => {
+      // Back-compat: the BE normalizer will strip .keyword server-side if
+      // the field turns out to be non-string. This preserves the wire
+      // format for installs that don't register metadata schemas.
+      const types = buildFieldTypeMap([
+        [{ name: "other_field", type: "string" }],
+      ]);
+      const result = compileElasticsearchFilter(
+        [{ field: "unregistered", operator: "==", value: "x" }],
+        types
+      );
+      expect(result).toEqual([
+        { term: { "metadata.content_metadata.unregistered.keyword": "x" } },
+      ]);
+    });
   });
 });

--- a/frontend/src/utils/filterExpression.ts
+++ b/frontend/src/utils/filterExpression.ts
@@ -146,15 +146,61 @@ export const compileMilvusFilter = (
 // =============================================================================
 // ELASTICSEARCH FILTER COMPILER
 // =============================================================================
-// ES filter_expr is a list of dicts using Elasticsearch Query DSL with field
-// paths in the form `metadata.content_metadata.<name>.keyword`. See
+// ES filter_expr is a list of dicts using Elasticsearch Query DSL. Field paths
+// are `metadata.content_metadata.<name>`, with a `.keyword` suffix appended
+// only for exact-match clauses (`term`/`terms`/`prefix`) on string-typed
+// fields. Numeric, datetime, and boolean fields use the bare path because
+// `.keyword` only exists as a multi-field on string mappings — appending it
+// elsewhere targets a non-existent field and silently returns zero hits. See
 // docs/custom-metadata.md#elasticsearch-filter-example.
 
 /** ES Query DSL clause. Kept loose because ES accepts arbitrary shapes. */
 export type ESClause = Record<string, unknown>;
 
-const esField = (name: string): string =>
-  `metadata.content_metadata.${name}.keyword`;
+/** Schema types that support a `.keyword` multi-field in ES mappings. */
+const STRING_FIELD_TYPES = new Set(["string"]);
+
+const isStringLikeField = (
+  field: string,
+  fieldTypes: FieldTypeMap
+): boolean => {
+  const t = fieldTypes.fieldType.get(field);
+  if (!t) {
+    // Unknown field (no schema loaded for the selected collection). Default
+    // to string-like to preserve the previous wire format for installs
+    // without registered schemas. The backend normalizer will strip
+    // `.keyword` server-side if the field turns out to be non-string.
+    return true;
+  }
+  if (STRING_FIELD_TYPES.has(t)) return true;
+  if (t === "array") {
+    const elem = fieldTypes.arrayElementType.get(field);
+    return elem !== undefined && STRING_FIELD_TYPES.has(elem);
+  }
+  return false;
+};
+
+/**
+ * Clause kinds we care about for the `.keyword` decision:
+ * - "exact"   → `term` / `terms` / `prefix` / `wildcard` / `match`: append
+ *   `.keyword` when the field is string-like (that's where the ES multi-field
+ *   exists). For non-string fields these clauses either don't apply or work
+ *   on the native field type, so use the bare path.
+ * - "range"  → never `.keyword`. String fields don't support range queries
+ *   server-side, and on numeric/datetime fields the keyword sub-field
+ *   doesn't exist.
+ */
+type EsClauseKind = "exact" | "range";
+
+const esField = (
+  name: string,
+  clauseKind: EsClauseKind,
+  fieldTypes: FieldTypeMap
+): string => {
+  const base = `metadata.content_metadata.${name}`;
+  if (clauseKind === "range") return base;
+  return isStringLikeField(name, fieldTypes) ? `${base}.keyword` : base;
+};
 
 /** Convert Milvus-style `%` wildcards to ES `*`/`?`. */
 const milvusLikeToEsWildcard = (pattern: string): string =>
@@ -164,57 +210,58 @@ const negate = (clause: ESClause): ESClause => ({
   bool: { must_not: [clause] },
 });
 
-const compileEsClause = (f: Filter): ESClause => {
-  const path = esField(f.field);
+const compileEsClause = (f: Filter, fieldTypes: FieldTypeMap): ESClause => {
+  const exactPath = esField(f.field, "exact", fieldTypes);
+  const rangePath = esField(f.field, "range", fieldTypes);
 
   switch (f.operator) {
     case "=":
     case "==":
-      return { term: { [path]: f.value } };
+      return { term: { [exactPath]: f.value } };
 
     case "!=":
-      return negate({ term: { [path]: f.value } });
+      return negate({ term: { [exactPath]: f.value } });
 
     case ">":
-      return { range: { [path]: { gt: f.value } } };
+      return { range: { [rangePath]: { gt: f.value } } };
     case ">=":
-      return { range: { [path]: { gte: f.value } } };
+      return { range: { [rangePath]: { gte: f.value } } };
     case "<":
-      return { range: { [path]: { lt: f.value } } };
+      return { range: { [rangePath]: { lt: f.value } } };
     case "<=":
-      return { range: { [path]: { lte: f.value } } };
+      return { range: { [rangePath]: { lte: f.value } } };
 
     case "after":
-      return { range: { [path]: { gt: f.value } } };
+      return { range: { [rangePath]: { gt: f.value } } };
     case "before":
-      return { range: { [path]: { lt: f.value } } };
+      return { range: { [rangePath]: { lt: f.value } } };
 
     case "in":
       return {
-        terms: { [path]: Array.isArray(f.value) ? f.value : [f.value] },
+        terms: { [exactPath]: Array.isArray(f.value) ? f.value : [f.value] },
       };
     case "not in":
       return negate({
-        terms: { [path]: Array.isArray(f.value) ? f.value : [f.value] },
+        terms: { [exactPath]: Array.isArray(f.value) ? f.value : [f.value] },
       });
 
     case "like":
       return {
         wildcard: {
-          [path]: milvusLikeToEsWildcard(String(f.value)),
+          [exactPath]: milvusLikeToEsWildcard(String(f.value)),
         },
       };
 
     // ES `term` already does set-membership for stored arrays, so a single
     // value matches any element of the array.
     case "array_contains":
-      return { term: { [path]: f.value } };
+      return { term: { [exactPath]: f.value } };
 
     // "all of" — emit one `term` per requested value, ANDed together.
     case "array_contains_all": {
       const values = Array.isArray(f.value) ? f.value : [f.value];
       return {
-        bool: { must: values.map((v) => ({ term: { [path]: v } })) },
+        bool: { must: values.map((v) => ({ term: { [exactPath]: v } })) },
       };
     }
 
@@ -222,11 +269,11 @@ const compileEsClause = (f: Filter): ESClause => {
     case "array_contains_any":
     case "includes":
       return {
-        terms: { [path]: Array.isArray(f.value) ? f.value : [f.value] },
+        terms: { [exactPath]: Array.isArray(f.value) ? f.value : [f.value] },
       };
     case "does not include":
       return negate({
-        terms: { [path]: Array.isArray(f.value) ? f.value : [f.value] },
+        terms: { [exactPath]: Array.isArray(f.value) ? f.value : [f.value] },
       });
 
     default: {
@@ -235,7 +282,7 @@ const compileEsClause = (f: Filter): ESClause => {
       // fall back to a `term` query so we still produce a valid request.
       const _exhaustive: never = f.operator;
       void _exhaustive;
-      return { term: { [path]: f.value } };
+      return { term: { [exactPath]: f.value } };
     }
   }
 };
@@ -252,9 +299,19 @@ const compileEsClause = (f: Filter): ESClause => {
  *   together via a single top-level `bool.should` envelope.
  *
  * Returns `undefined` for empty input (so the caller can omit the field).
+ *
+ * `fieldTypes` carries the schema-derived type info needed to decide whether
+ * `.keyword` should be appended for a given clause/field pair. When a field
+ * is missing from `fieldTypes` (e.g. no schema is registered), we default to
+ * the previous string-like behavior and rely on the backend normalizer to
+ * strip `.keyword` if the field is actually non-string.
  */
 export const compileElasticsearchFilter = (
-  filters: Filter[]
+  filters: Filter[],
+  fieldTypes: FieldTypeMap = {
+    fieldType: new Map(),
+    arrayElementType: new Map(),
+  }
 ): ESClause[] | undefined => {
   if (filters.length === 0) return undefined;
 
@@ -267,7 +324,7 @@ export const compileElasticsearchFilter = (
     if (op === "OR" && groups[groups.length - 1].length > 0) {
       groups.push([]);
     }
-    groups[groups.length - 1].push(compileEsClause(f));
+    groups[groups.length - 1].push(compileEsClause(f, fieldTypes));
   });
 
   if (groups.length === 1) {

--- a/src/nvidia_rag/rag_server/prompt.yaml
+++ b/src/nvidia_rag/rag_server/prompt.yaml
@@ -302,8 +302,19 @@ filter_expression_generator_prompt_elasticsearch:
     ### Field Path Convention ###
 
     - Always prefix field names with `metadata.content_metadata.` — e.g. for schema field `status`, target `metadata.content_metadata.status`.
-    - For `string` fields used in exact-match clauses (`term`, `terms`), append `.keyword` — e.g. `metadata.content_metadata.status.keyword`.
-    - Do NOT append `.keyword` for `wildcard`, `match`, `range`, or numeric/datetime/boolean fields.
+    - For `string` (or `array<string>`) fields used in exact-match clauses (`term`, `terms`, `prefix`), append `.keyword` — e.g. `metadata.content_metadata.status.keyword`.
+    - **Do NOT append `.keyword` for `wildcard`, `match`, `match_phrase`, `range`, or for any non-string field type (`integer`, `float`, `number`, `datetime`, `boolean`).**
+      The `.keyword` sub-field only exists on string-typed fields. Appending it to a numeric, datetime, or boolean field targets a non-existent ES mapping and silently returns zero hits.
+
+    #### Correct vs. incorrect — non-string fields ####
+
+    | Field type | ✅ Correct | ❌ Incorrect |
+    | --- | --- | --- |
+    | `integer` (e.g. `priority`) | `{{"term": {{"metadata.content_metadata.priority": 2}}}}` | `{{"term": {{"metadata.content_metadata.priority.keyword": 2}}}}` |
+    | `integer` range (e.g. `year`) | `{{"range": {{"metadata.content_metadata.year": {{"gte": 2024}}}}}}` | `{{"range": {{"metadata.content_metadata.year.keyword": {{"gte": 2024}}}}}}` |
+    | `datetime` (e.g. `created_at`) | `{{"range": {{"metadata.content_metadata.created_at": {{"gte": "2024-01-01T00:00:00"}}}}}}` | `{{"range": {{"metadata.content_metadata.created_at.keyword": {{...}}}}}}` |
+    | `boolean` (e.g. `is_public`) | `{{"term": {{"metadata.content_metadata.is_public": true}}}}` | `{{"term": {{"metadata.content_metadata.is_public.keyword": true}}}}` |
+    | `string` (e.g. `status`) | `{{"term": {{"metadata.content_metadata.status.keyword": "approved"}}}}` | `{{"term": {{"metadata.content_metadata.status": "approved"}}}}` (missing `.keyword`) |
 
     ### Output Format ###
 

--- a/src/nvidia_rag/utils/es_filter_validator.py
+++ b/src/nvidia_rag/utils/es_filter_validator.py
@@ -108,14 +108,30 @@ class ElasticsearchFilterValidator:
             return {"status": False, "error_message": str(e)}
 
     def process_filter(self, filter_clauses: list[dict[str, Any]]) -> dict[str, Any]:
-        """Validate and normalize ES DSL clauses (e.g. add `.keyword` where needed)."""
+        """Validate and normalize ES DSL clauses (e.g. add `.keyword` where needed).
+
+        Emits a WARNING listing every field-path change. Logged at WARNING
+        (not INFO) because we are silently rewriting user-supplied input —
+        the caller should fix the source so the rewrite eventually goes
+        away.
+        """
         try:
             normalized = copy.deepcopy(filter_clauses)
-            self._walk_clauses(normalized, normalize=True)
+            changes: list[tuple[str, str]] = []
+            self._walk_clauses(normalized, normalize=True, changes=changes)
+            if changes:
+                rewrites = ", ".join(f"{old} -> {new}" for old, new in changes)
+                logger.warning(
+                    "[ES Filter] Rewrote %d path(s): %s "
+                    "(`.keyword` is only valid on string fields).",
+                    len(changes),
+                    rewrites,
+                )
             return {
                 "status": True,
                 "processed_expression": normalized,
                 "message": "Filter clauses processed successfully",
+                "normalization_changes": changes,
             }
         except (FilterSyntaxError, FilterSemanticError) as e:
             return {"status": False, "error_message": str(e)}
@@ -131,6 +147,7 @@ class ElasticsearchFilterValidator:
         normalize: bool,
         depth: int = 0,
         clause_count: list[int] | None = None,
+        changes: list[tuple[str, str]] | None = None,
     ) -> None:
         if clause_count is None:
             clause_count = [0]
@@ -152,7 +169,11 @@ class ElasticsearchFilterValidator:
                     f"Filter contains more than {_MAX_CLAUSES} clauses."
                 )
             self._walk_clause(
-                clause, normalize=normalize, depth=depth, clause_count=clause_count
+                clause,
+                normalize=normalize,
+                depth=depth,
+                clause_count=clause_count,
+                changes=changes,
             )
 
     def _walk_clause(
@@ -162,6 +183,7 @@ class ElasticsearchFilterValidator:
         normalize: bool,
         depth: int,
         clause_count: list[int],
+        changes: list[tuple[str, str]] | None = None,
     ) -> None:
         if not isinstance(clause, dict) or len(clause) != 1:
             raise FilterSyntaxError(
@@ -173,7 +195,11 @@ class ElasticsearchFilterValidator:
 
         if clause_type in _BOOL_CLAUSE_TYPES:
             self._walk_bool(
-                body, normalize=normalize, depth=depth + 1, clause_count=clause_count
+                body,
+                normalize=normalize,
+                depth=depth + 1,
+                clause_count=clause_count,
+                changes=changes,
             )
             return
 
@@ -183,7 +209,9 @@ class ElasticsearchFilterValidator:
                 f"{sorted(_LEAF_CLAUSE_TYPES | _BOOL_CLAUSE_TYPES)}."
             )
 
-        self._validate_leaf(clause, clause_type, body, normalize=normalize)
+        self._validate_leaf(
+            clause, clause_type, body, normalize=normalize, changes=changes
+        )
 
     def _walk_bool(
         self,
@@ -192,6 +220,7 @@ class ElasticsearchFilterValidator:
         normalize: bool,
         depth: int,
         clause_count: list[int],
+        changes: list[tuple[str, str]] | None = None,
     ) -> None:
         if not isinstance(body, dict):
             raise FilterSyntaxError(
@@ -227,6 +256,7 @@ class ElasticsearchFilterValidator:
                 normalize=normalize,
                 depth=depth,
                 clause_count=clause_count,
+                changes=changes,
             )
 
     # ------------------------------------------------------------------
@@ -240,6 +270,7 @@ class ElasticsearchFilterValidator:
         body: Any,
         *,
         normalize: bool,
+        changes: list[tuple[str, str]] | None = None,
     ) -> None:
         # `exists` body is `{"field": "<path>"}`; others are `{"<path>": <value>}`.
         if clause_type == "exists":
@@ -252,9 +283,17 @@ class ElasticsearchFilterValidator:
                 raise FilterSyntaxError(
                     "'exists' clause 'field' value must be a string."
                 )
-            field_name, _ = self._strip_field_path(field_path)
+            field_name, had_keyword = self._strip_field_path(field_path)
             field_def = self._lookup_field(field_name)
             self._assert_clause_compatible(field_def, clause_type)
+            if normalize:
+                normalized_path = self._normalize_field_path(
+                    field_def, clause_type, field_name, had_keyword
+                )
+                if normalized_path != field_path:
+                    clause[clause_type] = {"field": normalized_path}
+                    if changes is not None:
+                        changes.append((field_path, normalized_path))
             return
 
         if not isinstance(body, dict) or len(body) != 1:
@@ -278,13 +317,17 @@ class ElasticsearchFilterValidator:
             if not isinstance(value, list):
                 raise FilterSyntaxError("'terms' clause value must be an array.")
 
-        # Normalization: ensure `.keyword` suffix where appropriate.
+        # Normalization: ensure `.keyword` suffix where appropriate, and strip
+        # it from non-string-like fields where it would target a non-existent
+        # ES sub-field.
         if normalize:
             normalized_path = self._normalize_field_path(
                 field_def, clause_type, field_name, had_keyword
             )
             if normalized_path != field_path:
                 clause[clause_type] = {normalized_path: value}
+                if changes is not None:
+                    changes.append((field_path, normalized_path))
 
     # ------------------------------------------------------------------
     # Helpers
@@ -374,20 +417,30 @@ class ElasticsearchFilterValidator:
 
         - Always prefixes with `metadata.content_metadata.`.
         - Adds `.keyword` for exact-match clauses on string-like fields.
+        - Strips a caller-supplied `.keyword` for non-string-like fields.
+          Rationale: `.keyword` is an Elasticsearch text multi-field — it only
+          exists on `string`-typed fields. Targeting `<numeric_field>.keyword`
+          points at a non-existent mapping and silently returns zero hits
+          (which previously broke UI-issued filters such as
+          `term: {priority.keyword: 2}` on an integer `priority`).
         """
         path = f"{_METADATA_PREFIX}{field_name}"
 
-        wants_keyword = clause_type in {"term", "terms", "prefix"} and (
-            field_def.type == MetadataType.STRING.value
-            or (
-                field_def.type == MetadataType.ARRAY.value
-                and field_def.array_type == MetadataType.STRING.value
-            )
+        is_string_like = field_def.type == MetadataType.STRING.value or (
+            field_def.type == MetadataType.ARRAY.value
+            and field_def.array_type == MetadataType.STRING.value
         )
-        if wants_keyword or had_keyword:
-            if wants_keyword:
-                path = f"{path}{_KEYWORD_SUFFIX}"
-            elif had_keyword:
-                # Preserve user intent
-                path = f"{path}{_KEYWORD_SUFFIX}"
+        # `term`/`terms`/`prefix` need `.keyword` on string-like fields to do
+        # exact (non-analyzed) matching. Other clause types either don't apply
+        # to strings or work on the analyzed text directly.
+        wants_keyword = clause_type in {"term", "terms", "prefix"} and is_string_like
+
+        if wants_keyword:
+            path = f"{path}{_KEYWORD_SUFFIX}"
+        elif had_keyword and is_string_like:
+            # Preserve user intent for string-like fields with non-default
+            # clauses (e.g. `wildcard` / `match` on the keyword sub-field).
+            path = f"{path}{_KEYWORD_SUFFIX}"
+        # else: caller supplied `.keyword` on a non-string field — drop it.
+
         return path

--- a/tests/unit/test_metadata_validation/test_es_filter_validator.py
+++ b/tests/unit/test_metadata_validation/test_es_filter_validator.py
@@ -215,6 +215,130 @@ class TestProcessFilter:
         validator.process_filter(clauses)
         assert clauses == snapshot
 
+    # --- Regression: `.keyword` on non-string fields must be stripped ---
+    # See _normalize_field_path. Caller-supplied `.keyword` targets a
+    # non-existent ES sub-field on numeric/datetime/boolean fields and would
+    # silently return zero hits without this normalization.
+
+    def test_strips_keyword_from_integer_term(self, validator):
+        clauses = [{"term": {"metadata.content_metadata.year.keyword": 2024}}]
+        result = validator.process_filter(clauses)
+        assert result["status"] is True
+        path = next(iter(result["processed_expression"][0]["term"].keys()))
+        assert path == "metadata.content_metadata.year"
+        assert result["normalization_changes"] == [
+            (
+                "metadata.content_metadata.year.keyword",
+                "metadata.content_metadata.year",
+            )
+        ]
+
+    def test_strips_keyword_from_float_term(self, validator):
+        clauses = [{"term": {"metadata.content_metadata.rating.keyword": 4.5}}]
+        result = validator.process_filter(clauses)
+        assert result["status"] is True
+        path = next(iter(result["processed_expression"][0]["term"].keys()))
+        assert path == "metadata.content_metadata.rating"
+
+    def test_strips_keyword_from_boolean_term(self, validator):
+        clauses = [{"term": {"metadata.content_metadata.is_public.keyword": True}}]
+        result = validator.process_filter(clauses)
+        assert result["status"] is True
+        path = next(iter(result["processed_expression"][0]["term"].keys()))
+        assert path == "metadata.content_metadata.is_public"
+
+    def test_strips_keyword_from_integer_terms(self, validator):
+        clauses = [{"terms": {"metadata.content_metadata.year.keyword": [2024, 2025]}}]
+        result = validator.process_filter(clauses)
+        assert result["status"] is True
+        path = next(iter(result["processed_expression"][0]["terms"].keys()))
+        assert path == "metadata.content_metadata.year"
+
+    def test_strips_keyword_from_datetime_range(self, validator):
+        clauses = [
+            {
+                "range": {
+                    "metadata.content_metadata.created_at.keyword": {
+                        "gte": "2024-01-01T00:00:00"
+                    }
+                }
+            }
+        ]
+        result = validator.process_filter(clauses)
+        assert result["status"] is True
+        path = next(iter(result["processed_expression"][0]["range"].keys()))
+        assert path == "metadata.content_metadata.created_at"
+
+    def test_strips_keyword_from_integer_range(self, validator):
+        clauses = [
+            {"range": {"metadata.content_metadata.year.keyword": {"gt": 2020}}}
+        ]
+        result = validator.process_filter(clauses)
+        assert result["status"] is True
+        path = next(iter(result["processed_expression"][0]["range"].keys()))
+        assert path == "metadata.content_metadata.year"
+
+    def test_preserves_keyword_on_string_wildcard(self, validator):
+        # `wildcard` on a string field can validly target `.keyword`; preserve
+        # the user's choice rather than rewriting it.
+        clauses = [
+            {"wildcard": {"metadata.content_metadata.status.keyword": "appr*"}}
+        ]
+        result = validator.process_filter(clauses)
+        assert result["status"] is True
+        path = next(iter(result["processed_expression"][0]["wildcard"].keys()))
+        assert path == "metadata.content_metadata.status.keyword"
+
+    def test_strips_keyword_inside_bool_must(self, validator):
+        # Normalization must recurse into bool composition.
+        clauses = [
+            {
+                "bool": {
+                    "must": [
+                        {"term": {"metadata.content_metadata.year.keyword": 2024}},
+                        {
+                            "term": {
+                                "metadata.content_metadata.status.keyword": "approved"
+                            }
+                        },
+                    ]
+                }
+            }
+        ]
+        result = validator.process_filter(clauses)
+        assert result["status"] is True
+        must = result["processed_expression"][0]["bool"]["must"]
+        # Integer year: keyword stripped.
+        assert "metadata.content_metadata.year" in must[0]["term"]
+        # String status: keyword preserved.
+        assert "metadata.content_metadata.status.keyword" in must[1]["term"]
+
+    def test_emits_warning_when_normalization_occurs(self, validator, caplog):
+        import logging as _logging
+
+        clauses = [{"term": {"metadata.content_metadata.year.keyword": 2024}}]
+        with caplog.at_level(
+            _logging.WARNING, logger="nvidia_rag.utils.es_filter_validator"
+        ):
+            validator.process_filter(clauses)
+        warnings = [r for r in caplog.records if r.levelno == _logging.WARNING]
+        assert any(
+            "[ES Filter]" in r.message
+            and "metadata.content_metadata.year.keyword" in r.message
+            for r in warnings
+        )
+
+    def test_no_log_when_no_changes(self, validator, caplog):
+        import logging as _logging
+
+        # A clean filter that the normalizer leaves untouched.
+        clauses = [{"term": {"metadata.content_metadata.year": 2024}}]
+        with caplog.at_level(
+            _logging.WARNING, logger="nvidia_rag.utils.es_filter_validator"
+        ):
+            validator.process_filter(clauses)
+        assert not any("[ES Filter]" in r.message for r in caplog.records)
+
 
 class TestDepthAndCount:
     def test_deeply_nested_bool_rejected(self, validator):


### PR DESCRIPTION
## Fix Elasticsearch filter on non-string fields (`.keyword` mis-applied)
- **Backend self-heal + WARNING log** (`src/nvidia_rag/utils/es_filter_validator.py`) — `_normalize_field_path` now **strips** a caller-supplied `.keyword` from non-string fields (integer/float/datetime/boolean) instead of preserving it. `.keyword` is an ES multi-field that only exists on string mappings; targeting `<numeric_field>.keyword` previously pointed at a non-existent path and silently returned zero hits (e.g. `term: {priority.keyword: 2}` on an integer `priority`). `process_filter` now emits one concise WARNING per request listing every rewrite so users aren't blinded when their filter is corrected server-side.

- **LLM prompt hardened** (`src/nvidia_rag/rag_server/prompt.yaml`) — added an explicit ✅/❌ table to the Elasticsearch filter-generator prompt showing correct bare-path usage for integer/float/datetime/boolean and reserving `.keyword` for string and array<string> fields, so LLM-generated filters don't reproduce the same mistake.

- **Frontend type-aware compiler** (`frontend/src/utils/filterExpression.ts`, `hooks/useMessageSubmit.ts`, `types/requests.ts`) — `compileElasticsearchFilter` now accepts the schema-derived `FieldTypeMap` (it was already built but ignored). `.keyword` is appended only for `term` / `terms` / `prefix` / `wildcard` / `match` on string-like fields; `range` never carries `.keyword`; unknown fields fall back to string-like to preserve back-compat (the backend normalizer will strip if needed).


## Checklist
- [X] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [X] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [X] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.