### PR TITLE
Added llm settings in Agentic RAG and Prompt changes

### DIFF
--- a/deploy/compose/nvdev.env
+++ b/deploy/compose/nvdev.env
@@ -117,6 +117,25 @@ export AGENTIC_SYNTHESIS_LLM_MODEL=nvidia/nemotron-3-super-120b-a12b
 # export AGENTIC_SEED_GEN_LLM_APIKEY=""
 # export AGENTIC_SYNTHESIS_LLM_APIKEY=""
 
+# Per-role generation parameter overrides. Uncomment to override the built-in
+# defaults shown below. Request-time values passed to /generate take precedence
+# over both env vars and the defaults.
+# Built-in defaults (applied automatically when unset):
+#   planner / seed_gen → temperature=0.1, top_p=1.0, max_tokens=32768
+#   task / synthesis   → temperature=0.0, top_p=1.0, max_tokens=32768
+# export AGENTIC_PLANNER_LLM_TEMPERATURE=0.1
+# export AGENTIC_PLANNER_LLM_TOP_P=1.0
+# export AGENTIC_PLANNER_LLM_MAX_TOKENS=32768
+# export AGENTIC_TASK_LLM_TEMPERATURE=0.0
+# export AGENTIC_TASK_LLM_TOP_P=1.0
+# export AGENTIC_TASK_LLM_MAX_TOKENS=32768
+# export AGENTIC_SEED_GEN_LLM_TEMPERATURE=0.1
+# export AGENTIC_SEED_GEN_LLM_TOP_P=1.0
+# export AGENTIC_SEED_GEN_LLM_MAX_TOKENS=32768
+# export AGENTIC_SYNTHESIS_LLM_TEMPERATURE=0.0
+# export AGENTIC_SYNTHESIS_LLM_TOP_P=1.0
+# export AGENTIC_SYNTHESIS_LLM_MAX_TOKENS=32768
+
 # Agent behaviour tuning (values match reference config defaults)
 export AGENTIC_LOG_LEVEL=INFO
 

--- a/src/nvidia_rag/rag_server/agentic_rag/agentic_rag.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/agentic_rag.py
@@ -219,14 +219,28 @@ class AgenticRag:
     # PER-REQUEST LLM OVERRIDE (runtime model / endpoint from RAG API)
     # =========================================================================
 
-    def _resolve_role_llm(self, default_llm: BaseChatModel) -> BaseChatModel:
+    def _resolve_role_llm(
+        self, role_name: str, default_llm: BaseChatModel
+    ) -> BaseChatModel:
         """Return either the per-request override LLM or the cached default.
 
         Looks up ``_agentic_llm_overrides`` ContextVar (set by main._agentic_chain
-        before graph.ainvoke).  When an override is in effect, all four role
-        properties return the same override-built LLM client — the first access
-        constructs it via get_llm() and caches it on the override dataclass for
-        the remainder of the request.
+        before graph.ainvoke).
+
+        Override behavior:
+          - When **model** or **llm_endpoint** is overridden, all four roles
+            share a single override-built LLM client (cached under the
+            ``__shared__`` key) — preserving the FR-1527 semantics of "runtime
+            model applies to every agentic LLM".
+          - When only generation params (**temperature** / **top_p** /
+            **max_tokens**) are overridden, each role keeps its own configured
+            model / endpoint and gets a freshly built client with those
+            generation params applied (cached per-role).
+          - When no override is set, the cached default LLM is returned.
+
+        Missing override fields fall through per-field:
+            override → per-role agentic cfg → planner agentic cfg → main RAG
+            LLM config (``rag_config.llm`` or ``rag_config.llm.parameters``).
 
         ContextVar isolation guarantees concurrent requests see independent
         override state, so the per-request cache cannot leak across requests.
@@ -236,35 +250,151 @@ class AgenticRag:
         from nvidia_rag.rag_server.agentic_rag.builder import _agentic_llm_overrides
 
         overrides = _agentic_llm_overrides.get()
-        if overrides is None or not (overrides.model or overrides.llm_endpoint):
+        if overrides is None or not overrides.has_any_override():
             return default_llm
 
-        if overrides._built_llm is None:
-            from nvidia_rag.utils.llm import get_llm
+        model_or_endpoint_overridden = (
+            overrides.model is not None or overrides.llm_endpoint is not None
+        )
+        cache_key = "__shared__" if model_or_endpoint_overridden else role_name
 
-            overrides._built_llm = get_llm(
-                config=self._rag_config,
-                model=overrides.model,
-                llm_endpoint=overrides.llm_endpoint,
-                api_key=overrides.api_key,
+        cache = overrides._built_llms
+        if cache_key in cache:
+            return cache[cache_key]
+
+        # Resolve per-role / planner agentic cfgs defensively — _rag_config may be
+        # None in unit tests that don't supply a full NvidiaRAGConfig.
+        agentic_cfg = (
+            getattr(self._rag_config, "agentic_rag", None)
+            if self._rag_config is not None
+            else None
+        )
+        role_cfg = (
+            getattr(agentic_cfg, f"{role_name}_llm", None)
+            if agentic_cfg is not None
+            else None
+        )
+        planner_cfg = (
+            getattr(agentic_cfg, "planner_llm", None)
+            if agentic_cfg is not None
+            else None
+        )
+        # When sharing one client across all roles (model/endpoint overridden),
+        # use planner as the role-level fallback for generation params — it's the
+        # canonical fallback already used elsewhere for missing per-role values.
+        effective_role_cfg = planner_cfg if model_or_endpoint_overridden else role_cfg
+
+        rag_llm = (
+            getattr(self._rag_config, "llm", None)
+            if self._rag_config is not None
+            else None
+        )
+        rag_llm_params = (
+            getattr(rag_llm, "parameters", None) if rag_llm is not None else None
+        )
+
+        def _resolve_gen(field_name: str, override_val: Any) -> Any:
+            if override_val is not None:
+                return override_val
+            if effective_role_cfg is not None:
+                role_val = getattr(effective_role_cfg, field_name, None)
+                if role_val is not None:
+                    return role_val
+            if planner_cfg is not None:
+                planner_val = getattr(planner_cfg, field_name, None)
+                if planner_val is not None:
+                    return planner_val
+            if rag_llm_params is not None:
+                return getattr(rag_llm_params, field_name, None)
+            return None
+
+        # Resolve model / endpoint / api_key.
+        if model_or_endpoint_overridden:
+            # Force model/endpoint to override values; api_key falls back through
+            # planner cfg → main RAG LLM cfg.
+            model = overrides.model
+            if model is None:
+                if planner_cfg is not None and planner_cfg.model_name:
+                    model = planner_cfg.model_name
+                elif rag_llm is not None:
+                    model = rag_llm.model_name
+            server_url = overrides.llm_endpoint
+            if server_url is None:
+                if planner_cfg is not None and planner_cfg.server_url:
+                    server_url = planner_cfg.server_url
+                elif rag_llm is not None:
+                    server_url = rag_llm.server_url
+            api_key = overrides.api_key
+            if api_key is None and planner_cfg is not None:
+                api_key = planner_cfg.get_api_key()
+            if api_key is None and rag_llm is not None:
+                api_key = rag_llm.get_api_key()
+        else:
+            # Only generation params overridden — keep this role's model/endpoint.
+            cfg = (
+                role_cfg
+                if (role_cfg is not None and role_cfg.model_name)
+                else planner_cfg
             )
-        return overrides._built_llm
+            model = None
+            server_url = None
+            api_key = None
+            if cfg is not None:
+                model = cfg.model_name or None
+                server_url = cfg.server_url or None
+                api_key = cfg.get_api_key()
+            if not model and rag_llm is not None:
+                model = rag_llm.model_name
+            if not server_url and rag_llm is not None:
+                server_url = rag_llm.server_url
+            if api_key is None and rag_llm is not None:
+                api_key = rag_llm.get_api_key()
+
+        temperature = _resolve_gen("temperature", overrides.temperature)
+        top_p = _resolve_gen("top_p", overrides.top_p)
+        max_tokens = _resolve_gen("max_tokens", overrides.max_tokens)
+
+        logger.info(
+            "Creating override agentic LLM (cache_key=%s, role=%s): "
+            "model=%s, url=%s, temperature=%s, top_p=%s, max_tokens=%s",
+            cache_key,
+            role_name,
+            model,
+            server_url or "(api-catalog)",
+            temperature,
+            top_p,
+            max_tokens,
+        )
+
+        from nvidia_rag.utils.llm import get_llm
+
+        built = get_llm(
+            config=self._rag_config,
+            model=model,
+            llm_endpoint=server_url,
+            api_key=api_key,
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_tokens,
+        )
+        cache[cache_key] = built
+        return built
 
     @property
     def planner_llm(self) -> BaseChatModel:
-        return self._resolve_role_llm(self._default_planner_llm)
+        return self._resolve_role_llm("planner", self._default_planner_llm)
 
     @property
     def task_llm(self) -> BaseChatModel:
-        return self._resolve_role_llm(self._default_task_llm)
+        return self._resolve_role_llm("task", self._default_task_llm)
 
     @property
     def seed_gen_llm(self) -> BaseChatModel:
-        return self._resolve_role_llm(self._default_seed_gen_llm)
+        return self._resolve_role_llm("seed_gen", self._default_seed_gen_llm)
 
     @property
     def synthesis_llm(self) -> BaseChatModel:
-        return self._resolve_role_llm(self._default_synthesis_llm)
+        return self._resolve_role_llm("synthesis", self._default_synthesis_llm)
 
     @contextmanager
     def _otel_and_trace(self, span_name: str, span_kind: str = "CHAIN"):
@@ -866,7 +996,7 @@ class AgenticRag:
                         self.seed_gen_prompt,
                         {"question": question, "tried_queries": tried_summary},
                         step_name=f"Task {tid} seed gen (attempt {attempt + 1})",
-                        json_mode=False,
+                        json_mode=True,
                         # config intentionally omitted — see method docstring.
                     )
                     seed_result = self._parse_json_response(seed_response)
@@ -964,6 +1094,7 @@ class AgenticRag:
                     {"question": task_question, "documents": docs_str},
                     step_name=f"Task {tid} answer (attempt {attempt + 1})",
                     # config intentionally omitted — see method docstring.
+                    json_mode=True,
                 )
                 parsed = self._parse_task_answer(raw_answer)
 
@@ -1192,7 +1323,7 @@ class AgenticRag:
                             "scope_section": scope_section,
                         },
                         step_name=f"Planner ({phase})",
-                        json_mode=False,
+                        json_mode=True,
                         config=config,
                     )
                     plan = self._parse_json_response(response)
@@ -1741,7 +1872,7 @@ class AgenticRag:
                         "task_summary": task_summary,
                     },
                     step_name="Verification",
-                    json_mode=False,
+                    json_mode=True,
                     config=config,
                 )
                 result = self._parse_json_response(response)

--- a/src/nvidia_rag/rag_server/agentic_rag/builder.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/builder.py
@@ -87,9 +87,10 @@ logger = logging.getLogger(__name__)
 class AgenticLLMOverrides:
     """Per-request LLM overrides applied across all 4 agentic roles.
 
