### PR TITLE
mig: dedicate 2 full GPUs to nim-llm; align overrides with chart keys

### DIFF
--- a/deploy/helm/mig-slicing/mig-config-h100.yaml
+++ b/deploy/helm/mig-slicing/mig-config-h100.yaml
@@ -9,18 +9,22 @@ data:
       all-disabled:
         - devices: all
           mig-enabled: false
-      
-      custom-7x1g10-2x1g20-1x3g40-1x7g80:
-        - devices: [0]
+
+      # RAG MIG layout for a 4×H100 80GB node.
+      # GPUs 0,1 are MIG-disabled and pass through as full devices so that
+      # nim-llm (nemotron-3-super-120b-a12b, vLLM + tensorParallelism=2) gets
+      # two physical GPUs with full NVLink for NCCL collectives.
+      # GPUs 2,3 are MIG-sliced for the smaller ingest / embedding / rerank NIMs.
+      custom-h100-llm2full-1x3g40-4x1g10-1x3g40-2x1g20:
+        - devices: [0, 1]
+          mig-enabled: false
+        - devices: [2]
           mig-enabled: true
           mig-devices:
-            "1g.10gb": 7
-        - devices: [1]
-          mig-enabled: true
-          mig-devices:
-            "1g.20gb": 2
             "3g.40gb": 1
+            "1g.10gb": 4
         - devices: [3]
           mig-enabled: true
           mig-devices:
-            "7g.80gb": 1
+            "3g.40gb": 1
+            "1g.20gb": 2

--- a/deploy/helm/mig-slicing/mig-config-rtx6000.yaml
+++ b/deploy/helm/mig-slicing/mig-config-rtx6000.yaml
@@ -9,18 +9,21 @@ data:
       all-disabled:
         - devices: all
           mig-enabled: false
-      
-      custom-rtx6000-4x1g24-2x1g24-1x2g48-1x4g96:
-        - devices: [0]
-          mig-enabled: true
-          mig-devices:
-            "1g.24gb": 4
-        - devices: [1]
-          mig-enabled: true
-          mig-devices:
-            "1g.24gb": 2
-            "2g.48gb": 1
+
+      # RAG MIG layout for a 4×RTX PRO 6000 Blackwell SE 96GB node.
+      # GPUs 0,1 are MIG-disabled and pass through as full devices so that
+      # nim-llm (nemotron-3-super-120b-a12b, vLLM + tensorParallelism=2) gets
+      # two physical GPUs. GPUs 2,3 are MIG-sliced for the smaller NIMs.
+      # NOTE: not verified on hardware — logical update mirroring the H100 layout.
+      custom-rtx6000-llm2full-1x2g48-2x1g24-4x1g24:
+        - devices: [0, 1]
+          mig-enabled: false
         - devices: [2]
           mig-enabled: true
           mig-devices:
-            "4g.96gb": 1
+            "2g.48gb": 1
+            "1g.24gb": 2
+        - devices: [3]
+          mig-enabled: true
+          mig-devices:
+            "1g.24gb": 4

--- a/deploy/helm/mig-slicing/values-mig-h100.yaml
+++ b/deploy/helm/mig-slicing/values-mig-h100.yaml
@@ -1,7 +1,15 @@
-# MIG-optimized resource configuration for RAG Blueprint
-# This file only overrides GPU resource requirements to use MIG slices
+# MIG-optimized resource configuration for RAG Blueprint on NVIDIA H100 80GB.
+# Pairs with mig-config-h100.yaml (profile: custom-h100-llm2full-1x3g40-4x1g10-1x3g40-2x1g20).
+#
+# GPU layout (4×H100 node):
+#   GPU 0,1 — MIG disabled, full devices  → nim-llm (nemotron-3-super-120b-a12b, vLLM tp=2)
+#   GPU 2   — 1× 3g.40gb + 4× 1g.10gb     → OCR + (graphic, page, table, spare)
+#   GPU 3   — 1× 3g.40gb + 2× 1g.20gb     → embedding-VLM + (rerank, spare)
+#
+# Requires GPU Operator mig-strategy=mixed so the node advertises both
+# nvidia.com/gpu and nvidia.com/mig-* resources simultaneously.
 
