### PR TITLE
ci: add blueprints-skills-eval-runner as default runner

### DIFF
--- a/.github/workflows/run-branch-script.yml
+++ b/.github/workflows/run-branch-script.yml
@@ -19,9 +19,10 @@ on:
       runner:
         description: 'Runner label to use'
         required: true
-        default: 'sonarqube-workflows-bp-sre'
+        default: 'blueprints-skills-eval-runner'
         type: choice
         options:
+          - blueprints-skills-eval-runner
           - sonarqube-workflows-bp-sre
           - arc-runners-org-nvidia-ai-bp-2-gpu
 


### PR DESCRIPTION
New dedicated internal VM for RAG skill eval CI. Added as default runner option in the dispatcher workflow. sonarqube-workflows-bp-sre kept as fallback.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.