-    When the /generate API receives a non-None ``model`` or ``llm_endpoint``,
-    the value is propagated to planner / task / seed_gen / synthesis LLMs via
-    this dataclass on the ``_agentic_llm_overrides`` ContextVar.
+    When the /generate API receives a non-None ``model``, ``llm_endpoint``,
+    ``temperature``, ``top_p``, or ``max_tokens``, the value is propagated to
+    planner / task / seed_gen / synthesis LLMs via this dataclass on the
+    ``_agentic_llm_overrides`` ContextVar.
 
     ``_built_llm`` is a per-request cache: the first role-property access builds
     the override LLM client; subsequent accesses (other roles, same request)
@@ -100,8 +101,31 @@ class AgenticLLMOverrides:
     model: str | None = None
     llm_endpoint: str | None = None
     api_key: str | None = None
-    # Mutable cache slot; not part of equality / hashing.
-    _built_llm: Any = field(default=None, repr=False, compare=False)
+    temperature: float | None = None
+    top_p: float | None = None
+    max_tokens: int | None = None
+    # Per-request cache: maps cache key → built LLM client. Key is "__shared__"
+    # when model/endpoint is overridden (all 4 roles collapse to one client);
+    # otherwise it's the role name (planner / task / seed_gen / synthesis) so
+    # each role gets its own client with that role's configured model/endpoint
+    # but the request-provided generation params applied.
+    # Mutable; not part of equality / hashing.
+    _built_llms: dict[str, Any] = field(
+        default_factory=dict, repr=False, compare=False
+    )
+
+    def has_any_override(self) -> bool:
+        """True if at least one non-None override is set."""
+        return any(
+            v is not None
+            for v in (
+                self.model,
+                self.llm_endpoint,
+                self.temperature,
+                self.top_p,
+                self.max_tokens,
+            )
+        )
 
 
 # ContextVar holding per-request LLM overrides.