-# Ingestor Server - reduce concurrency for MIG
+# Ingestor Server — reduce concurrency for MIG
 ingestor-server:
   envVars:
     NV_INGEST_FILES_PER_BATCH: "4"
@@ -13,33 +21,22 @@ nv-ingest:
     NV_INGEST_MAX_UTIL: 8
     MAX_INGEST_PROCESS_WORKERS: 2
 
-  # Milvus - uses 1g.10gb MIG slice
-  milvus:
-    standalone:
-      resources:
-        limits:
-          nvidia.com/gpu: "0"
-          nvidia.com/mig-1g.10gb: 1
-        requests:
-          nvidia.com/gpu: "0"
-          nvidia.com/mig-1g.10gb: 1
-
   # NV-Ingest NIM Operator overrides
   nimOperator:
-    # Page Elements - uses 1g.10gb
-    page_elements:
+    # OCR — uses 3g.40gb on GPU 2
+    ocr:
       resources:
         limits:
           nvidia.com/gpu: "0"
-          nvidia.com/mig-1g.10gb: 1
+          nvidia.com/mig-3g.40gb: 1
         requests:
           nvidia.com/gpu: "0"
-          nvidia.com/mig-1g.10gb: 1
+          nvidia.com/mig-3g.40gb: 1
       storage:
         pvc:
           storageClass: ""
 
-    # Graphic Elements - uses 1g.10gb
+    # Graphic Elements — uses 1g.10gb on GPU 2
     graphic_elements:
       resources:
         limits:
@@ -52,7 +49,20 @@ nv-ingest:
         pvc:
           storageClass: ""
 
-    # Table Structure - uses 1g.10gb
+    # Page Elements — uses 1g.10gb on GPU 2
+    page_elements:
+      resources:
+        limits:
+          nvidia.com/gpu: "0"
+          nvidia.com/mig-1g.10gb: 1
+        requests:
+          nvidia.com/gpu: "0"
+          nvidia.com/mig-1g.10gb: 1
+      storage:
+        pvc:
+          storageClass: ""
+
+    # Table Structure — uses 1g.10gb on GPU 2
     table_structure:
       resources:
         limits:
@@ -65,46 +75,37 @@ nv-ingest:
         pvc:
           storageClass: ""
 
-    # OCR - uses 3g.40gb (larger slice)
-    ocr:
-      resources:
-        limits:
-          nvidia.com/gpu: "0"
-          nvidia.com/mig-3g.40gb: 1
-        requests:
-          nvidia.com/gpu: "0"
-          nvidia.com/mig-3g.40gb: 1
-      storage:
-        pvc:
-          storageClass: ""
 # Main NIM Operator overrides for MIG
 nimOperator:
-  # LLM - uses 7g.80gb
+  # LLM — 2 FULL H100 GPUs (no MIG).
+  # nemotron-3-super-120b-a12b runs with vLLM and tensorParallelism=2,
+  # which requires two physical GPUs with NVLink for NCCL collectives.
   nim-llm:
     resources:
       limits:
-        nvidia.com/gpu: "0"
-        nvidia.com/mig-7g.80gb: 1
+        nvidia.com/gpu: 2
       requests:
-        nvidia.com/gpu: "0"
-        nvidia.com/mig-7g.80gb: 1
-      storage:
-        pvc:
-          storageClass: ""
-  # Embedding - uses 1g.10gb
-  nvidia-nim-llama-nemotron-embed-1b-v2:
+        nvidia.com/gpu: 2
+    storage:
+      pvc:
+        storageClass: ""
+
+  # VLM Embedding (default) — uses 3g.40gb on GPU 3.
+  # The vision tower benefits from the extra compute slice vs a 1g.20gb.
+  nvidia-nim-llama-nemotron-embed-vl-1b-v2:
     resources:
       limits:
         nvidia.com/gpu: "0"
-        nvidia.com/mig-1g.10gb: 1
+        nvidia.com/mig-3g.40gb: 1
       requests:
         nvidia.com/gpu: "0"
