### PR TITLE
ci: add rag-eval runner option to Run Branch Script dispatcher

### DIFF
--- a/.github/workflows/run-branch-script.yml
+++ b/.github/workflows/run-branch-script.yml
@@ -25,6 +25,7 @@ on:
           - blueprints-skills-eval-runner
           - sonarqube-workflows-bp-sre
           - arc-runners-org-nvidia-ai-bp-2-gpu
+          - rag-eval
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Adds `rag-eval` to the `runner` choice list in `.github/workflows/run-branch-script.yml`.

## Why

We just registered a dedicated self-hosted runner `rag-skill-validator` (a Brev CPU VM) at the org level with labels `[self-hosted, Linux, X64, rag-eval, brev, rag]`. This mirrors the VSS pattern (`vss-skill-validator` with label `vss-eval`).

To target this runner from \`Run Branch Script\` dispatcher, the label needs to be in the input choice list. This is a 1-line additive change — no existing options change, no logic change.

## What this enables

Once merged, triggering Actions → Run Branch Script → Run workflow → \`runner=rag-eval\` will route the job to \`rag-skill-validator\` for the upcoming skill-eval CI on feat/skill-eval.

## Test plan

- [ ] Merge PR
- [ ] Actions → Run Branch Script → Run workflow → pick \`rag-eval\` from runner dropdown
- [ ] Job lands on \`rag-skill-validator\` (verifiable in run logs and runner busy state)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)