@@ -246,6 +270,26 @@ def make_retriever_fn(
 # =============================================================================
 
 
+def _resolve_role_generation_param(
+    role_cfg: AgenticAnyLLMConfig,
+    fallback_cfg: AgenticAnyLLMConfig,
+    rag_config: NvidiaRAGConfig,
+    field_name: str,
+) -> Any:
+    """Resolve one generation parameter (temperature / top_p / max_tokens).
+
+    Per-field fallback chain: role_cfg → fallback_cfg (planner) → rag_config.llm.parameters.
+    A value of ``None`` at any level is treated as "not set" and skipped.
+    """
+    role_val = getattr(role_cfg, field_name, None)
+    if role_val is not None:
+        return role_val
+    fallback_val = getattr(fallback_cfg, field_name, None)
+    if fallback_val is not None:
+        return fallback_val
+    return getattr(rag_config.llm.parameters, field_name, None)
+
+
 def _make_role_llm(
     role_cfg: AgenticAnyLLMConfig,
     fallback_cfg: AgenticAnyLLMConfig,
@@ -257,6 +301,11 @@ def _make_role_llm(
       1. role_cfg (if model_name is non-empty)
       2. fallback_cfg (planner LLM config)
       3. rag_config.llm (main RAG LLM config)
+
+    Resolution order for temperature / top_p / max_tokens (per-field):
+      1. role_cfg (if the field is non-None)
+      2. fallback_cfg (planner LLM config) (if non-None)
+      3. rag_config.llm.parameters (main RAG LLM parameters)
     """
     from nvidia_rag.utils.llm import get_llm
 
@@ -266,10 +315,23 @@ def _make_role_llm(
     server_url = cfg.server_url or rag_config.llm.server_url
     api_key = cfg.get_api_key() or rag_config.llm.get_api_key()
 
+    temperature = _resolve_role_generation_param(
+        role_cfg, fallback_cfg, rag_config, "temperature"
+    )
+    top_p = _resolve_role_generation_param(
+        role_cfg, fallback_cfg, rag_config, "top_p"
+    )
+    max_tokens = _resolve_role_generation_param(
+        role_cfg, fallback_cfg, rag_config, "max_tokens"
+    )
+
     logger.debug(
-        "Creating agentic LLM: model=%s, url=%s",
+        "Creating agentic LLM: model=%s, url=%s, temperature=%s, top_p=%s, max_tokens=%s",
         model_name,
         server_url or "(api-catalog)",
+        temperature,
+        top_p,
+        max_tokens,
     )
 
     return get_llm(
@@ -277,6 +339,9 @@ def _make_role_llm(
         model=model_name,
         llm_endpoint=server_url,
         api_key=api_key,
+        temperature=temperature,
+        top_p=top_p,
+        max_tokens=max_tokens,
     )
 
 

--- a/src/nvidia_rag/rag_server/agentic_rag/prompt.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/prompt.py
@@ -60,15 +60,52 @@ Think through these steps:
 5. SYNTHESIS INSTRUCTION: Describe how to combine all task answers into a final response. Leave empty ("") if scope_only=true or if there are no tasks.
 
 Rules:
-- Each task needs a question and a retrieval query (10-20 words using natural vocabulary likely in source documents).
+- Each task object MUST contain ALL THREE fields: `id`, `question`, `query`. Omitting ANY field makes the output invalid.
+- `id`: a short unique identifier for the task (e.g. "t1", "t2", "disc1").
+- `question`: a specific sub-question in natural language describing what you want answered.
+- `query`: a SEPARATE 10-20 word retrieval query using natural vocabulary likely to appear in source documents. The `query` is sent to semantic search; the `question` is sent to the answering LLM. They serve different purposes and BOTH are required for every task.
 - For answer tasks (scope_only=false): the retrieval query MUST reference the same subject/entity as the question. For scope discovery tasks (scope_only=true): the query may be broader to explore what data exists.
 - Keep retrieval queries SHORT and NATURAL — use key entity names, time periods, and topic words. Avoid long formal document-title phrasing. Shorter queries with key terms match better in semantic search.
 - Documents may label the same concept differently — consider alternate terminology when writing queries.
 - If a requested metric is not directly available as a named entry, it may need to be derived from component values. Create tasks for the components.
 - Do not add tasks for information the query did not ask about.
 
-Output JSON only:
-{{"scope_only": true/false, "scope_resolution": "<what was resolved or needs discovery>", "resolved_query": "<resolved question>", "tasks": [{{"id": "<short_id>", "question": "<specific sub-question>", "query": "<10-20 word retrieval query>"}}], "synthesis_instruction": "<how to combine task answers; empty string if scope_only or no tasks>"}}"""
+Output JSON only — schema (every task object must contain id AND question AND query):
+{{
+  "scope_only": true | false,
+  "scope_resolution": "<what was resolved or needs discovery>",
+  "resolved_query": "<resolved question>",
+  "tasks": [
+    {{
+      "id": "<short id>",
+      "question": "<specific sub-question>",
+      "query": "<10-20 word retrieval query>"
+    }}
+  ],
+  "synthesis_instruction": "<how to combine task answers; empty string if scope_only or no tasks>"
+}}
+
+Example of a valid plan with two answer tasks (every task has all three fields):
+{{
+  "scope_only": false,
+  "scope_resolution": "Compare the key architectural features of the NVIDIA Blackwell and Hopper GPU architectures.",
+  "resolved_query": "How do the key architectural features of NVIDIA's Blackwell GPU architecture compare to those of the Hopper architecture?",
+  "tasks": [
+    {{
+      "id": "t1",
+      "question": "What are the key architectural features of the NVIDIA Blackwell GPU architecture?",
+      "query": "NVIDIA Blackwell GPU architecture key features"
+    }},
+    {{
+      "id": "t2",
+      "question": "What are the key architectural features of the NVIDIA Hopper GPU architecture?",
+      "query": "NVIDIA Hopper GPU architecture key features"
+    }}
+  ],
+  "synthesis_instruction": "Summarize the key architectural features of Blackwell and Hopper, then contrast them side by side."
+}}
+
+REMEMBER: every task object must include id AND question AND query. A task missing any of these fields is invalid."""
 
 PLANNER_USER_PROMPT = """User Question: {query}
 {scope_section}
@@ -227,9 +264,26 @@ Retrieval query rules (applies to all tasks you create):
 - Keep each query SHORT and NATURAL — use key entity names, time periods, and topic words only. Avoid long formal phrases, document-type identifiers, or packing multiple constraints into one query. Shorter queries with key terms match better in semantic search.
 - Each query must target ONE specific piece of missing information — do not combine multiple search intents into one query.
 
+Every task object (when status is "fail") MUST contain ALL THREE fields: `id` (short identifier), `question` (specific sub-question to answer), and `query` (8-15 word retrieval query for semantic search). Omitting any field is invalid output.
+
 Output JSON only:
-If adequate: {{"status": "pass", "reasoning": "<brief explanation>"}}
-If gaps found: {{"status": "fail", "issues": ["<issue 1>", ...], "tasks": [{{"id": "<short_id>", "question": "<specific sub-question>", "query": "<8-15 word retrieval query>"}}]}}
+If adequate:
+{{
+  "status": "pass",
+  "reasoning": "<brief explanation>"
+}}
+If gaps found (every task must have id AND question AND query):
+{{
+  "status": "fail",
+  "issues": ["<issue 1>", "<issue 2>"],
+  "tasks": [
+    {{
+      "id": "<short id>",
+      "question": "<specific sub-question>",
+      "query": "<8-15 word retrieval query>"
+    }}
+  ]
+}}
 Maximum {max_verification_tasks} tasks. Only create tasks for parts of the question that were silently omitted."""
 
 VERIFICATION_USER_PROMPT = """Original Question: {query}

--- a/src/nvidia_rag/rag_server/agentic_rag/runner.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/runner.py
@@ -145,6 +145,9 @@ async def run_agentic_pipeline(
     runtime_model_override: str | None = None,
     runtime_llm_endpoint_override: str | None = None,
     runtime_api_key_override: str | None = None,
+    runtime_temperature_override: float | None = None,
+    runtime_top_p_override: float | None = None,
+    runtime_max_tokens_override: int | None = None,
 ) -> RAGResponse:
     """Run the compiled agentic RAG graph for one request and return a RAGResponse.
 
@@ -199,6 +202,9 @@ async def run_agentic_pipeline(
             runtime_model_override=runtime_model_override,
             runtime_llm_endpoint_override=runtime_llm_endpoint_override,
             runtime_api_key_override=runtime_api_key_override,
+            runtime_temperature_override=runtime_temperature_override,
+            runtime_top_p_override=runtime_top_p_override,
+            runtime_max_tokens_override=runtime_max_tokens_override,
         )
 
     # ------------------------------------------------------------------
@@ -210,12 +216,22 @@ async def run_agentic_pipeline(
     params_token = _agentic_search_params.set(search_params)
     citations_token = _agentic_all_citations.set(citations_acc)
     override_token = None
-    if runtime_model_override or runtime_llm_endpoint_override:
+    has_runtime_override = (
+        runtime_model_override is not None
+        or runtime_llm_endpoint_override is not None
+        or runtime_temperature_override is not None
+        or runtime_top_p_override is not None
+        or runtime_max_tokens_override is not None
+    )
+    if has_runtime_override:
         override_token = _agentic_llm_overrides.set(
             AgenticLLMOverrides(
                 model=runtime_model_override,
                 llm_endpoint=runtime_llm_endpoint_override,
                 api_key=runtime_api_key_override,
+                temperature=runtime_temperature_override,
+                top_p=runtime_top_p_override,
+                max_tokens=runtime_max_tokens_override,
             )
         )
 
@@ -311,6 +327,9 @@ async def _run_streaming(
     runtime_model_override: str | None = None,
     runtime_llm_endpoint_override: str | None = None,
     runtime_api_key_override: str | None = None,
+    runtime_temperature_override: float | None = None,
+    runtime_top_p_override: float | None = None,
+    runtime_max_tokens_override: int | None = None,
 ) -> RAGResponse:
     """Build a RAGResponse whose generator delegates to ``translate_graph_stream``.
 
@@ -342,12 +361,22 @@ async def _run_streaming(
         params_token = _agentic_search_params.set(search_params)
         citations_token = _agentic_all_citations.set(citations_acc)
         override_token = None
-        if runtime_model_override or runtime_llm_endpoint_override:
+        has_runtime_override = (
+            runtime_model_override is not None
+            or runtime_llm_endpoint_override is not None
+            or runtime_temperature_override is not None
+            or runtime_top_p_override is not None
+            or runtime_max_tokens_override is not None
+        )
+        if has_runtime_override:
             override_token = _agentic_llm_overrides.set(
                 AgenticLLMOverrides(
                     model=runtime_model_override,
                     llm_endpoint=runtime_llm_endpoint_override,
                     api_key=runtime_api_key_override,
+                    temperature=runtime_temperature_override,
+                    top_p=runtime_top_p_override,
+                    max_tokens=runtime_max_tokens_override,
                 )
             )
         try:

--- a/src/nvidia_rag/rag_server/main.py
+++ b/src/nvidia_rag/rag_server/main.py
@@ -588,6 +588,15 @@ class NvidiaRAG:
         # Resolve agentic flag: per-request value takes precedence over global config.
         agentic = agentic if agentic is not None else self.config.enable_agentic_rag
 
+        # Capture raw runtime generation-param overrides BEFORE applying config
+        # defaults so the agentic path can distinguish "client omitted the field"
+        # (use per-role agentic env defaults) from "client passed a value"
+        # (override all roles). Mirrors the existing model / llm_endpoint capture
+        # below for FR-1527 parity.
+        runtime_temperature_override = temperature
+        runtime_top_p_override = top_p
+        runtime_max_tokens_override = max_tokens
+
         # Apply defaults from config for None values
         model_params = self.config.llm.get_model_parameters()
         temperature = (
@@ -802,6 +811,9 @@ class NvidiaRAG:
                         metrics=metrics,
                         runtime_model_override=runtime_model_override,
                         runtime_llm_endpoint_override=runtime_llm_endpoint_override,
+                        runtime_temperature_override=runtime_temperature_override,
+                        runtime_top_p_override=runtime_top_p_override,
+                        runtime_max_tokens_override=runtime_max_tokens_override,
                     )
                 except Exception:
                     self._close_vdb_op_if_one_off(vdb_op)
@@ -2314,6 +2326,9 @@ class NvidiaRAG:
         metrics: Any | None,
         runtime_model_override: str | None = None,
         runtime_llm_endpoint_override: str | None = None,
+        runtime_temperature_override: float | None = None,
+        runtime_top_p_override: float | None = None,
+        runtime_max_tokens_override: int | None = None,
     ) -> RAGResponse:
         """Orchestrate one agentic RAG request.
 
@@ -2448,11 +2463,21 @@ class NvidiaRAG:
         # ContextVars (search params, trace, citations) and stays active for the
         # full lifetime of the streaming RAGResponse generator — not just until
         # this function returns.
-        if runtime_model_override or runtime_llm_endpoint_override:
+        if (
+            runtime_model_override
+            or runtime_llm_endpoint_override
+            or runtime_temperature_override is not None
+            or runtime_top_p_override is not None
+            or runtime_max_tokens_override is not None
+        ):
             logger.info(
-                "  - runtime LLM override: model=%s, endpoint=%s",
+                "  - runtime LLM override: model=%s, endpoint=%s, "
+                "temperature=%s, top_p=%s, max_tokens=%s",
                 runtime_model_override,
                 runtime_llm_endpoint_override or "(api-catalog)",
+                runtime_temperature_override,
+                runtime_top_p_override,
+                runtime_max_tokens_override,
             )
 
         return await run_agentic_pipeline(
@@ -2471,6 +2496,9 @@ class NvidiaRAG:
             runtime_model_override=runtime_model_override,
             runtime_llm_endpoint_override=runtime_llm_endpoint_override,
             runtime_api_key_override=self.config.llm.get_api_key(),
+            runtime_temperature_override=runtime_temperature_override,
+            runtime_top_p_override=runtime_top_p_override,
+            runtime_max_tokens_override=runtime_max_tokens_override,
         )
 
     async def _rag_chain(

--- a/src/nvidia_rag/utils/agentic_rag_config.py
+++ b/src/nvidia_rag/utils/agentic_rag_config.py
@@ -134,11 +134,57 @@ class AgenticContextConfig(_ConfigBase):
 # =============================================================================
 
 
+def _normalize_role_url(v: Any) -> Any:
+    """Shared server_url normalizer for per-role agentic LLM configs."""
+    if isinstance(v, str):
+        v = v.strip().strip('"').strip("'")
+        if v and not v.startswith(("http://", "https://")):
+            return f"http://{v}"
+    return v
+
+
+def _validate_role_temperature(v: Any) -> float | None:
+    """Coerce empty strings / None to None; validate non-negative."""
+    if isinstance(v, str) and not v.strip():
+        return None
+    if v is None:
+        return v
+    v = float(v)
+    if v < 0.0:
+        raise ValueError("Temperature must be non-negative")
+    return v
+
+
+def _validate_role_top_p(v: Any) -> float | None:
+    """Coerce empty strings / None to None; validate in [0.0, 1.0]."""
+    if isinstance(v, str) and not v.strip():
+        return None
+    if v is None:
+        return v
+    v = float(v)
+    if not (0.0 <= v <= 1.0):
+        raise ValueError("top_p must be between 0.0 and 1.0")
+    return v
+
+
+def _validate_role_max_tokens(v: Any) -> int | None:
+    """Coerce empty strings / None to None; validate positive integer."""
+    if isinstance(v, str) and not v.strip():
+        return None
+    if v is None:
+        return v
+    v = int(v)
+    if v <= 0:
+        raise ValueError("max_tokens must be a positive integer")
+    return v
+
+
 class AgenticPlannerLLMConfig(_ConfigBase):
     """LLM config for the planner role (scope resolution + task creation).
 
     Env vars: AGENTIC_PLANNER_LLM_SERVERURL, AGENTIC_PLANNER_LLM_MODEL,
-              AGENTIC_PLANNER_LLM_APIKEY
+              AGENTIC_PLANNER_LLM_APIKEY, AGENTIC_PLANNER_LLM_TEMPERATURE,
+              AGENTIC_PLANNER_LLM_TOP_P, AGENTIC_PLANNER_LLM_MAX_TOKENS
     """
 
     server_url: str = Field(
@@ -156,22 +202,52 @@ class AgenticPlannerLLMConfig(_ConfigBase):
         env="AGENTIC_PLANNER_LLM_APIKEY",
         description="API key for the planner LLM (overrides global NVIDIA_API_KEY).",
     )
+    temperature: float | None = Field(
+        default=0.1,
+        env="AGENTIC_PLANNER_LLM_TEMPERATURE",
+        description=(
+            "Sampling temperature for the planner LLM. Default 0.1 (slight randomness "
+            "is intentional for planning). Set to a number or leave at default."
+        ),
+    )
+    top_p: float | None = Field(
+        default=1.0,
+        env="AGENTIC_PLANNER_LLM_TOP_P",
+        description="Nucleus-sampling top_p for the planner LLM. Default 1.0.",
+    )
+    max_tokens: int | None = Field(
+        default=32768,
+        env="AGENTIC_PLANNER_LLM_MAX_TOKENS",
+        description="Max generated tokens for the planner LLM. Default 32768.",
+    )
 
     @field_validator("server_url", mode="before")
     @classmethod
     def normalize_url(cls, v: Any) -> Any:
-        if isinstance(v, str):
-            v = v.strip().strip('"').strip("'")
-            if v and not v.startswith(("http://", "https://")):
-                return f"http://{v}"
-        return v
+        return _normalize_role_url(v)
+
+    @field_validator("temperature", mode="before")
+    @classmethod
+    def _validate_temperature(cls, v: Any) -> float | None:
+        return _validate_role_temperature(v)
+
+    @field_validator("top_p", mode="before")
+    @classmethod
+    def _validate_top_p(cls, v: Any) -> float | None:
+        return _validate_role_top_p(v)
+
+    @field_validator("max_tokens", mode="before")
+    @classmethod
+    def _validate_max_tokens(cls, v: Any) -> int | None:
+        return _validate_role_max_tokens(v)
 
 
 class AgenticTaskLLMConfig(_ConfigBase):
     """LLM config for the task role (answering individual sub-questions).
 
     Env vars: AGENTIC_TASK_LLM_SERVERURL, AGENTIC_TASK_LLM_MODEL,
-              AGENTIC_TASK_LLM_APIKEY
+              AGENTIC_TASK_LLM_APIKEY, AGENTIC_TASK_LLM_TEMPERATURE,
+              AGENTIC_TASK_LLM_TOP_P, AGENTIC_TASK_LLM_MAX_TOKENS
     """
 
     server_url: str = Field(
@@ -189,22 +265,49 @@ class AgenticTaskLLMConfig(_ConfigBase):
         env="AGENTIC_TASK_LLM_APIKEY",
         description="API key for the task LLM (overrides global NVIDIA_API_KEY).",
     )
+    temperature: float | None = Field(
+        default=0.0,
+        env="AGENTIC_TASK_LLM_TEMPERATURE",
+        description="Sampling temperature for the task LLM. Default 0.0 (deterministic).",
+    )
+    top_p: float | None = Field(
+        default=1.0,
+        env="AGENTIC_TASK_LLM_TOP_P",
+        description="Nucleus-sampling top_p for the task LLM. Default 1.0.",
+    )
+    max_tokens: int | None = Field(
+        default=32768,
+        env="AGENTIC_TASK_LLM_MAX_TOKENS",
+        description="Max generated tokens for the task LLM. Default 32768.",
+    )
 
     @field_validator("server_url", mode="before")
     @classmethod
     def normalize_url(cls, v: Any) -> Any:
-        if isinstance(v, str):
-            v = v.strip().strip('"').strip("'")
-            if v and not v.startswith(("http://", "https://")):
-                return f"http://{v}"
-        return v
+        return _normalize_role_url(v)
+
+    @field_validator("temperature", mode="before")
+    @classmethod
+    def _validate_temperature(cls, v: Any) -> float | None:
+        return _validate_role_temperature(v)
+
+    @field_validator("top_p", mode="before")
+    @classmethod
+    def _validate_top_p(cls, v: Any) -> float | None:
+        return _validate_role_top_p(v)
+
+    @field_validator("max_tokens", mode="before")
+    @classmethod
+    def _validate_max_tokens(cls, v: Any) -> int | None:
+        return _validate_role_max_tokens(v)
 
 
 class AgenticSeedGenLLMConfig(_ConfigBase):
     """LLM config for the seed-gen role (retry seed query generation).
 
     Env vars: AGENTIC_SEED_GEN_LLM_SERVERURL, AGENTIC_SEED_GEN_LLM_MODEL,
-              AGENTIC_SEED_GEN_LLM_APIKEY
+              AGENTIC_SEED_GEN_LLM_APIKEY, AGENTIC_SEED_GEN_LLM_TEMPERATURE,
+              AGENTIC_SEED_GEN_LLM_TOP_P, AGENTIC_SEED_GEN_LLM_MAX_TOKENS
     """
 
     server_url: str = Field(
@@ -222,22 +325,52 @@ class AgenticSeedGenLLMConfig(_ConfigBase):
         env="AGENTIC_SEED_GEN_LLM_APIKEY",
         description="API key for the seed-gen LLM (overrides global NVIDIA_API_KEY).",
     )
+    temperature: float | None = Field(
+        default=0.1,
+        env="AGENTIC_SEED_GEN_LLM_TEMPERATURE",
+        description=(
+            "Sampling temperature for the seed-gen LLM. Default 0.1 (slight randomness "
+            "is intentional for retry seed diversity)."
+        ),
+    )
+    top_p: float | None = Field(
+        default=1.0,
+        env="AGENTIC_SEED_GEN_LLM_TOP_P",
+        description="Nucleus-sampling top_p for the seed-gen LLM. Default 1.0.",
+    )
+    max_tokens: int | None = Field(
+        default=32768,
+        env="AGENTIC_SEED_GEN_LLM_MAX_TOKENS",
+        description="Max generated tokens for the seed-gen LLM. Default 32768.",
+    )
 
     @field_validator("server_url", mode="before")
     @classmethod
     def normalize_url(cls, v: Any) -> Any:
-        if isinstance(v, str):
-            v = v.strip().strip('"').strip("'")
-            if v and not v.startswith(("http://", "https://")):
-                return f"http://{v}"
-        return v
+        return _normalize_role_url(v)
+
+    @field_validator("temperature", mode="before")
+    @classmethod
+    def _validate_temperature(cls, v: Any) -> float | None:
+        return _validate_role_temperature(v)
+
+    @field_validator("top_p", mode="before")
+    @classmethod
+    def _validate_top_p(cls, v: Any) -> float | None:
+        return _validate_role_top_p(v)
+
+    @field_validator("max_tokens", mode="before")
+    @classmethod
+    def _validate_max_tokens(cls, v: Any) -> int | None:
+        return _validate_role_max_tokens(v)
 
 
 class AgenticSynthesisLLMConfig(_ConfigBase):
     """LLM config for the synthesis role (final answer generation).
 
     Env vars: AGENTIC_SYNTHESIS_LLM_SERVERURL, AGENTIC_SYNTHESIS_LLM_MODEL,
-              AGENTIC_SYNTHESIS_LLM_APIKEY
+              AGENTIC_SYNTHESIS_LLM_APIKEY, AGENTIC_SYNTHESIS_LLM_TEMPERATURE,
+              AGENTIC_SYNTHESIS_LLM_TOP_P, AGENTIC_SYNTHESIS_LLM_MAX_TOKENS
     """
 
     server_url: str = Field(
@@ -255,15 +388,41 @@ class AgenticSynthesisLLMConfig(_ConfigBase):
         env="AGENTIC_SYNTHESIS_LLM_APIKEY",
         description="API key for the synthesis LLM (overrides global NVIDIA_API_KEY).",
     )
+    temperature: float | None = Field(
+        default=0.0,
+        env="AGENTIC_SYNTHESIS_LLM_TEMPERATURE",
+        description="Sampling temperature for the synthesis LLM. Default 0.0 (deterministic).",
+    )
+    top_p: float | None = Field(
+        default=1.0,
+        env="AGENTIC_SYNTHESIS_LLM_TOP_P",
+        description="Nucleus-sampling top_p for the synthesis LLM. Default 1.0.",
+    )
+    max_tokens: int | None = Field(
+        default=32768,
+        env="AGENTIC_SYNTHESIS_LLM_MAX_TOKENS",
+        description="Max generated tokens for the synthesis LLM. Default 32768.",
+    )
 
     @field_validator("server_url", mode="before")
     @classmethod
     def normalize_url(cls, v: Any) -> Any:
-        if isinstance(v, str):
-            v = v.strip().strip('"').strip("'")
-            if v and not v.startswith(("http://", "https://")):
-                return f"http://{v}"
-        return v
+        return _normalize_role_url(v)
+
+    @field_validator("temperature", mode="before")
+    @classmethod
+    def _validate_temperature(cls, v: Any) -> float | None:
+        return _validate_role_temperature(v)
+
+    @field_validator("top_p", mode="before")
+    @classmethod
+    def _validate_top_p(cls, v: Any) -> float | None:
+        return _validate_role_top_p(v)
+
+    @field_validator("max_tokens", mode="before")
+    @classmethod
+    def _validate_max_tokens(cls, v: Any) -> int | None:
+        return _validate_role_max_tokens(v)
 
 
 # Union type used for type hints in builder.py.

--- a/tests/unit/test_rag_server/test_agentic_rag.py
+++ b/tests/unit/test_rag_server/test_agentic_rag.py
@@ -924,3 +924,437 @@ class TestBuildAgenticRagAgentSignature:
 
     def test_build_agentic_rag_agent_is_coroutine_function(self) -> None:
         assert inspect.iscoroutinefunction(build_agentic_rag_agent)
+
+
+class TestAgenticRoleGenerationParamFallback:
+    """Per-role generation-param fallback in builder._make_role_llm.
+
+    Covers Case 2 of the FR (no /generate override): each role's LLM is built
+    with temperature / top_p / max_tokens resolved via
+        role_cfg → planner_cfg → rag_config.llm.parameters.
+    """
+
+    def _build_rag_config(
+        self,
+        *,
+        main_temperature: float | None = None,
+        main_top_p: float | None = None,
+        main_max_tokens: int = 32768,
+        planner_overrides: dict | None = None,
+        task_overrides: dict | None = None,
+    ):
+        """Construct a minimal NvidiaRAGConfig and patch in role overrides."""
+        from nvidia_rag.utils.configuration import NvidiaRAGConfig
+
+        cfg = NvidiaRAGConfig()
+        # Force main-LLM generation params explicitly (cls defaults read env).
+        cfg.llm.parameters.temperature = main_temperature
+        cfg.llm.parameters.top_p = main_top_p
+        cfg.llm.parameters.max_tokens = main_max_tokens
+
+        for field_name, value in (planner_overrides or {}).items():
+            setattr(cfg.agentic_rag.planner_llm, field_name, value)
+        for field_name, value in (task_overrides or {}).items():
+            setattr(cfg.agentic_rag.task_llm, field_name, value)
+        return cfg
+
+    def test_role_value_wins_over_planner_and_main(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[dict] = []
+
+        def fake_get_llm(**kwargs):
+            calls.append(kwargs)
+            return MagicMock()
+
+        monkeypatch.setattr("nvidia_rag.utils.llm.get_llm", fake_get_llm)
+        from nvidia_rag.rag_server.agentic_rag.builder import _make_role_llm
+
+        cfg = self._build_rag_config(
+            main_temperature=0.9,
+            main_top_p=0.99,
+            main_max_tokens=8000,
+            planner_overrides={
+                "model_name": "planner/model",
+                "temperature": 0.5,
+                "top_p": 0.7,
+                "max_tokens": 4000,
+            },
+            task_overrides={
+                "model_name": "task/model",
+                "temperature": 0.1,
+                "top_p": 0.3,
+                "max_tokens": 1000,
+            },
+        )
+
+        _make_role_llm(cfg.agentic_rag.task_llm, cfg.agentic_rag.planner_llm, cfg)
+        assert calls, "get_llm must have been invoked"
+        kw = calls[-1]
+        assert kw["temperature"] == 0.1
+        assert kw["top_p"] == 0.3
+        assert kw["max_tokens"] == 1000
+        assert kw["model"] == "task/model"
+
+    def test_planner_value_wins_when_role_gen_params_explicitly_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When a role's gen-param fields are explicitly set to None (rare —
+        the role defaults are non-None — but valid via the typing), the
+        fallback chain hops to the planner role's values."""
+        calls: list[dict] = []
+
+        def fake_get_llm(**kwargs):
+            calls.append(kwargs)
+            return MagicMock()
+
+        monkeypatch.setattr("nvidia_rag.utils.llm.get_llm", fake_get_llm)
+        from nvidia_rag.rag_server.agentic_rag.builder import _make_role_llm
+
+        cfg = self._build_rag_config(
+            main_temperature=0.9,
+            main_top_p=0.99,
+            main_max_tokens=8000,
+            planner_overrides={
+                "model_name": "planner/model",
+                "temperature": 0.5,
+                "top_p": 0.7,
+                "max_tokens": 4000,
+            },
+            # task role leaves model_name empty AND explicitly nulls gen params
+            # so the fallback to planner fires.
+            task_overrides={
+                "temperature": None,
+                "top_p": None,
+                "max_tokens": None,
+            },
+        )
+
+        _make_role_llm(cfg.agentic_rag.task_llm, cfg.agentic_rag.planner_llm, cfg)
+        kw = calls[-1]
+        # Per-role model_name is empty → falls back to planner's model.
+        assert kw["model"] == "planner/model"
+        # Generation params fall back to planner's values.
+        assert kw["temperature"] == 0.5
+        assert kw["top_p"] == 0.7
+        assert kw["max_tokens"] == 4000
+
+    def test_main_rag_config_value_wins_when_role_and_planner_gen_params_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When BOTH the role and the planner have None gen params, the chain
+        falls all the way through to ``rag_config.llm.parameters``."""
+        calls: list[dict] = []
+
+        def fake_get_llm(**kwargs):
+            calls.append(kwargs)
+            return MagicMock()
+
+        monkeypatch.setattr("nvidia_rag.utils.llm.get_llm", fake_get_llm)
+        from nvidia_rag.rag_server.agentic_rag.builder import _make_role_llm
+
+        # Planner has a model_name (so a model can be resolved) but nulled
+        # gen params; task likewise nulled.
+        cfg = self._build_rag_config(
+            main_temperature=0.42,
+            main_top_p=0.55,
+            main_max_tokens=12345,
+            planner_overrides={
+                "model_name": "planner/model",
+                "temperature": None,
+                "top_p": None,
+                "max_tokens": None,
+            },
+            task_overrides={
+                "temperature": None,
+                "top_p": None,
+                "max_tokens": None,
+            },
+        )
+
+        _make_role_llm(cfg.agentic_rag.task_llm, cfg.agentic_rag.planner_llm, cfg)
+        kw = calls[-1]
+        # All gen params fall through to rag_config.llm.parameters.
+        assert kw["temperature"] == 0.42
+        assert kw["top_p"] == 0.55
+        assert kw["max_tokens"] == 12345
+
+    def test_role_defaults_used_when_no_overrides_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Each role's built-in defaults (planner/seed_gen=0.1, task/synthesis=0.0,
+        top_p=1.0, max_tokens=32768) are applied when no env vars are set."""
+        from nvidia_rag.utils.configuration import NvidiaRAGConfig
+
+        calls: list[dict] = []
+
+        def fake_get_llm(**kwargs):
+            calls.append(kwargs)
+            return MagicMock()
+
+        monkeypatch.setattr("nvidia_rag.utils.llm.get_llm", fake_get_llm)
+        from nvidia_rag.rag_server.agentic_rag.builder import _make_role_llm
+
+        cfg = NvidiaRAGConfig()
+        # Give planner a model_name so a model can be resolved; leave gen
+        # params at their built-in defaults.
+        cfg.agentic_rag.planner_llm.model_name = "planner/m"
+
+        for role_name, expected_temp in [
+            ("planner_llm", 0.1),
+            ("task_llm", 0.0),
+            ("seed_gen_llm", 0.1),
+            ("synthesis_llm", 0.0),
+        ]:
+            calls.clear()
+            role_cfg = getattr(cfg.agentic_rag, role_name)
+            _make_role_llm(role_cfg, cfg.agentic_rag.planner_llm, cfg)
+            kw = calls[-1]
+            assert kw["temperature"] == expected_temp, (
+                f"{role_name} expected temperature={expected_temp}, got "
+                f"{kw['temperature']}"
+            )
+            assert kw["top_p"] == 1.0, (
+                f"{role_name} expected top_p=1.0, got {kw['top_p']}"
+            )
+            assert kw["max_tokens"] == 32768, (
+                f"{role_name} expected max_tokens=32768, got {kw['max_tokens']}"
+            )
+
+
+class TestAgenticRuntimeGenerationParamOverrides:
+    """Per-request /generate overrides for temperature / top_p / max_tokens.
+
+    Covers Case 1 of the FR: values passed at request time take precedence
+    over every env-var level and are applied to every role's LLM.
+    """
+
+    def test_temperature_only_override_keeps_role_models_but_applies_temp(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No model/endpoint override → each role keeps its configured model,
+        but the request-provided temperature is applied to all roles.
+        """
+        from nvidia_rag.utils.configuration import NvidiaRAGConfig
+
+        calls: list[dict] = []
+
+        def fake_get_llm(**kwargs):
+            stub = MagicMock(name=f"role-{kwargs.get('model')}")
+            stub.model = kwargs.get("model")
+            stub.temperature = kwargs.get("temperature")
+            calls.append(kwargs)
+            return stub
+
+        monkeypatch.setattr("nvidia_rag.utils.llm.get_llm", fake_get_llm)
+
+        cfg = NvidiaRAGConfig()
+        cfg.agentic_rag.planner_llm.model_name = "planner/m"
+        cfg.agentic_rag.task_llm.model_name = "task/m"
+        cfg.agentic_rag.seed_gen_llm.model_name = "seed/m"
+        cfg.agentic_rag.synthesis_llm.model_name = "synth/m"
+
+        agent = AgenticRag(
+            planner_llm=MagicMock(),
+            task_llm=MagicMock(),
+            seed_gen_llm=MagicMock(),
+            synthesis_llm=MagicMock(),
+            retriever_fn=AsyncMock(return_value=None),
+            log_level="WARNING",
+            concurrency_limit=2,
+            rag_config=cfg,
+        )
+
+        token = _agentic_llm_overrides.set(
+            AgenticLLMOverrides(temperature=0.77)
+        )
+        try:
+            # Each role builds its own client because model/endpoint are NOT
+            # overridden — generation-param-only override doesn't collapse roles.
+            llms = [
+                agent.planner_llm,
+                agent.task_llm,
+                agent.seed_gen_llm,
+                agent.synthesis_llm,
+            ]
+        finally:
+            _agentic_llm_overrides.reset(token)
+
+        # 4 distinct clients, one per role.
+        assert len({id(x) for x in llms}) == 4
+        assert len(calls) == 4
+        # All four carry the override temperature.
+        assert all(c["temperature"] == 0.77 for c in calls)
+        # Each role still uses its own configured model.
+        models = sorted(c["model"] for c in calls)
+        assert models == ["planner/m", "seed/m", "synth/m", "task/m"]
+
+    def test_model_override_collapses_all_roles_to_one_client_with_gen_params(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Model + temperature overridden together → exactly one shared client
+        is built, used by all 4 roles, with the request temperature applied.
+        """
+        from nvidia_rag.utils.configuration import NvidiaRAGConfig
+
+        calls: list[dict] = []
+        built = MagicMock(name="shared-override-llm")
+
+        def fake_get_llm(**kwargs):
+            calls.append(kwargs)
+            return built
+
+        monkeypatch.setattr("nvidia_rag.utils.llm.get_llm", fake_get_llm)
+
+        cfg = NvidiaRAGConfig()
+        cfg.agentic_rag.planner_llm.model_name = "planner/m"
+
+        agent = AgenticRag(
+            planner_llm=MagicMock(),
+            task_llm=MagicMock(),
+            seed_gen_llm=MagicMock(),
+            synthesis_llm=MagicMock(),
+            retriever_fn=AsyncMock(return_value=None),
+            log_level="WARNING",
+            concurrency_limit=2,
+            rag_config=cfg,
+        )
+
+        token = _agentic_llm_overrides.set(
+            AgenticLLMOverrides(
+                model="runtime/model",
+                llm_endpoint="https://runtime",
+                temperature=0.33,
+                top_p=0.66,
+                max_tokens=999,
+            )
+        )
+        try:
+            assert agent.planner_llm is built
+            assert agent.task_llm is built
+            assert agent.seed_gen_llm is built
+            assert agent.synthesis_llm is built
+        finally:
+            _agentic_llm_overrides.reset(token)
+
+        # Single shared client → get_llm called exactly once.
+        assert len(calls) == 1
+        kw = calls[0]
+        assert kw["model"] == "runtime/model"
+        assert kw["llm_endpoint"] == "https://runtime"
+        assert kw["temperature"] == 0.33
+        assert kw["top_p"] == 0.66
+        assert kw["max_tokens"] == 999
+
+    def test_partial_gen_param_override_falls_back_per_field(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only temperature passed at request time → top_p uses task role's
+        configured value; max_tokens falls all the way through to the main RAG
+        LLM (per-field fallback)."""
+        from nvidia_rag.utils.configuration import NvidiaRAGConfig
+
+        calls: list[dict] = []
+
+        def fake_get_llm(**kwargs):
+            calls.append(kwargs)
+            return MagicMock()
+
+        monkeypatch.setattr("nvidia_rag.utils.llm.get_llm", fake_get_llm)
+
+        cfg = NvidiaRAGConfig()
+        cfg.llm.parameters.temperature = 0.99
+        cfg.llm.parameters.top_p = 0.88
+        cfg.llm.parameters.max_tokens = 7777
+        cfg.agentic_rag.planner_llm.model_name = "planner/m"
+        # Null out planner gen params so the chain can fall through them.
+        cfg.agentic_rag.planner_llm.temperature = None
+        cfg.agentic_rag.planner_llm.top_p = None
+        cfg.agentic_rag.planner_llm.max_tokens = None
+        # task_llm role has top_p set but not temperature/max_tokens.
+        cfg.agentic_rag.task_llm.model_name = "task/m"
+        cfg.agentic_rag.task_llm.temperature = None
+        cfg.agentic_rag.task_llm.top_p = 0.42
+        cfg.agentic_rag.task_llm.max_tokens = None
+
+        agent = AgenticRag(
+            planner_llm=MagicMock(),
+            task_llm=MagicMock(),
+            seed_gen_llm=MagicMock(),
+            synthesis_llm=MagicMock(),
+            retriever_fn=AsyncMock(return_value=None),
+            log_level="WARNING",
+            concurrency_limit=2,
+            rag_config=cfg,
+        )
+
+        token = _agentic_llm_overrides.set(
+            AgenticLLMOverrides(temperature=0.05)
+        )
+        try:
+            _ = agent.task_llm
+        finally:
+            _agentic_llm_overrides.reset(token)
+
+        # The single task-role build call should carry:
+        # temperature → override value
+        # top_p → task role's configured value (0.42)
+        # max_tokens → main RAG LLM value (7777, not set on task or planner)
+        task_calls = [c for c in calls if c.get("model") == "task/m"]
+        assert task_calls, "expected get_llm call with task/m model"
+        kw = task_calls[0]
+        assert kw["temperature"] == 0.05
+        assert kw["top_p"] == 0.42
+        assert kw["max_tokens"] == 7777
+
+    def test_runtime_overrides_take_precedence_over_role_env_values(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the per-role agentic env vars are set AND request-time
+        gen-param overrides are also passed, the request values win."""
+        from nvidia_rag.utils.configuration import NvidiaRAGConfig
+
+        calls: list[dict] = []
+
+        def fake_get_llm(**kwargs):
+            calls.append(kwargs)
+            return MagicMock()
+
+        monkeypatch.setattr("nvidia_rag.utils.llm.get_llm", fake_get_llm)
+
+        cfg = NvidiaRAGConfig()
+        cfg.agentic_rag.planner_llm.model_name = "planner/m"
+        cfg.agentic_rag.task_llm.model_name = "task/m"
+        cfg.agentic_rag.task_llm.temperature = 0.1
+        cfg.agentic_rag.task_llm.top_p = 0.2
+        cfg.agentic_rag.task_llm.max_tokens = 1000
+
+        agent = AgenticRag(
+            planner_llm=MagicMock(),
+            task_llm=MagicMock(),
+            seed_gen_llm=MagicMock(),
+            synthesis_llm=MagicMock(),
+            retriever_fn=AsyncMock(return_value=None),
+            log_level="WARNING",
+            concurrency_limit=2,
+            rag_config=cfg,
+        )
+
+        token = _agentic_llm_overrides.set(
+            AgenticLLMOverrides(
+                temperature=0.9,
+                top_p=0.95,
+                max_tokens=5000,
+            )
+        )
+        try:
+            _ = agent.task_llm
+        finally:
+            _agentic_llm_overrides.reset(token)
+
+        task_calls = [c for c in calls if c.get("model") == "task/m"]
+        assert task_calls
+        kw = task_calls[0]
+        assert kw["temperature"] == 0.9
+        assert kw["top_p"] == 0.95
+        assert kw["max_tokens"] == 5000


### PR DESCRIPTION
## Description
- Added llm settings in Agentic RAG from environment config and runtime params
- Added `json_mode=True` for intermediate stages of agentic rag
- Prompt changes for agentic rag

## Checklist
- [X] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [X] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [X] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.