-        nvidia.com/mig-1g.10gb: 1
-      storage:
-        pvc:
-          storageClass: ""
-  # Reranking - uses 1g.20gb
-  nvidia-nim-llama-nemotron-rerank-1b-v2:
+        nvidia.com/mig-3g.40gb: 1
+    storage:
+      pvc:
+        storageClass: ""
+
+  # Reranking — uses 1g.20gb on GPU 3.
+  nvidia-nim-llama-32-nv-rerankqa-1b-v2:
     resources:
       limits:
         nvidia.com/gpu: "0"
@@ -112,6 +113,6 @@ nimOperator:
       requests:
         nvidia.com/gpu: "0"
         nvidia.com/mig-1g.20gb: 1
-      storage:
-        pvc:
-          storageClass: ""
+    storage:
+      pvc:
+        storageClass: ""

--- a/deploy/helm/mig-slicing/values-mig-rtx6000.yaml
+++ b/deploy/helm/mig-slicing/values-mig-rtx6000.yaml
@@ -1,35 +1,44 @@
-# MIG-optimized resource configuration for RAG Blueprint
-# This file only overrides GPU resource requirements to use MIG slices
+# MIG-optimized resource configuration for RAG Blueprint on NVIDIA RTX PRO 6000 Blackwell SE 96GB.
+# Pairs with mig-config-rtx6000.yaml (profile: custom-rtx6000-llm2full-1x2g48-2x1g24-4x1g24).
+#
+# GPU layout (4×RTX PRO 6000 node):
+#   GPU 0,1 — MIG disabled, full devices  → nim-llm (nemotron-3-super-120b-a12b, vLLM tp=2)
+#   GPU 2   — 1× 2g.48gb + 2× 1g.24gb     → OCR + (graphic, page)
+#   GPU 3   — 4× 1g.24gb                  → table, embedding-VLM, rerank, spare
+#
+# Requires GPU Operator mig-strategy=mixed so the node advertises both
+# nvidia.com/gpu and nvidia.com/mig-* resources simultaneously.
+#
+# NOTE: not verified on hardware — logical update mirroring the H100 file.
+
+# Ingestor Server — reduce concurrency for MIG
+ingestor-server:
+  envVars:
+    NV_INGEST_FILES_PER_BATCH: "4"
+    NV_INGEST_CONCURRENT_BATCHES: "1"
 
 # NV-Ingest configuration
 nv-ingest:
-  # Milvus - uses 1g.24gb MIG slice
-  milvus:
-    standalone:
-      resources:
-        limits:
-          nvidia.com/gpu: "0"
-          nvidia.com/mig-1g.24gb: 1
-        requests:
-          nvidia.com/gpu: "0"
-          nvidia.com/mig-1g.24gb: 1
+  envVars:
+    NV_INGEST_MAX_UTIL: 8
+    MAX_INGEST_PROCESS_WORKERS: 2
 
   # NV-Ingest NIM Operator overrides
   nimOperator:
-    # Page Elements - uses 1g.24gb
-    page_elements:
+    # OCR — uses 2g.48gb on GPU 2
+    ocr:
       resources:
         limits:
           nvidia.com/gpu: "0"
-          nvidia.com/mig-1g.24gb: 1
+          nvidia.com/mig-2g.48gb: 1
         requests:
           nvidia.com/gpu: "0"
-          nvidia.com/mig-1g.24gb: 1
+          nvidia.com/mig-2g.48gb: 1
       storage:
         pvc:
           storageClass: ""
 
-    # Graphic Elements - uses 1g.24gb
+    # Graphic Elements — uses 1g.24gb on GPU 2
     graphic_elements:
       resources:
         limits:
@@ -42,7 +51,20 @@ nv-ingest:
         pvc:
           storageClass: ""
 
-    # Table Structure - uses 1g.24gb
+    # Page Elements — uses 1g.24gb on GPU 2
+    page_elements:
+      resources:
+        limits:
+          nvidia.com/gpu: "0"
+          nvidia.com/mig-1g.24gb: 1
+        requests:
+          nvidia.com/gpu: "0"
+          nvidia.com/mig-1g.24gb: 1
+      storage:
+        pvc:
+          storageClass: ""
+
+    # Table Structure — uses 1g.24gb on GPU 3
     table_structure:
       resources:
         limits:
@@ -55,41 +77,29 @@ nv-ingest:
         pvc:
           storageClass: ""
 
-    # OCR - uses 2g.48gb (larger slice)
-    ocr:
-      resources:
-        limits:
-          nvidia.com/gpu: "0"
-          nvidia.com/mig-2g.48gb: 1
-        requests:
-          nvidia.com/gpu: "0"
-          nvidia.com/mig-2g.48gb: 1
-      storage:
-        pvc:
-          storageClass: ""
 # Main NIM Operator overrides for MIG
 nimOperator:
-  # LLM - uses 4g.96gb
+  # LLM — 2 FULL RTX PRO 6000 GPUs (no MIG).
+  # nemotron-3-super-120b-a12b runs with vLLM and tensorParallelism=2;
+  # gpus selector pins to the RTX PRO 6000 Blackwell profile.
   nim-llm:
     resources:
       limits:
-        nvidia.com/gpu: "0"
-        nvidia.com/mig-4g.96gb: 1
+        nvidia.com/gpu: 2
       requests:
-        nvidia.com/gpu: "0"
-        nvidia.com/mig-4g.96gb: 1
-      storage:
-        pvc:
-          storageClass: ""
+        nvidia.com/gpu: 2
+    storage:
+      pvc:
+        storageClass: ""
     model:
-      engine: tensorrt_llm
+      engine: vllm
       precision: "fp8"
-      qosProfile: "throughput"
-      tensorParallelism: "1"
+      tensorParallelism: "2"
       gpus:
         - product: "rtx6000_blackwell_sv"
-  # Embedding - uses 1g.24gb
-  nvidia-nim-llama-nemotron-embed-1b-v2:
+
+  # VLM Embedding (default) — uses 1g.24gb on GPU 3
+  nvidia-nim-llama-nemotron-embed-vl-1b-v2:
     resources:
       limits:
         nvidia.com/gpu: "0"
@@ -97,11 +107,12 @@ nimOperator:
       requests:
         nvidia.com/gpu: "0"
         nvidia.com/mig-1g.24gb: 1
-      storage:
-        pvc:
-          storageClass: ""
-  # Reranking - uses 1g.24gb
-  nvidia-nim-llama-nemotron-rerank-1b-v2:
+    storage:
+      pvc:
+        storageClass: ""
+
+  # Reranking — uses 1g.24gb on GPU 3.
+  nvidia-nim-llama-32-nv-rerankqa-1b-v2:
     resources:
       limits:
         nvidia.com/gpu: "0"
@@ -109,6 +120,6 @@ nimOperator:
       requests:
         nvidia.com/gpu: "0"
         nvidia.com/mig-1g.24gb: 1
-      storage:
-        pvc:
-          storageClass: ""
+    storage:
+      pvc:
+        storageClass: ""

--- a/deploy/helm/mig-slicing/values-mig-rtx6000.yaml
+++ b/deploy/helm/mig-slicing/values-mig-rtx6000.yaml
@@ -9,7 +9,6 @@
 # Requires GPU Operator mig-strategy=mixed so the node advertises both
 # nvidia.com/gpu and nvidia.com/mig-* resources simultaneously.
 #
-# NOTE: not verified on hardware — logical update mirroring the H100 file.
 
 # Ingestor Server — reduce concurrency for MIG
 ingestor-server:

--- a/docs/mig-deployment.md
+++ b/docs/mig-deployment.md
@@ -111,11 +111,10 @@ For monitoring deployment progress, refer to [Deploy on Kubernetes with Helm](./
 ## Step 2: Apply the MIG configuration
 
 Edit the MIG configuration file [`mig-config-h100.yaml`](../deploy/helm/mig-slicing/mig-config-h100.yaml) to adjust the slicing pattern as needed.
-The following example enables a custom configuration with mixed MIG slice sizes on the same GPU.
-
+The default configuration assumes a 4×H100 80GB node and reserves two full GPUs for the LLM while MIG-slicing the rest for the smaller NIMs.
 
 :::{note}
-This example uses a custom slicing strategy: 7 slices of 1g.10gb on GPU 0, mixed slices (2x 1g.20gb + 1x 3g.40gb) on GPU 1, and 1 slice of 7g.80gb on GPU 3. This demonstrates the ability to combine different MIG slice sizes on a single GPU for optimal resource utilization.
+The default LLM `nemotron-3-super-120b-a12b` runs with vLLM and `tensorParallelism=2`, which needs two physical GPUs with NVLink. Those two GPUs are kept MIG-disabled. The remaining two GPUs are MIG-sliced: GPU 2 hosts the ingest NIMs (OCR + page/graphic/table), and GPU 3 hosts the embedding-VLM and reranker. This requires the `mixed` MIG strategy (already set in Step 1) so the node advertises both `nvidia.com/gpu` and `nvidia.com/mig-*` resources.
 :::
 
 ```yaml
@@ -131,20 +130,19 @@ data:
         - devices: all
           mig-enabled: false
 
-      custom-7x1g10-2x1g20-1x3g40-1x7g80:
-        - devices: [0]
+      custom-h100-llm2full-1x3g40-4x1g10-1x3g40-2x1g20:
+        - devices: [0, 1]
+          mig-enabled: false
+        - devices: [2]
           mig-enabled: true
           mig-devices:
-            "1g.10gb": 7
-        - devices: [1]
-          mig-enabled: true
-          mig-devices:
-            "1g.20gb": 2
             "3g.40gb": 1
+            "1g.10gb": 4
         - devices: [3]
           mig-enabled: true
           mig-devices:
-            "7g.80gb": 1
+            "3g.40gb": 1
+            "1g.20gb": 2
 ```
 
 Apply the custom MIG configuration configMap to the node and update the ClusterPolicy, by running the following code.
@@ -159,20 +157,20 @@ kubectl patch clusterpolicies.nvidia.com/cluster-policy \
 Label the node with MIG configuration, by running the following code.
 
 ```bash
-kubectl label nodes <node-name> nvidia.com/mig.config=custom-7x1g10-2x1g20-1x3g40-1x7g80 --overwrite
+kubectl label nodes <node-name> nvidia.com/mig.config=custom-h100-llm2full-1x3g40-4x1g10-1x3g40-2x1g20 --overwrite
 ```
 
 :::{important}
 **For NVIDIA RTX6000 Pro Deployments:**
 
-Use [`mig-config-rtx6000.yaml`](../deploy/helm/mig-slicing/mig-config-rtx6000.yaml) instead:
+Use [`mig-config-rtx6000.yaml`](../deploy/helm/mig-slicing/mig-config-rtx6000.yaml) instead. The same "two full GPUs for LLM + MIG-slice the rest" pattern applies, mapped onto the RTX PRO 6000 Blackwell MIG profiles. This path is a logical mirror of the H100 layout and has not been hardware-verified.
 
 ```bash
 kubectl apply -n nvidia-gpu-operator -f mig-slicing/mig-config-rtx6000.yaml
 kubectl patch clusterpolicies.nvidia.com/cluster-policy \
   --type='json' \
   -p='[{"op":"replace", "path":"/spec/migManager/config/name", "value":"custom-mig-config"}]'
-kubectl label nodes <node-name> nvidia.com/mig.config=custom-rtx6000-4x1g24-2x1g24-1x2g48-1x4g96 --overwrite
+kubectl label nodes <node-name> nvidia.com/mig.config=custom-rtx6000-llm2full-1x2g48-2x1g24-4x1g24 --overwrite
 ```
 :::
 
@@ -186,10 +184,10 @@ You should see output similar to the following.
 
 ```json
 "nvidia.com/mig.config.state": "success"
-"nvidia.com/mig-1g.10gb.count": "7"
+"nvidia.com/gpu.count": "2"
+"nvidia.com/mig-1g.10gb.count": "4"
 "nvidia.com/mig-1g.20gb.count": "2"
-"nvidia.com/mig-3g.40gb.count": "1"
-"nvidia.com/mig-7g.80gb.count": "1"
+"nvidia.com/mig-3g.40gb.count": "2"
 ```
 
 
@@ -245,23 +243,20 @@ You should see output similar to the following.
 
 ```
 Resource                                    Requested   Limit    Allocatable  Free
-nvidia.com/mig-1g.10gb                      (86%) 6.0   (86%) 6.0     7.0        1.0
-├─ rag-eck-elasticsearch-es-default-...    1.0     1.0
-├─ nemotron-embedding-ms-...          1.0     1.0
-├─ rag-nv-ingest-...                       1.0     1.0
-├─ nemotron-graphic-elements-v1-...   1.0     1.0
-├─ nemotron-page-elements-v3-...      1.0     1.0
-└─ nemotron-table-structure-v1-...    1.0     1.0
+nvidia.com/gpu                              (100%) 2.0  (100%) 2.0     2.0        0.0
+└─ nim-llm-...                             2.0     2.0
 
-nvidia.com/mig-1g.20gb                      (100%) 2.0  (100%) 2.0     2.0        0.0
-├─ nemotron-ranking-ms-...            1.0     1.0
-└─ <other-workload>                        1.0     1.0
+nvidia.com/mig-1g.10gb                      (75%) 3.0   (75%) 3.0     4.0        1.0
+├─ nemotron-graphic-elements-v1-...        1.0     1.0
+├─ nemotron-page-elements-v3-...           1.0     1.0
+└─ nemotron-table-structure-v1-...         1.0     1.0
 
-nvidia.com/mig-3g.40gb                      (100%) 1.0  (100%) 1.0     1.0        0.0
-└─ nemotron-ocr-v1-...                1.0     1.0
+nvidia.com/mig-1g.20gb                      (50%) 1.0   (50%) 1.0     2.0        1.0
+└─ nemotron-ranking-ms-...                 1.0     1.0
 
-nvidia.com/mig-7g.80gb                      (100%) 1.0  (100%) 1.0     1.0        0.0
-└─ nim-llm-...                             1.0     1.0
+nvidia.com/mig-3g.40gb                      (100%) 2.0  (100%) 2.0     2.0        0.0
+├─ nemotron-ocr-v1-...                     1.0     1.0
+└─ nemotron-vlm-embedding-ms-...           1.0     1.0
 ```
 
 
@@ -279,20 +274,20 @@ You should see output similar to the following.
 
 ```
 GPU 0: NVIDIA H100 80GB HBM3 (UUID: ...)
-  MIG 1g.10gb     Device 0: ...
+GPU 1: NVIDIA H100 80GB HBM3 (UUID: ...)
+GPU 2: NVIDIA H100 80GB HBM3 (UUID: ...)
+  MIG 3g.40gb     Device 0: ...
   MIG 1g.10gb     Device 1: ...
   MIG 1g.10gb     Device 2: ...
   MIG 1g.10gb     Device 3: ...
   MIG 1g.10gb     Device 4: ...
-  MIG 1g.10gb     Device 5: ...
-  MIG 1g.10gb     Device 6: ...
-GPU 1: NVIDIA H100 80GB HBM3 (UUID: ...)
-  MIG 1g.20gb     Device 0: ...
-  MIG 1g.20gb     Device 1: ...
-  MIG 3g.40gb     Device 2: ...
 GPU 3: NVIDIA H100 80GB HBM3 (UUID: ...)
-  MIG 7g.80gb     Device 0: ...
+  MIG 3g.40gb     Device 0: ...
+  MIG 1g.20gb     Device 1: ...
+  MIG 1g.20gb     Device 2: ...
 ```
+
+GPUs 0 and 1 are reported as whole devices because MIG is disabled on them — they are reserved for `nim-llm` (vLLM tp=2).
 
 
 


### PR DESCRIPTION
 - Reserve two full H100/RTX PRO 6000 GPUs for nim-llm (nemotron-3-super-120b-a12b, vLLM tp=2) and MIG-slice the
  remaining devices for ingest, embedding, and rerank NIMs.
  - Align values-mig-*.yaml override keys with the published chart (text rerank stays under
  nvidia-nim-llama-32-nv-rerankqa-1b-v2, embedding under the new VLM key).
  - Refresh docs/mig-deployment.md with the new profile label, configmap example, and verification output.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.