### PR TITLE
Fix langchain and summarization notebooks for v2.6 (NVBugs 6173763, 6180461)

### DIFF
--- a/notebooks/.env_library
+++ b/notebooks/.env_library
@@ -16,12 +16,12 @@ export OBJECTSTORE_ACCESSKEY=seaweedfsadmin
 export OBJECTSTORE_SECRETKEY=seaweedfsadmin
 
 # === Embedding Model specific configurations ===
-export APP_EMBEDDINGS_SERVERURL=nemotron-embedding-ms:8000/v1
-export APP_EMBEDDINGS_MODELNAME=nvidia/llama-nemotron-embed-1b-v2
+export APP_EMBEDDINGS_SERVERURL=nemotron-vlm-embedding-ms:8000/v1
+export APP_EMBEDDINGS_MODELNAME=nvidia/llama-nemotron-embed-vl-1b-v2
 export APP_EMBEDDINGS_DIMENSIONS=2048
-# For VLM Embedding Model (Nemoretriever-1b-vlm-embed-v1)
-# export APP_EMBEDDINGS_SERVERURL=localhost:9081
-# export APP_EMBEDDINGS_MODELNAME=nvidia/llama-nemotron-embed-vl-1b-v2
+# For text-only embedding NIM (optional; requires text-embed compose profile)
+# export APP_EMBEDDINGS_SERVERURL=nemotron-embedding-ms:8000/v1
+# export APP_EMBEDDINGS_MODELNAME=nvidia/llama-nemotron-embed-1b-v2
 
 # === NV-Ingest Connection Configurations ===
 export APP_NVINGEST_MESSAGECLIENTHOSTNAME=localhost

--- a/notebooks/langchain_nvidia_retriever.ipynb
+++ b/notebooks/langchain_nvidia_retriever.ipynb
@@ -1,315 +1,317 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "303aa520",
-   "metadata": {},
-   "source": [
-    "# NVIDIARAGRetriever Connector – LangChain Integration\n",
-    "\n",
-    "**Motivation:** This notebook showcases the **LangChain integration** with the NVIDIA RAG Blueprint. The `NVIDIARAGRetriever` from `langchain-nvidia-ai-endpoints` connects to the NVIDIA RAG `/v1/search` endpoint and returns standard LangChain `Document` objects, enabling seamless use in chains, agents, and RAG pipelines without custom HTTP code.\n",
-    "\n",
-    "---\n",
-    "\n",
-    "## Prerequisite: Run Ingestion First\n",
-    "\n",
-    "**You must ingest documents before using this notebook.** Use the [ingestion_api_usage.ipynb](./ingestion_api_usage.ipynb) notebook:\n",
-    "\n",
-    "1. Open [ingestion_api_usage.ipynb](./ingestion_api_usage.ipynb).\n",
-    "2. Execute the following cells **in order** (top to bottom):\n",
-    "   - **1. Install Dependencies** – `pip install aiohttp`\n",
-    "   - **2. Setup Base Configuration** – ingestor URL (port 8082)\n",
-    "   - **3. Health Check** – verify ingestor is running\n",
-    "   - **4. Create collection** – creates `multimodal_data` collection\n",
-    "   - **4. Upload Document** – FILEPATHS cell, then `upload_documents` cell\n",
-    "   - **5. Get Task Status** – poll until state is `FINISHED`\n",
-    "3. When ingestion is complete, return here and run the cells below.\n",
-    "\n",
-    "Ensure the **RAG server** (port 8081) is running. See [Get Started](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/deploy-docker-self-hosted.md)."
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# NVIDIARAGRetriever Connector – LangChain Integration\n",
+        "\n",
+        "**Motivation:** This notebook showcases the **LangChain integration** with the NVIDIA RAG Blueprint. The `NVIDIARAGRetriever` from `langchain-nvidia-ai-endpoints` connects to the NVIDIA RAG `/v1/search` endpoint and returns standard LangChain `Document` objects, enabling seamless use in chains, agents, and RAG pipelines without custom HTTP code.\n",
+        "\n",
+        "---\n",
+        "\n",
+        "## Prerequisite: Run Ingestion First\n",
+        "\n",
+        "**You must ingest documents before using this notebook.** Use the [ingestion_api_usage.ipynb](./ingestion_api_usage.ipynb) notebook:\n",
+        "\n",
+        "1. Open [ingestion_api_usage.ipynb](./ingestion_api_usage.ipynb).\n",
+        "2. Execute the following cells **in order** (top to bottom):\n",
+        "   - **1. Install Dependencies** – `pip install aiohttp`\n",
+        "   - **2. Setup Base Configuration** – ingestor URL (port 8082)\n",
+        "   - **3. Health Check** – verify ingestor is running\n",
+        "   - **4. Create collection** – creates `multimodal_data` collection\n",
+        "   - **4. Upload Document** – FILEPATHS cell, then `upload_documents` cell\n",
+        "   - **5. Get Task Status** – poll until state is `FINISHED`\n",
+        "3. When ingestion is complete, return here and run the cells below.\n",
+        "\n",
+        "Ensure the **RAG server** (port 8081) is running. See [Get Started](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/deploy-docker-self-hosted.md)."
+      ],
+      "id": "303aa520"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## Setup"
+      ],
+      "id": "c7a2a7dd"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!pip install \"langchain-nvidia-ai-endpoints>=1.2.1\" langchain-core\n",
+        "\n",
+        "import os\n",
+        "\n",
+        "# RAG server URL (use collection from ingestion_api_usage.ipynb)\n",
+        "RAG_IPADDRESS = (\n",
+        "    \"rag-server\" if os.environ.get(\"AI_WORKBENCH\", \"false\") == \"true\" else \"localhost\"\n",
+        ")\n",
+        "RAG_BASE_URL = f\"http://{RAG_IPADDRESS}:8081\"\n",
+        "\n",
+        "# Collection from ingestion_api_usage.ipynb (default: multimodal_data)\n",
+        "COLLECTION_NAME = \"multimodal_data\""
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "e6fe7153"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## Retrieval with NVIDIARAGRetriever\n",
+        "\n",
+        "The `NVIDIARAGRetriever` from `langchain-nvidia-ai-endpoints` connects to the NVIDIA RAG Blueprint `/v1/search` endpoint and returns LangChain `Document` objects. Use `COLLECTION_NAME` to match the collection you created in [ingestion_api_usage.ipynb](./ingestion_api_usage.ipynb).\n",
+        "\n",
+        "By default the retriever does **not** send `vdb_endpoint`; the RAG server uses its configured vector store (for example Elasticsearch). Only set `vdb_endpoint` when you need to override that URL."
+      ],
+      "id": "640eee93"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 2.1 Basic Sync Retrieval"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "from langchain_nvidia_ai_endpoints import NVIDIARAGRetriever\n",
+        "\n",
+        "retriever = NVIDIARAGRetriever(\n",
+        "    base_url=RAG_BASE_URL,\n",
+        "    collection_names=[COLLECTION_NAME],\n",
+        "    k=5,\n",
+        ")\n",
+        "\n",
+        "query = \"What are the main topics or products discussed?\"\n",
+        "docs = retriever.invoke(query)\n",
+        "\n",
+        "print(f\"Query: {query}\")\n",
+        "print(f\"Retrieved {len(docs)} documents:\\n\")\n",
+        "for i, doc in enumerate(docs, 1):\n",
+        "    content_preview = (doc.page_content or \"\")[:300] + \"...\" if len(doc.page_content or \"\") > 300 else (doc.page_content or \"\")\n",
+        "    score = doc.metadata.get(\"score\", \"N/A\")\n",
+        "    source = doc.metadata.get(\"document_name\", \"N/A\")\n",
+        "    print(f\"--- Document {i} ---\")\n",
+        "    print(f\"Score: {score} | Source: {source}\")\n",
+        "    print(f\"Content: {content_preview}\")\n",
+        "    print()"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "4b09138a"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 2.2 Custom Retrieval Parameters"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "For details on retrieval parameters, filter expressions, and metadata:\n",
+        "- [Custom metadata & filter expressions](../docs/custom-metadata.md) – `filter_expr` syntax (Elasticsearch), metadata schema\n",
+        "- [Multi-turn & query rewriting](../docs/multiturn.md) – `enable_query_rewriting` for decontextualizing follow-up questions\n",
+        "- [Retriever API usage](./retriever_api_usage.ipynb) – Search endpoint payload parameters"
+      ],
+      "id": "35d7f118"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "retriever_custom = NVIDIARAGRetriever(\n",
+        "    base_url=RAG_BASE_URL,\n",
+        "    collection_names=[COLLECTION_NAME],\n",
+        "    # Result counts\n",
+        "    k=3,  # Number of document chunks to return (0-25, maps to reranker_top_k)\n",
+        "    vdb_top_k=50,  # Top results from vector DB before reranking (0-400)\n",
+        "    # Feature toggles\n",
+        "    enable_reranker=True,  # Rerank results for relevance\n",
+        "    enable_query_rewriting=False,  # Rewrite query for better retrieval\n",
+        "    enable_filter_generator=False,  # Auto-generate filters from query\n",
+        "    enable_citations=True,  # Include image/table/chart citations in metadata\n",
+        "    # Filtering\n",
+        "    confidence_threshold=0.0,  # Min confidence (0.0-1.0, requires enable_reranker=True)\n",
+        "    filter_expr=None,  # Elasticsearch filter expression, e.g. [{\"term\": {\"metadata.content_metadata.file_name.keyword\": \"doc.pdf\"}}]\n",
+        "    # Advanced (omit vdb_endpoint to use the RAG server's configured vector store)\n",
+        "    # vdb_endpoint=\"http://elasticsearch:9200\",\n",
+        "    messages=[],  # Conversation history for context-aware retrieval\n",
+        "    timeout=60.0,  # HTTP request timeout in seconds\n",
+        ")\n",
+        "\n",
+        "docs = retriever_custom.invoke(\"Summarize key information\")\n",
+        "print(f\"Retrieved {len(docs)} documents\")\n",
+        "for i, doc in enumerate(docs, 1):\n",
+        "    print(f\"  {i}. {doc.metadata.get('document_name', 'N/A')} (score: {doc.metadata.get('score', 'N/A')})\")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "6e5aa122"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 2.3 Async Retrieval"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "docs = await retriever.ainvoke(\"What features or benefits are described?\")\n",
+        "print(f\"Async retrieval: {len(docs)} documents\")\n",
+        "for i, doc in enumerate(docs[:3], 1):\n",
+        "    print(f\"  {i}. {doc.metadata.get('document_name', 'N/A')}\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 2.4 Error Handling"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "from langchain_nvidia_ai_endpoints.retrievers import (\n",
+        "    NVIDIARAGConnectionError,\n",
+        "    NVIDIARAGServerError,\n",
+        "    NVIDIARAGValidationError,\n",
+        ")\n",
+        "\n",
+        "try:\n",
+        "    bad_retriever = NVIDIARAGRetriever(\n",
+        "        base_url=\"http://invalid-host:8081\",\n",
+        "        collection_names=[COLLECTION_NAME],\n",
+        "    )\n",
+        "    bad_retriever.invoke(\"test\")\n",
+        "except NVIDIARAGConnectionError as e:\n",
+        "    print(f\"Connection error (expected): {e}\")\n",
+        "except NVIDIARAGValidationError as e:\n",
+        "    print(f\"Validation error: {e}\")\n",
+        "except NVIDIARAGServerError as e:\n",
+        "    print(f\"Server error ({e.status_code}): {e}\")\n",
+        "\n",
+        "print(\"\\nError handling works as expected.\")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "bfcc9f22"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## RAG Chain (Optional)\n",
+        "\n",
+        "Chain `NVIDIARAGRetriever` with `ChatNVIDIA` for end-to-end question answering. Requires `NVIDIA_API_KEY` to call the NVIDIA API Catalog.\n",
+        "\n",
+        "**Get an API key:** See [Get an API Key](../docs/api-key.md) for instructions."
+      ],
+      "id": "3b5824c6"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Set NVIDIA_API_KEY if not already set (see ../docs/api-key.md to get a key)\n",
+        "if not os.environ.get(\"NVIDIA_API_KEY\", \"\").startswith(\"nvapi-\"):\n",
+        "    import getpass\n",
+        "    key = getpass.getpass(\"Enter your NVIDIA API key (nvapi-...): \")\n",
+        "    if key.startswith(\"nvapi-\"):\n",
+        "        os.environ[\"NVIDIA_API_KEY\"] = key\n",
+        "    else:\n",
+        "        print(\"NVIDIA_API_KEY not set. Set it to run the RAG chain. See [Get an API Key](../docs/api-key.md)\")\n",
+        "\n",
+        "if os.environ.get(\"NVIDIA_API_KEY\", \"\").startswith(\"nvapi-\"):\n",
+        "    from langchain_core.output_parsers import StrOutputParser\n",
+        "    from langchain_core.prompts import ChatPromptTemplate\n",
+        "    from langchain_core.runnables import RunnablePassthrough\n",
+        "\n",
+        "    from langchain_nvidia_ai_endpoints import ChatNVIDIA, NVIDIARAGRetriever\n",
+        "\n",
+        "    retriever = NVIDIARAGRetriever(\n",
+        "        base_url=RAG_BASE_URL,\n",
+        "        collection_names=[COLLECTION_NAME],\n",
+        "        k=4,\n",
+        "    )\n",
+        "\n",
+        "    def format_docs(docs):\n",
+        "        return \"\\n\\n\".join(d.page_content for d in docs)\n",
+        "\n",
+        "    prompt = ChatPromptTemplate.from_messages([\n",
+        "        (\"system\", \"Answer based only on the context below.\\n\\n{context}\"),\n",
+        "        (\"human\", \"{question}\"),\n",
+        "    ])\n",
+        "\n",
+        "    # Model aligned with rag-server default (nvidia/nemotron-3-super-120b-a12b)\n",
+        "    llm = ChatNVIDIA(model=\"nvidia/nemotron-3-super-120b-a12b\")\n",
+        "    chain = (\n",
+        "        {\"context\": retriever | format_docs, \"question\": RunnablePassthrough()}\n",
+        "        | prompt\n",
+        "        | llm\n",
+        "        | StrOutputParser()\n",
+        "    )\n",
+        "\n",
+        "    answer = chain.invoke(\"What are the main topics or products?\")\n",
+        "    print(answer)\n",
+        "else:\n",
+        "    print(\"NVIDIA_API_KEY not set. Set it (e.g. os.environ['NVIDIA_API_KEY'] = 'nvapi-...') or run this cell again to be prompted. See [Get an API Key](../docs/api-key.md)\")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "d82a5d54"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## Cleanup (Optional)\n",
+        "\n",
+        "To remove the collection and documents, use the delete cells in [ingestion_api_usage.ipynb](./ingestion_api_usage.ipynb) (sections 7 and 9)."
+      ],
+      "id": "4c95fdc6"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Use ingestion_api_usage.ipynb sections 7 (Delete Documents) and 9 (Delete Collections)\n",
+        "# to remove the multimodal_data collection when finished."
+      ],
+      "execution_count": null,
+      "outputs": []
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.11.12"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "id": "c7a2a7dd",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## Setup"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e6fe7153",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install langchain-nvidia-ai-endpoints langchain-core\n",
-    "\n",
-    "import os\n",
-    "\n",
-    "# RAG server URL (use collection from ingestion_api_usage.ipynb)\n",
-    "RAG_IPADDRESS = (\n",
-    "    \"rag-server\" if os.environ.get(\"AI_WORKBENCH\", \"false\") == \"true\" else \"localhost\"\n",
-    ")\n",
-    "RAG_BASE_URL = f\"http://{RAG_IPADDRESS}:8081\"\n",
-    "\n",
-    "# Collection from ingestion_api_usage.ipynb (default: multimodal_data)\n",
-    "COLLECTION_NAME = \"multimodal_data\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "640eee93",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## Retrieval with NVIDIARAGRetriever\n",
-    "\n",
-    "The `NVIDIARAGRetriever` from `langchain-nvidia-ai-endpoints` connects to the NVIDIA RAG Blueprint `/v1/search` endpoint and returns LangChain `Document` objects. Use `COLLECTION_NAME` to match the collection you created in [ingestion_api_usage.ipynb](./ingestion_api_usage.ipynb)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 2.1 Basic Sync Retrieval"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4b09138a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from langchain_nvidia_ai_endpoints import NVIDIARAGRetriever\n",
-    "\n",
-    "retriever = NVIDIARAGRetriever(\n",
-    "    base_url=RAG_BASE_URL,\n",
-    "    collection_names=[COLLECTION_NAME],\n",
-    "    k=5,\n",
-    ")\n",
-    "\n",
-    "query = \"What are the main topics or products discussed?\"\n",
-    "docs = retriever.invoke(query)\n",
-    "\n",
-    "print(f\"Query: {query}\")\n",
-    "print(f\"Retrieved {len(docs)} documents:\\n\")\n",
-    "for i, doc in enumerate(docs, 1):\n",
-    "    content_preview = (doc.page_content or \"\")[:300] + \"...\" if len(doc.page_content or \"\") > 300 else (doc.page_content or \"\")\n",
-    "    score = doc.metadata.get(\"score\", \"N/A\")\n",
-    "    source = doc.metadata.get(\"document_name\", \"N/A\")\n",
-    "    print(f\"--- Document {i} ---\")\n",
-    "    print(f\"Score: {score} | Source: {source}\")\n",
-    "    print(f\"Content: {content_preview}\")\n",
-    "    print()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 2.2 Custom Retrieval Parameters"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "35d7f118",
-   "metadata": {},
-   "source": [
-    "For details on retrieval parameters, filter expressions, and metadata:\n",
-    "- [Custom metadata & filter expressions](../docs/custom-metadata.md) – `filter_expr` syntax (Elasticsearch), metadata schema\n",
-    "- [Multi-turn & query rewriting](../docs/multiturn.md) – `enable_query_rewriting` for decontextualizing follow-up questions\n",
-    "- [Retriever API usage](./retriever_api_usage.ipynb) – Search endpoint payload parameters"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6e5aa122",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "retriever_custom = NVIDIARAGRetriever(\n",
-    "    base_url=RAG_BASE_URL,\n",
-    "    collection_names=[COLLECTION_NAME],\n",
-    "    # Result counts\n",
-    "    k=3,  # Number of document chunks to return (0-25, maps to reranker_top_k)\n",
-    "    vdb_top_k=50,  # Top results from vector DB before reranking (0-400)\n",
-    "    # Feature toggles\n",
-    "    enable_reranker=True,  # Rerank results for relevance\n",
-    "    enable_query_rewriting=False,  # Rewrite query for better retrieval\n",
-    "    enable_filter_generator=False,  # Auto-generate filters from query\n",
-    "    enable_citations=True,  # Include image/table/chart citations in metadata\n",
-    "    # Filtering\n",
-    "    confidence_threshold=0.0,  # Min confidence (0.0-1.0, requires enable_reranker=True)\n",
-    "    filter_expr=None,  # Elasticsearch filter expression, e.g. [{\"term\": {\"metadata.content_metadata.file_name.keyword\": \"doc.pdf\"}}]\n",
-    "    # Advanced\n",
-    "    vdb_endpoint=\"http://elasticsearch:9200\",  # Vector DB endpoint (override if needed)\n",
-    "    messages=[],  # Conversation history for context-aware retrieval\n",
-    "    timeout=60.0,  # HTTP request timeout in seconds\n",
-    ")\n",
-    "\n",
-    "docs = retriever_custom.invoke(\"Summarize key information\")\n",
-    "print(f\"Retrieved {len(docs)} documents\")\n",
-    "for i, doc in enumerate(docs, 1):\n",
-    "    print(f\"  {i}. {doc.metadata.get('document_name', 'N/A')} (score: {doc.metadata.get('score', 'N/A')})\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 2.3 Async Retrieval"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "docs = await retriever.ainvoke(\"What features or benefits are described?\")\n",
-    "print(f\"Async retrieval: {len(docs)} documents\")\n",
-    "for i, doc in enumerate(docs[:3], 1):\n",
-    "    print(f\"  {i}. {doc.metadata.get('document_name', 'N/A')}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 2.4 Error Handling"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bfcc9f22",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from langchain_nvidia_ai_endpoints.retrievers import (\n",
-    "    NVIDIARAGConnectionError,\n",
-    "    NVIDIARAGServerError,\n",
-    "    NVIDIARAGValidationError,\n",
-    ")\n",
-    "\n",
-    "try:\n",
-    "    bad_retriever = NVIDIARAGRetriever(\n",
-    "        base_url=\"http://invalid-host:8081\",\n",
-    "        collection_names=[COLLECTION_NAME],\n",
-    "    )\n",
-    "    bad_retriever.invoke(\"test\")\n",
-    "except NVIDIARAGConnectionError as e:\n",
-    "    print(f\"Connection error (expected): {e}\")\n",
-    "except NVIDIARAGValidationError as e:\n",
-    "    print(f\"Validation error: {e}\")\n",
-    "except NVIDIARAGServerError as e:\n",
-    "    print(f\"Server error ({e.status_code}): {e}\")\n",
-    "\n",
-    "print(\"\\nError handling works as expected.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3b5824c6",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## RAG Chain (Optional)\n",
-    "\n",
-    "Chain `NVIDIARAGRetriever` with `ChatNVIDIA` for end-to-end question answering. Requires `NVIDIA_API_KEY` to call the NVIDIA API Catalog.\n",
-    "\n",
-    "**Get an API key:** See [Get an API Key](../docs/api-key.md) for instructions."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d82a5d54",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Set NVIDIA_API_KEY if not already set (see ../docs/api-key.md to get a key)\n",
-    "if not os.environ.get(\"NVIDIA_API_KEY\", \"\").startswith(\"nvapi-\"):\n",
-    "    import getpass\n",
-    "    key = getpass.getpass(\"Enter your NVIDIA API key (nvapi-...): \")\n",
-    "    if key.startswith(\"nvapi-\"):\n",
-    "        os.environ[\"NVIDIA_API_KEY\"] = key\n",
-    "    else:\n",
-    "        print(\"NVIDIA_API_KEY not set. Set it to run the RAG chain. See [Get an API Key](../docs/api-key.md)\")\n",
-    "\n",
-    "if os.environ.get(\"NVIDIA_API_KEY\", \"\").startswith(\"nvapi-\"):\n",
-    "    from langchain_core.output_parsers import StrOutputParser\n",
-    "    from langchain_core.prompts import ChatPromptTemplate\n",
-    "    from langchain_core.runnables import RunnablePassthrough\n",
-    "\n",
-    "    from langchain_nvidia_ai_endpoints import ChatNVIDIA, NVIDIARAGRetriever\n",
-    "\n",
-    "    retriever = NVIDIARAGRetriever(\n",
-    "        base_url=RAG_BASE_URL,\n",
-    "        collection_names=[COLLECTION_NAME],\n",
-    "        k=4,\n",
-    "    )\n",
-    "\n",
-    "    def format_docs(docs):\n",
-    "        return \"\\n\\n\".join(d.page_content for d in docs)\n",
-    "\n",
-    "    prompt = ChatPromptTemplate.from_messages([\n",
-    "        (\"system\", \"Answer based only on the context below.\\n\\n{context}\"),\n",
-    "        (\"human\", \"{question}\"),\n",
-    "    ])\n",
-    "\n",
-    "    # Model aligned with rag-server default (nvidia/nemotron-3-super-120b-a12b)\n",
-    "    llm = ChatNVIDIA(model=\"nvidia/nemotron-3-super-120b-a12b\")\n",
-    "    chain = (\n",
-    "        {\"context\": retriever | format_docs, \"question\": RunnablePassthrough()}\n",
-    "        | prompt\n",
-    "        | llm\n",
-    "        | StrOutputParser()\n",
-    "    )\n",
-    "\n",
-    "    answer = chain.invoke(\"What are the main topics or products?\")\n",
-    "    print(answer)\n",
-    "else:\n",
-    "    print(\"NVIDIA_API_KEY not set. Set it (e.g. os.environ['NVIDIA_API_KEY'] = 'nvapi-...') or run this cell again to be prompted. See [Get an API Key](../docs/api-key.md)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4c95fdc6",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## Cleanup (Optional)\n",
-    "\n",
-    "To remove the collection and documents, use the delete cells in [ingestion_api_usage.ipynb](./ingestion_api_usage.ipynb) (sections 7 and 9)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Use ingestion_api_usage.ipynb sections 7 (Delete Documents) and 9 (Delete Collections)\n",
-    "# to remove the multimodal_data collection when finished."
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": ".venv",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3.11.12"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/notebooks/summarization.ipynb
+++ b/notebooks/summarization.ipynb
@@ -1,1450 +1,1493 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "fbf6ca4e",
-   "metadata": {},
-   "source": [
-    "# Document Summarization Customization Guide\n",
-    "\n",
-    "This notebook demonstrates how to customize the document summarization feature in NVIDIA RAG.\n",
-    "\n",
-    "## Two Modes of Operation\n",
-    "\n",
-    "- **Library Mode**: Programmatic configuration changes in Python notebooks/scripts\n",
-    "- **Docker Mode**: Configuration via environment variables and config files"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b134dbf9",
-   "metadata": {},
-   "source": [
-    "## 📊 Summarization Pipeline Architecture\n",
-    "\n",
-    "The diagram below shows how document summarization integrates into the complete RAG pipeline:\n",
-    "\n",
-    "![Summarization Pipeline Architecture](https://github.com/NVIDIA-AI-Blueprints/rag/raw/main/docs/assets/summarization_flow_diagram.png)\n",
-    "\n",
-    "The summarization workflow that this notebook focuses on. You'll learn to customize:\n",
-    "\n",
-    "- **Page Filtering**: Select specific pages using ranges, negative indexing, or even/odd patterns\n",
-    "- **Shallow vs Full Extraction**: Fast text-only OR comprehensive multimodal processing\n",
-    "- **Summarization Strategy**: Choose between Single (fastest), Hierarchical (balanced), or Iterative (best quality - default)\n",
-    "    - **Single**: Merge all content, chunk by configured size, and summarize only the first chunk (fastest, one LLM call)\n",
-    "    - **Hierarchical**: Tree-based summarization - summarize all chunks, merge summaries until they fit chunk size, repeat recursively until reaching one final summary (balanced speed/quality)\n",
-    "    - **Iterative (default)**: Process chunks sequentially with context refinement from previous summaries (best quality, N sequential LLM calls)\n",
-    "- **Token-based Chunking**: 9000 tokens per chunk with 400 token overlap\n",
-    "- **Real-time Status Tracking**: Monitor progress via Redis with chunk-level updates"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3a62b1a6",
-   "metadata": {},
-   "source": [
-    "---"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0dc56f4f",
-   "metadata": {},
-   "source": [
-    "## Part 1: Library Mode "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f389a897",
-   "metadata": {},
-   "source": [
-    "### 1. Setup before using library mode"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7adbc9f2",
-   "metadata": {},
-   "source": [
-    "#### 1.1. Installation guide for python package\n",
-    "\n",
-    "> **Note**: Python version **3.11 or higher** is required.\n",
-    "\n",
-    "##### 📝 **Development Mode Note:**\n",
-    "\n",
-    "- Installing with `uv pip install -e \"..[all]\"` allows you to make live edits to the `nvidia_rag` source code and have those changes reflected without reinstalling the package.\n",
-    "- After making changes to the source code, you need to:\n",
-    "  - Restart the kernel of your notebook server\n",
-    "  - Re-execute the cells under `Setting up the dependencies` and `Import the packages` sections"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d2bb524d",
-   "metadata": {},
-   "source": [
-    "#### Install uv (if not already installed)\n",
-    "\n",
-    "Run the cell below to check if `uv` is installed and install it if needed."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f7fa66fc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import subprocess\n",
-    "import shutil\n",
-    "\n",
-    "# Check if uv is installed\n",
-    "if shutil.which(\"uv\"):\n",
-    "    result = subprocess.run([\"uv\", \"--version\"], capture_output=True, text=True)\n",
-    "    print(f\"✅ uv is already installed: {result.stdout.strip()}\")\n",
-    "else:\n",
-    "    print(\"⚠️ uv is not installed. Installing now...\")\n",
-    "    # Install uv using the official installer\n",
-    "    !curl -LsSf https://astral.sh/uv/install.sh | sh\n",
-    "    print(\"\\n✅ uv installed! Please restart your terminal/kernel and re-run this notebook.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c6ce9248",
-   "metadata": {},
-   "source": [
-    "#### Install the NVIDIA RAG Package\n",
-    "\n",
-    "Choose one of the installation options below:\n",
-    "- **Option A**: Install from PyPI (recommended for most users)\n",
-    "- **Option B**: Install from source in development mode (for contributors)\n",
-    "- **Option C**: Build and install from source wheel"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e775b4ac",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Option A: Install from PyPI (recommended)\n",
-    "# Uncomment the line below to install from PyPI\n",
-    "# !uv pip install nvidia-rag[all]\n",
-    "\n",
-    "# Option B: Install from source in development mode (for contributors)\n",
-    "# Note: \"..\" refers to the parent directory where pyproject.toml is located\n",
-    "!uv pip install -e \"..[all]\"\n",
-    "\n",
-    "# Option C: Build and install from source wheel\n",
-    "# Uncomment the lines below to build and install from source\n",
-    "# !cd .. && uv build\n",
-    "# !uv pip install ../dist/nvidia_rag-*-py3-none-any.whl[all]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7cdd2bd9",
-   "metadata": {},
-   "source": [
-    "#### 1.2. Verify the installation\n",
-    "The location of the package shown in the output of this command should be inside the virtual environment.\n",
-    "\n",
-    "Location: `<workspace_path>/rag/.venv/lib/python3.12/site-packages`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "08c40dab",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!uv pip show nvidia_rag | grep Location"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ff09d666",
-   "metadata": {},
-   "source": [
-    "### 2. Setting up the dependencies"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "efdd89dc",
-   "metadata": {},
-   "source": [
-    "After the environment for the python package is set up, launch all the dependent services and NIMs that the pipeline depends on.\n",
-    "\n",
-    "Fulfill the [prerequisites here](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/deploy-docker-self-hosted.md) to set up docker on your system."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "84bf4f5f",
-   "metadata": {},
-   "source": [
-    "#### 2.1. Setup the default configurations"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1b5162b4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!uv pip install python-dotenv\n",
-    "import os\n",
-    "from getpass import getpass\n",
-    "\n",
-    "from dotenv import load_dotenv"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ec509cc9",
-   "metadata": {},
-   "source": [
-    "Provide your NGC_API_KEY after executing the cell below. You can obtain a key by following steps [here](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/api-key.md)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d60f81ff",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# del os.environ['NVIDIA_API_KEY']  ## delete key and reset if needed\n",
-    "if os.environ.get(\"NGC_API_KEY\", \"\").startswith(\"nvapi-\"):\n",
-    "    print(\"Valid NGC_API_KEY already in environment. Delete to reset\")\n",
-    "else:\n",
-    "    candidate_api_key = getpass(\"NVAPI Key (starts with nvapi-): \")\n",
-    "    assert candidate_api_key.startswith(\"nvapi-\"), (\n",
-    "        f\"{candidate_api_key[:5]}... is not a valid key\"\n",
-    "    )\n",
-    "    os.environ[\"NGC_API_KEY\"] = candidate_api_key"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "70dec262",
-   "metadata": {},
-   "source": [
-    "Login to nvcr.io which is needed for pulling the containers of dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7fec18c6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!echo \"${NGC_API_KEY}\" | docker login nvcr.io -u '$oauthtoken' --password-stdin"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "593ac9b0",
-   "metadata": {},
-   "source": [
-    "#### 2.2. Setup the Elasticsearch vector DB services\n",
-    "Elasticsearch is the default vector store.\n",
-    "See [change-vectordb.md](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/change-vectordb.md) to switch to Milvus if needed."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b5fa2f5d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "os.environ[\"VECTORSTORE_GPU_DEVICE_ID\"] = \"0\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "51c7b137",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!docker compose -f ../deploy/compose/vectordb.yaml up -d"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3969aa2c",
-   "metadata": {},
-   "source": [
-    "#### 2.3. Setup the NIMs"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "99abdce4",
-   "metadata": {},
-   "source": [
-    "#### Option 1: Deploy on-prem models"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4bb2ea98",
-   "metadata": {},
-   "source": [
-    "Move to Option 2 if you are interested in using cloud models.\n",
-    "\n",
-    "Ensure you meet [the hardware requirements](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/support-matrix.md). By default the NIMs are configured to use 2xH100."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "816b14c7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Create the model cache directory\n",
-    "!mkdir -p ~/.cache/model-cache"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "50299ae0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Set the MODEL_DIRECTORY environment variable in the Python kernel\n",
-    "import os\n",
-    "\n",
-    "os.environ[\"MODEL_DIRECTORY\"] = os.path.expanduser(\"~/.cache/model-cache\")\n",
-    "print(\"MODEL_DIRECTORY set to:\", os.environ[\"MODEL_DIRECTORY\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f577f8ff",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Configure GPU IDs for the various microservices if needed\n",
-    "os.environ[\"EMBEDDING_MS_GPU_ID\"] = \"0\"\n",
-    "os.environ[\"RANKING_MS_GPU_ID\"] = \"0\"\n",
-    "os.environ[\"YOLOX_MS_GPU_ID\"] = \"0\"\n",
-    "os.environ[\"YOLOX_GRAPHICS_MS_GPU_ID\"] = \"0\"\n",
-    "os.environ[\"YOLOX_TABLE_MS_GPU_ID\"] = \"0\"\n",
-    "os.environ[\"OCR_MS_GPU_ID\"] = \"0\"\n",
-    "os.environ[\"LLM_MS_GPU_ID\"] = \"1\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1c621259",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# ⚠️ Deploying NIMs - This may take a while as models download. If kernel times out, just rerun this cell.\n",
-    "!USERID=$(id -u) docker compose -f ../deploy/compose/nims.yaml up -d"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "af5e0f6f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Watch the status of running containers (run this cell repeatedly or in a terminal)\n",
-    "!docker ps"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2ba63d1d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Set deployment mode for on-prem NIMs\n",
-    "DEPLOYMENT_MODE = \"on_prem\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9fed48c0",
-   "metadata": {},
-   "source": [
-    "Ensure all the below are running and healthy before proceeding further\n",
-    "```output\n",
-    "NAMES                           STATUS\n",
-    "nemotron-ranking-ms        Up ... (healthy)\n",
-    "compose-page-elements-1         Up ...\n",
-    "compose-nemotron-ocr-1     Up ...\n",
-    "compose-graphic-elements-1      Up ...\n",
-    "compose-table-structure-1       Up ...\n",
-    "nemotron-vlm-embedding-ms  Up ... (healthy)\n",
-    "nim-llm-ms                      Up ... (healthy)\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "dbac5b7a",
-   "metadata": {},
-   "source": [
-    "#### Option 2: Using Nvidia Hosted models"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2d529315",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "DEPLOYMENT_MODE = \"cloud\"\n",
-    "\n",
-    "# Set deployment mode for NVIDIA hosted cloud APIs\n",
-    "os.environ[\"OCR_HTTP_ENDPOINT\"] = \"https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-ocr-v1\"\n",
-    "os.environ[\"OCR_INFER_PROTOCOL\"] = \"http\"\n",
-    "os.environ[\"YOLOX_HTTP_ENDPOINT\"] = (\n",
-    "    \"https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-page-elements-v3\"\n",
-    ")\n",
-    "os.environ[\"YOLOX_INFER_PROTOCOL\"] = \"http\"\n",
-    "os.environ[\"YOLOX_GRAPHIC_ELEMENTS_HTTP_ENDPOINT\"] = (\n",
-    "    \"https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-graphic-elements-v1\"\n",
-    ")\n",
-    "os.environ[\"YOLOX_GRAPHIC_ELEMENTS_INFER_PROTOCOL\"] = \"http\"\n",
-    "os.environ[\"YOLOX_TABLE_STRUCTURE_HTTP_ENDPOINT\"] = (\n",
-    "    \"https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-table-structure-v1\"\n",
-    ")\n",
-    "os.environ[\"YOLOX_TABLE_STRUCTURE_INFER_PROTOCOL\"] = \"http\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d5b176dc",
-   "metadata": {},
-   "source": [
-    "#### 2.4. Setup the Nvidia Ingest runtime and redis service"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "be355c11",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!docker compose -f ../deploy/compose/docker-compose-ingestor-server.yaml up nv-ingest-ms-runtime redis -d"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cbc0ef32",
-   "metadata": {},
-   "source": [
-    "#### 2.5. Load optional profiles if needed"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4c1fca90",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Load accuracy profile\n",
-    "# load_dotenv(dotenv_path='../deploy/compose/accuracy_profile.env', override=True)\n",
-    "\n",
-    "# OR load perf profile\n",
-    "# load_dotenv(dotenv_path='../deploy/compose/perf_profile.env', override=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "12b33ced",
-   "metadata": {},
-   "source": [
-    "### 3. Import libraries and view defaults\n",
-    "\n",
-    "After setting up the python package and starting all dependent services, we can now import the libraries and view default configuration for summarization."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0f067c70",
-   "metadata": {},
-   "source": [
-    "#### 3.1. Set logging level\n",
-    "\n",
-    "First let's set the required logging level. Set to INFO for displaying basic important logs. Set to DEBUG for full verbosity."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f15e1d4f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import logging\n",
-    "import os\n",
-    "\n",
-    "# Set the log level via environment variable before importing nvidia_rag\n",
-    "# This ensures the package respects our log level setting\n",
-    "LOGLEVEL = logging.WARNING  # Set to INFO, DEBUG, WARNING or ERROR\n",
-    "os.environ[\"LOGLEVEL\"] = logging.getLevelName(LOGLEVEL)\n",
-    "\n",
-    "# Configure logging\n",
-    "logging.basicConfig(level=LOGLEVEL, force=True)\n",
-    "\n",
-    "# Set log levels for specific loggers after package import\n",
-    "for name in logging.root.manager.loggerDict:\n",
-    "    if name == \"nvidia_rag\" or name.startswith(\"nvidia_rag.\"):\n",
-    "        logging.getLogger(name).setLevel(LOGLEVEL)\n",
-    "    if name == \"nv_ingest_client\" or name.startswith(\"nv_ingest_client.\"):\n",
-    "        logging.getLogger(name).setLevel(LOGLEVEL)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5be07e0e",
-   "metadata": {},
-   "source": [
-    "#### 3.2. Import the packages and initialize configuration\n",
-    "You can import both or either one based on your requirements. `NvidiaRAG()` exposes APIs to interact with the uploaded documents or retrieve summaries and `NvidiaRAGIngestor()` exposes APIs for document upload, management and summary generation."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "47db7b83",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from nvidia_rag import NvidiaRAG, NvidiaRAGIngestor\n",
-    "from nvidia_rag.utils.configuration import NvidiaRAGConfig\n",
-    "from nvidia_rag.rag_server.response_generator import retrieve_summary\n",
-    "\n",
-    "# Get the configuration object\n",
-    "config = NvidiaRAGConfig.from_yaml(\"config.yaml\")\n",
-    "\n",
-    "# Update config for cloud deployment if using Option 2\n",
-    "if DEPLOYMENT_MODE == \"cloud\":\n",
-    "    config.embeddings.server_url = \"https://integrate.api.nvidia.com/v1\"\n",
-    "    config.llm.server_url = \"\"  # Empty uses NVIDIA API catalog\n",
-    "    config.ranking.server_url = \"https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-nemotron-rerank-1b-v2/reranking/v1\"\n",
-    "    config.summarizer.server_url = \"\"  # Empty uses NVIDIA API catalog\n",
-    "else:\n",
-    "    config.embeddings.server_url = \"nemotron-vlm-embedding-ms:8000/v1\"\n",
-    "    config.ranking.server_url = \"nemotron-ranking-ms:8000\"\n",
-    "    config.summarizer.server_url = \"nim-llm:8000\"\n",
-    "    config.llm.server_url = \"nim-llm:8000\"\n",
-    "\n",
-    "# Initialize NvidiaRAG and NvidiaRAGIngestor with config\n",
-    "# For summarization customization, pass prompts to NvidiaRAGIngestor:\n",
-    "#   - A path to a YAML/JSON file: prompts=\"custom_prompts.yaml\"\n",
-    "#   - A dictionary: prompts={\"document_summary_prompt\": {...}}\n",
-    "rag = NvidiaRAG(config=config)\n",
-    "ingestor = NvidiaRAGIngestor(config=config)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8fceebee",
-   "metadata": {},
-   "source": [
-    "#### 3.3. View Default Summarizer LLM Settings\n",
-    "\n",
-    "Let's see what LLM model and parameters are used by default for summarization."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5b53e5bf",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"=\" * 70)\n",
-    "print(\"DEFAULT SUMMARIZER LLM CONFIGURATION\")\n",
-    "print(\"=\" * 70)\n",
-    "print(f\"Model:             {config.summarizer.model_name}\")\n",
-    "print(f\"Server URL:        {config.summarizer.server_url}\")\n",
-    "print(f\"Temperature:       {config.summarizer.temperature}\")\n",
-    "print(f\"Top P:             {config.summarizer.top_p}\")\n",
-    "print(f\"Max Parallel:      {config.summarizer.max_parallelization}\")\n",
-    "print(f\"Max Chunk Length:  {config.summarizer.max_chunk_length}\")\n",
-    "print(f\"Chunk Overlap:     {config.summarizer.chunk_overlap}\")\n",
-    "print(\"=\" * 70)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d50f697c",
-   "metadata": {},
-   "source": [
-    "#### 3.4. View Default Summarization Prompts\n",
-    "\n",
-    "The prompt template controls how the LLM generates summaries. Let's see the default prompts."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b6cbb7d0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import json\n",
-    "\n",
-    "# Access prompts from the NvidiaRAGIngestor instance (initialized with defaults)\n",
-    "# Summarization is handled by NvidiaRAGIngestor, so view prompts from ingestor\n",
-    "print(\"=\" * 70)\n",
-    "print(\"DEFAULT DOCUMENT SUMMARY PROMPT\")\n",
-    "print(\"=\" * 70)\n",
-    "print(json.dumps(ingestor.prompts[\"document_summary_prompt\"], indent=2))\n",
-    "print(\"=\" * 70)\n",
-    "\n",
-    "print(\"\\n\" + \"=\" * 70)\n",
-    "print(\"DEFAULT ITERATIVE SUMMARY PROMPT\")\n",
-    "print(\"=\" * 70)\n",
-    "print(json.dumps(ingestor.prompts[\"iterative_summary_prompt\"], indent=2))\n",
-    "print(\"=\" * 70)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fce20869",
-   "metadata": {},
-   "source": [
-    "This will display the default prompts used for:\n",
-    "- **document_summary_prompt**: Summarizing a single document or chunk (used for full multimodal extraction)\n",
-    "- **shallow_summary_prompt**: Summarizing with fast text-only extraction (used when `shallow_summary: true`)\n",
-    "- **iterative_summary_prompt**: Combining multiple summaries for large documents\n",
-    "\n",
-    "The system automatically selects the appropriate prompt based on extraction mode and document size."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3eefeb2b",
-   "metadata": {},
-   "source": [
-    "---"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "27ec763e",
-   "metadata": {},
-   "source": [
-    "## Part 2: Library Mode - Change Configuration\n",
-    "Now let's see how to modify these settings programmatically in library mode.\n",
-    "\n",
-    "### 1. Change LLM Model and Parameters\n",
-    "\n",
-    "You can change the model and sampling parameters dynamically."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6cc84ba0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Change to a different model (e.g., Llama 3.1 70B)\n",
-    "config.summarizer.model_name = \"meta/llama-3.1-70b-instruct\"\n",
-    "config.summarizer.server_url = \"\"\n",
-    "\n",
-    "# Lower temperature for more deterministic, focused summaries\n",
-    "config.summarizer.temperature = 0.2\n",
-    "\n",
-    "# Adjust top_p for nucleus sampling\n",
-    "config.summarizer.top_p = 0.7\n",
-    "\n",
-    "# Configure global rate limiting (max parallel summary tasks across all workers)\n",
-    "# Prevents overwhelming GPU/API with too many concurrent LLM calls\n",
-    "config.summarizer.max_parallelization = 10  # Default: 20\n",
-    "\n",
-    "print(\"✅ Updated Summarizer Configuration:\")\n",
-    "print(f\"   Model:       {config.summarizer.model_name}\")\n",
-    "print(f\"   Server URL:  {config.summarizer.server_url}\")\n",
-    "print(f\"   Temperature: {config.summarizer.temperature}\")\n",
-    "print(f\"   Top P:       {config.summarizer.top_p}\")\n",
-    "print(f\"   Max Parallel:{config.summarizer.max_parallelization}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "15dabf4c",
-   "metadata": {},
-   "source": [
-    "### 2. Customize Summarization Prompts\n",
-    "\n",
-    "Customize the prompt to change the style and focus of summaries by passing prompts during `NvidiaRAGIngestor` initialization.\n",
-    "\n",
-    "This is the **recommended approach** for library mode - pass prompts directly to the constructor for clean, instance-specific configuration.\n",
-    "\n",
-    "> **Note**: Summarization is handled by `NvidiaRAGIngestor`, so prompts for summarization should be passed to `NvidiaRAGIngestor`, not `NvidiaRAG`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "05167610",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Define custom prompts as a dictionary\n",
-    "custom_prompts = {\n",
-    "    \"document_summary_prompt\": {\n",
-    "        \"system\": \"/no_think\",\n",
-    "        \"human\": \"\"\"You are a documentation specialist.\n",
-    "\n",
-    "Create a clear, summary that:\n",
-    "1. Identifies the main topic and purpose\n",
-    "2. Lists key concepts or features\n",
-    "3. Highlights important procedures or steps  \n",
-    "4. Notes any warnings or critical information\n",
-    "\n",
-    "Keep the summary concise.\n",
-    "\n",
-    "Text to summarize:\n",
-    "{document_text}\n",
-    "\n",
-    "Summary:\"\"\"\n",
-    "    }\n",
-    "}\n",
-    "\n",
-    "# Create NvidiaRAGIngestor instance with custom prompts (Recommended Approach)\n",
-    "# The prompts are merged with defaults - only specified keys are overridden\n",
-    "ingestor_custom = NvidiaRAGIngestor(config=config, prompts=custom_prompts)\n",
-    "\n",
-    "print(\"✅ NvidiaRAGIngestor initialized with custom prompts\")\n",
-    "print(\"\\nCustom prompt preview (first 200 chars):\")\n",
-    "print(ingestor_custom.prompts[\"document_summary_prompt\"][\"human\"][:200] + \"...\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a90fa503",
-   "metadata": {},
-   "source": [
-    "#### Alternative: Using a YAML File\n",
-    "\n",
-    "You can also pass a path to a YAML file containing your custom prompts:\n",
-    "\n",
-    "```python\n",
-    "# Using a YAML file path\n",
-    "ingestor_from_yaml = NvidiaRAGIngestor(config=config, prompts=\"custom_prompts.yaml\")\n",
-    "```\n",
-    "\n",
-    "The YAML file format should match the structure shown in the Docker Mode section below.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c56d2be2",
-   "metadata": {},
-   "source": [
-    "### 3. Configure Summary Options"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0fce6903",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "summary_options = {\n",
-    "    # Page filtering: [[1, 10]] (ranges), [[-5, -1]] (last N pages), \"even\"/\"odd\"\n",
-    "    \"page_filter\": [[1, 10]],  # Only pages 1-10\n",
-    "    \n",
-    "    # Fast mode: Text-only extraction first, summary in seconds\n",
-    "    \"shallow_summary\": True,  # Default: False\n",
-    "    \n",
-    "    # Strategy: None (iterative/best), \"single\" (fastest/truncates), \"hierarchical\" (parallel/faster than iterative)\n",
-    "    \"summarization_strategy\": \"hierarchical\"  # Default: None\n",
-    "}\n",
-    "\n",
-    "\n",
-    "print(f\"  • Page Filter: {summary_options['page_filter']}\")\n",
-    "print(f\"  • Shallow Summary: {summary_options['shallow_summary']}\")\n",
-    "print(f\"  • Strategy: {summary_options['summarization_strategy']}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ff3be036",
-   "metadata": {},
-   "source": [
-    "### 4. Complete Workflow Example\n",
-    "\n",
-    "This section demonstrates the end-to-end workflow: create collection → upload documents → check status → retrieve summary → cleanup."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c0c75f90",
-   "metadata": {},
-   "source": [
-    "#### 4.1. Create Collection"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "606e67a3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Create collection\n",
-    "collection_name = \"test_summary\"\n",
-    "response = ingestor.create_collection(\n",
-    "    collection_name=collection_name,\n",
-    "    vdb_endpoint=\"http://localhost:9200\"\n",
-    ")\n",
-    "print(f\"✅ Collection response: {response}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1ac5baec",
-   "metadata": {},
-   "source": [
-    "#### 4.2. Upload Documents"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cbf50562",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Upload documents with summary options\n",
-    "result = await ingestor.upload_documents(\n",
-    "    filepaths=[\"../data/multimodal/functional_validation.pdf\"],\n",
-    "    collection_name=collection_name,\n",
-    "    generate_summary=True,\n",
-    "    summary_options=summary_options,  # From previous cell\n",
-    "    blocking=False  # Don't wait, check status instead\n",
-    ")\n",
-    "print(f\"✅ Upload started: {result}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "02afe705",
-   "metadata": {},
-   "source": [
-    "#### 4.3. Check Status and Get Summary"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "94cebc0e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Check summary status\n",
-    "status = await retrieve_summary(\n",
-    "    collection_name=collection_name,\n",
-    "    file_name=\"functional_validation.pdf\",\n",
-    "    wait=False  # Just check, don't wait\n",
-    ")\n",
-    "print(f\"\\n📊 Status: {status.get('status')}\")\n",
-    "if status.get('status') == 'IN_PROGRESS':\n",
-    "    progress = status.get('progress', {})\n",
-    "    print(f\"   Progress: Chunk {progress.get('current')}/{progress.get('total')}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "301f8dfc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Get summary (blocking - waits until complete)\n",
-    "summary_result = await retrieve_summary(\n",
-    "    collection_name=collection_name,\n",
-    "    file_name=\"functional_validation.pdf\",\n",
-    "    wait=True,\n",
-    "    timeout=300\n",
-    ")\n",
-    "\n",
-    "if summary_result.get('status') == 'SUCCESS':\n",
-    "    print(f\"\\n✅ Summary:\\n{summary_result.get('summary')}\")\n",
-    "else:\n",
-    "    print(f\"\\n❌ {summary_result.get('status')}: {summary_result.get('message')}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "de34199d",
-   "metadata": {},
-   "source": [
-    "#### 4.4. Delete Collection"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "71fe09fe",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Delete the test collection\n",
-    "response = ingestor.delete_collections(\n",
-    "    collection_names=[collection_name],\n",
-    "    vdb_endpoint=\"http://localhost:9200\"\n",
-    ")\n",
-    "print(f\"✅ Delete response: {response}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "caea11bf",
-   "metadata": {},
-   "source": [
-    "---"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a55c3b72",
-   "metadata": {},
-   "source": [
-    "## Part 3: Docker Mode - Change Configuration via Environment Variables\n",
-    "\n",
-    "When running in Docker mode, you configure the ingestor-server and rag-server containers via environment variables and REST APIs.\n",
-    "\n",
-    "**Prerequisites:**\n",
-    "- If you're starting fresh with Part 3, first complete section **\"2. Setting up the dependencies\"** from Part 1 above to start all required services (Elasticsearch, NV-Ingest, Redis)\n",
-    "- If you completed Part 1, these services are already running"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f9e4a17e",
-   "metadata": {},
-   "source": [
-    "### 1. Configure via Environment Variables\n",
-    "\n",
-    "Configure the ingestor server by setting environment variables before startup. Adjust these values according to your requirements:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4eae9bca",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Set environment variables in Python based on mode\n",
-    "if DEPLOYMENT_MODE == \"cloud\":\n",
-    "    os.environ[\"SUMMARY_LLM_SERVERURL\"] = \"\"\n",
-    "    os.environ[\"LLM_SERVER_URL\"] = \"\"\n",
-    "    os.environ[\"APP_EMBEDDINGS_SERVERURL\"] = \"https://integrate.api.nvidia.com/v1\"\n",
-    "    print(\"✓ Configured for NVIDIA cloud APIs\")\n",
-    "else:\n",
-    "    os.environ[\"SUMMARY_LLM_SERVERURL\"] = \"nim-llm:8000\"\n",
-    "    os.environ[\"LLM_SERVER_URL\"] = \"nim-llm:8000\"\n",
-    "    os.environ[\"APP_EMBEDDINGS_SERVERURL\"] = \"nemotron-vlm-embedding-ms:8000/v1\"\n",
-    "    print(\"✓ Configured for on-prem NIMs\")\n",
-    "\n",
-    "os.environ[\"LOGLEVEL\"] = \"INFO\"\n",
-    "\n",
-    "print(\"Environment variables set for deployment mode\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "920a5ad0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "# Custom Summarization configuration\n",
-    "export SUMMARY_LLM=\"meta/llama-3.1-70b-instruct\"\n",
-    "export SUMMARY_LLM_TEMPERATURE=0.2\n",
-    "export SUMMARY_LLM_TOP_P=0.7\n",
-    "export SUMMARY_LLM_MAX_CHUNK_LENGTH=9000\n",
-    "export SUMMARY_CHUNK_OVERLAP=400\n",
-    "export SUMMARY_MAX_PARALLELIZATION=20\n",
-    "\n",
-    "# start container\n",
-    "docker compose -f ../deploy/compose/docker-compose-ingestor-server.yaml up -d ingestor-server\n",
-    "docker compose -f ../deploy/compose/docker-compose-rag-server.yaml up -d rag-server\n",
-    "\n",
-    "echo \"Configure summarization parameters and start container\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7307d496",
-   "metadata": {},
-   "source": [
-    "### 2. Custom Prompts via YAML File\n",
-    "\n",
-    "To change prompts in Docker mode, create a custom `prompt.yaml` file and set the `PROMPT_CONFIG_FILE` environment variable.\n",
-    "\n",
-    "#### 2.1. Create Custom Prompt File\n",
-    "\n",
-    "Create your custom prompt file (e.g., `/home/user/my_custom_prompt.yaml`):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "73da6ef7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Define custom prompt configuration\n",
-    "custom_prompt_content = \"\"\"document_summary_prompt:\n",
-    "  system: |\n",
-    "    /no_think\n",
-    "  \n",
-    "  human: |\n",
-    "    You are a technical documentation specialist.\n",
-    "    \n",
-    "    Create a clear, technical summary that:\n",
-    "    1. Identifies the main topic and purpose\n",
-    "    2. Lists key technical concepts or features\n",
-    "    3. Highlights important procedures or steps\n",
-    "    4. Notes any warnings or critical information\n",
-    "    \n",
-    "    Keep the summary concise and technical.\n",
-    "    \n",
-    "    Text to summarize:\n",
-    "    {document_text}\n",
-    "    \n",
-    "    Technical Summary:\n",
-    "\n",
-    "iterative_summary_prompt:\n",
-    "  system: |\n",
-    "    /no_think\n",
-    "  \n",
-    "  human: |\n",
-    "    You are a technical documentation specialist combining summaries.\n",
-    "    \n",
-    "    Previous Summary:\n",
-    "    {previous_summary}\n",
-    "    \n",
-    "    New chunk:\n",
-    "    {new_chunk}\n",
-    "    \n",
-    "    Create an updated technical summary combining both.\n",
-    "\"\"\"\n",
-    "\n",
-    "# Write the custom prompt file\n",
-    "import os\n",
-    "custom_prompt_path = os.path.expanduser(\"~/my_custom_prompt.yaml\")\n",
-    "with open(custom_prompt_path, \"w\") as f:\n",
-    "    f.write(custom_prompt_content)\n",
-    "\n",
-    "print(f\"Custom prompt file created at: {custom_prompt_path}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "beffd23e",
-   "metadata": {},
-   "source": [
-    "#### 2.2. Set Environment Variable and Restart\n",
-    "\n",
-    "Set the environment variable and restart the container:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a33369d9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "# Set path to custom prompt file\n",
-    "export PROMPT_CONFIG_FILE=~/my_custom_prompt.yaml\n",
-    "\n",
-    "# Restart the container (no rebuild needed)\n",
-    "# Note: This inherits NGC_API_KEY from the parent shell if it was set via os.environ earlier\n",
-    "docker compose -f ../deploy/compose/docker-compose-ingestor-server.yaml up -d ingestor-server\n",
-    "\n",
-    "echo \"Ingestor server restarted with custom prompts from: $PROMPT_CONFIG_FILE\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b25fe3db",
-   "metadata": {},
-   "source": [
-    "**Key Points:**\n",
-    "- The service will merge your custom prompts with the defaults\n",
-    "- Only the prompts you specify will be overridden - all others remain unchanged\n",
-    "- No container rebuild is required, just restart with the new environment variable!\n",
-    "\n",
-    "For more details, see the prompt customization documentation."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cb475d78",
-   "metadata": {},
-   "source": [
-    "### 3. Using Ingestor Server REST APIs\n",
-    "\n",
-    "When running in Docker mode, you interact with the ingestor server via REST APIs. Here's the complete workflow for document summarization using APIs.\n",
-    "\n",
-    "#### Prerequisites\n",
-    "- Ensure ingestor-server and rag-server containers are running\n",
-    "- Replace `localhost` with actual IP if hosted on another system"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "069af221",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Install Dependencies\n",
-    "!uv pip install aiohttp"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "54c02b58",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import json\n",
-    "import os\n",
-    "import aiohttp\n",
-    "\n",
-    "# Setup base configuration\n",
-    "INGESTOR_BASE_URL = \"http://localhost:8082\"\n",
-    "RAG_BASE_URL = \"http://localhost:8081\"\n",
-    "\n",
-    "\n",
-    "async def print_response(response):\n",
-    "    \"\"\"Helper to print API response.\"\"\"\n",
-    "    try:\n",
-    "        response_json = await response.json()\n",
-    "        print(json.dumps(response_json, indent=2))\n",
-    "    except aiohttp.ClientResponseError:\n",
-    "        print(await response.text())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ece3f9ed",
-   "metadata": {},
-   "source": [
-    "#### 3.1. Health Check"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e2b9bd62",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "async def check_health():\n",
-    "    \"\"\"Check ingestor server health.\"\"\"\n",
-    "    url = f\"{INGESTOR_BASE_URL}/v1/health\"\n",
-    "    params = {\"check_dependencies\": \"True\"}\n",
-    "    async with aiohttp.ClientSession() as session:\n",
-    "        async with session.get(url, params=params) as response:\n",
-    "            await print_response(response)\n",
-    "\n",
-    "await check_health()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e56e52f7",
-   "metadata": {},
-   "source": [
-    "#### 3.2. Create Collection"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2908a9b7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "async def create_collection(collection_name: str):\n",
-    "    \"\"\"Create a collection for document storage.\"\"\"\n",
-    "    data = {\n",
-    "        \"collection_name\": collection_name,\n",
-    "        \"metadata_schema\": []\n",
-    "    }\n",
-    "    \n",
-    "    headers = {\"Content-Type\": \"application/json\"}\n",
-    "    \n",
-    "    async with aiohttp.ClientSession() as session:\n",
-    "        try:\n",
-    "            async with session.post(\n",
-    "                f\"{INGESTOR_BASE_URL}/v1/collection\", \n",
-    "                json=data, \n",
-    "                headers=headers\n",
-    "            ) as response:\n",
-    "                await print_response(response)\n",
-    "        except aiohttp.ClientError as e:\n",
-    "            print(f\"Error: {e}\")\n",
-    "\n",
-    "# Create collection\n",
-    "await create_collection(collection_name=\"test_summary_api\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9492a594",
-   "metadata": {},
-   "source": [
-    "#### 3.3. Upload Documents with Summary Options"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8bf7cada",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "async def upload_with_summary(collection_name: str, filepaths: list):\n",
-    "    \"\"\"Upload documents and generate summaries.\"\"\"\n",
-    "    \n",
-    "    # Configure summary options\n",
-    "    data = {\n",
-    "        \"collection_name\": collection_name,\n",
-    "        \"blocking\": False,  # Non-blocking upload\n",
-    "        \"split_options\": {\"chunk_size\": 512, \"chunk_overlap\": 150},\n",
-    "        \"generate_summary\": True,  # Enable summary generation\n",
-    "        \"summary_options\": {\n",
-    "            \"page_filter\": [[1, 10], [-5, -1]],  # First 10 and last 5 pages\n",
-    "            \"shallow_summary\": True,  # Fast text-only extraction\n",
-    "            \"summarization_strategy\": \"single\"  # fastest strategy other available: \"hierarchical\", None(iterative)\n",
-    "        }\n",
-    "    }\n",
-    "    \n",
-    "    form_data = aiohttp.FormData()\n",
-    "    for file_path in filepaths:\n",
-    "        form_data.add_field(\n",
-    "            \"documents\",\n",
-    "            open(file_path, \"rb\"),\n",
-    "            filename=os.path.basename(file_path),\n",
-    "            content_type=\"application/pdf\",\n",
-    "        )\n",
-    "    \n",
-    "    form_data.add_field(\"data\", json.dumps(data), content_type=\"application/json\")\n",
-    "    \n",
-    "    async with aiohttp.ClientSession() as session:\n",
-    "        try:\n",
-    "            async with session.post(\n",
-    "                f\"{INGESTOR_BASE_URL}/v1/documents\", \n",
-    "                data=form_data\n",
-    "            ) as response:\n",
-    "                await print_response(response)\n",
-    "                response_json = await response.json()\n",
-    "                return response_json.get(\"task_id\")\n",
-    "        except aiohttp.ClientError as e:\n",
-    "            print(f\"Error: {e}\")\n",
-    "            return None\n",
-    "\n",
-    "# Upload documents\n",
-    "task_id = await upload_with_summary(\n",
-    "    collection_name=\"test_summary_api\",\n",
-    "    filepaths=[\"../data/multimodal/functional_validation.pdf\"]\n",
-    ")\n",
-    "print(f\"\\n✅ Upload task_id: {task_id}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1d4c4704",
-   "metadata": {},
-   "source": [
-    "#### 3.4. Check Upload Status (Ingestor Server)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d1d17b62",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "async def check_upload_status(task_id: str):\n",
-    "    \"\"\"Check ingestion task status.\"\"\"\n",
-    "    params = {\"task_id\": task_id}\n",
-    "    headers = {\"Content-Type\": \"application/json\"}\n",
-    "    \n",
-    "    async with aiohttp.ClientSession() as session:\n",
-    "        try:\n",
-    "            async with session.get(\n",
-    "                f\"{INGESTOR_BASE_URL}/v1/status\", \n",
-    "                params=params, \n",
-    "                headers=headers\n",
-    "            ) as response:\n",
-    "                await print_response(response)\n",
-    "        except aiohttp.ClientError as e:\n",
-    "            print(f\"Error: {e}\")\n",
-    "\n",
-    "# Check status\n",
-    "if task_id:\n",
-    "    await check_upload_status(task_id=task_id)\n",
-    "else:\n",
-    "    print(\"No task_id available\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9986e2f9",
-   "metadata": {},
-   "source": [
-    "#### 3.5. Check Summary Status (RAG Server)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1b773bfa",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "async def check_summary_status(collection_name: str, file_name: str):\n",
-    "    \"\"\"Check summary generation status via RAG server.\"\"\"\n",
-    "    params = {\n",
-    "        \"collection_name\": collection_name,\n",
-    "        \"file_name\": file_name,\n",
-    "        \"blocking\": \"false\"  # Just check status, don't wait\n",
-    "    }\n",
-    "    \n",
-    "    url = f\"{RAG_BASE_URL}/v1/summary\"\n",
-    "    \n",
-    "    async with aiohttp.ClientSession() as session:\n",
-    "        try:\n",
-    "            async with session.get(url, params=params) as response:\n",
-    "                await print_response(response)\n",
-    "        except aiohttp.ClientError as e:\n",
-    "            print(f\"Error: {e}\")\n",
-    "\n",
-    "# Check summary status\n",
-    "await check_summary_status(\n",
-    "    collection_name=\"test_summary_api\",\n",
-    "    file_name=\"functional_validation.pdf\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bcb0e82b",
-   "metadata": {},
-   "source": [
-    "#### 3.6. Delete Collection"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fa7edca4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "async def delete_collections(collection_names: list[str]):\n",
-    "    \"\"\"Delete collections from the vector store.\"\"\"\n",
-    "    url = f\"{INGESTOR_BASE_URL}/v1/collections\"\n",
-    "    \n",
-    "    async with aiohttp.ClientSession() as session:\n",
-    "        try:\n",
-    "            async with session.delete(url, json=collection_names) as response:\n",
-    "                await print_response(response)\n",
-    "        except aiohttp.ClientError as e:\n",
-    "            print(f\"Error: {e}\")\n",
-    "\n",
-    "# Delete the test collection\n",
-    "await delete_collections(collection_names=[\"test_summary_api\"])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5e120e1c",
-   "metadata": {},
-   "source": [
-    "---"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "baab41ef",
-   "metadata": {},
-   "source": [
-    "## Summary of Available Configuration Options\n",
-    "\n",
-    "### Summarizer Configuration Fields\n",
-    "\n",
-    "| Field | Environment Variable | Default Value | Description |\n",
-    "|-------|---------------------|---------------|-------------|\n",
-    "| `model_name` | `SUMMARY_LLM` | `nvidia/nemotron-3-super-120b-a12b` | The LLM model used for summarization |\n",
-    "| `server_url` | `SUMMARY_LLM_SERVERURL` | (empty) | Server URL for custom model hosting |\n",
-    "| `temperature` | `SUMMARY_LLM_TEMPERATURE` | `0.0` | Controls randomness (0.0-1.0) |\n",
-    "| `top_p` | `SUMMARY_LLM_TOP_P` | `1.0` | Nucleus sampling parameter (0.0-1.0) |\n",
-    "| `max_chunk_length` | `SUMMARY_LLM_MAX_CHUNK_LENGTH` | `9000` | Maximum chunk size in tokens |\n",
-    "| `chunk_overlap` | `SUMMARY_CHUNK_OVERLAP` | `400` | Overlap between chunks in tokens |\n",
-    "\n",
-    "### Prompt Template Variables\n",
-    "\n",
-    "- **document_summary_prompt**: Use `{document_text}` variable\n",
-    "- **iterative_summary_prompt**: Use `{previous_summary}` and `{new_chunk}` variable\n",
-    "\n",
-    "**Note:** Changes made in library mode take effect immediately without restarting any services. Changes in Docker mode require a container restart but no rebuild."
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": ".venv",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.10"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Document Summarization Customization Guide\n",
+        "\n",
+        "This notebook demonstrates how to customize the document summarization feature in NVIDIA RAG.\n",
+        "\n",
+        "## Two Modes of Operation\n",
+        "\n",
+        "- **Library Mode**: Programmatic configuration changes in Python notebooks/scripts\n",
+        "- **Docker Mode**: Configuration via environment variables and config files"
+      ],
+      "id": "fbf6ca4e"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 📊 Summarization Pipeline Architecture\n",
+        "\n",
+        "The diagram below shows how document summarization integrates into the complete RAG pipeline:\n",
+        "\n",
+        "![Summarization Pipeline Architecture](https://github.com/NVIDIA-AI-Blueprints/rag/raw/main/docs/assets/summarization_flow_diagram.png)\n",
+        "\n",
+        "The summarization workflow that this notebook focuses on. You'll learn to customize:\n",
+        "\n",
+        "- **Page Filtering**: Select specific pages using ranges, negative indexing, or even/odd patterns\n",
+        "- **Shallow vs Full Extraction**: Fast text-only OR comprehensive multimodal processing\n",
+        "- **Summarization Strategy**: Choose between Single (fastest), Hierarchical (balanced), or Iterative (best quality - default)\n",
+        "    - **Single**: Merge all content, chunk by configured size, and summarize only the first chunk (fastest, one LLM call)\n",
+        "    - **Hierarchical**: Tree-based summarization - summarize all chunks, merge summaries until they fit chunk size, repeat recursively until reaching one final summary (balanced speed/quality)\n",
+        "    - **Iterative (default)**: Process chunks sequentially with context refinement from previous summaries (best quality, N sequential LLM calls)\n",
+        "- **Token-based Chunking**: 9000 tokens per chunk with 400 token overlap\n",
+        "- **Real-time Status Tracking**: Monitor progress via Redis with chunk-level updates"
+      ],
+      "id": "b134dbf9"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---"
+      ],
+      "id": "3a62b1a6"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Part 1: Library Mode "
+      ],
+      "id": "0dc56f4f"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 1. Setup before using library mode"
+      ],
+      "id": "f389a897"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 1.1. Installation guide for python package\n",
+        "\n",
+        "> **Note**: Python version **3.11 or higher** is required.\n",
+        "\n",
+        "##### 📝 **Development Mode Note:**\n",
+        "\n",
+        "- Installing with `uv pip install -e \"..[all]\"` allows you to make live edits to the `nvidia_rag` source code and have those changes reflected without reinstalling the package.\n",
+        "- After making changes to the source code, you need to:\n",
+        "  - Restart the kernel of your notebook server\n",
+        "  - Re-execute the cells under `Setting up the dependencies` and `Import the packages` sections"
+      ],
+      "id": "7adbc9f2"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### Install uv (if not already installed)\n",
+        "\n",
+        "Run the cell below to check if `uv` is installed and install it if needed."
+      ],
+      "id": "d2bb524d"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import subprocess\n",
+        "import shutil\n",
+        "\n",
+        "# Check if uv is installed\n",
+        "if shutil.which(\"uv\"):\n",
+        "    result = subprocess.run([\"uv\", \"--version\"], capture_output=True, text=True)\n",
+        "    print(f\"✅ uv is already installed: {result.stdout.strip()}\")\n",
+        "else:\n",
+        "    print(\"⚠️ uv is not installed. Installing now...\")\n",
+        "    # Install uv using the official installer\n",
+        "    !curl -LsSf https://astral.sh/uv/install.sh | sh\n",
+        "    print(\"\\n✅ uv installed! Please restart your terminal/kernel and re-run this notebook.\")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "f7fa66fc"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### Install the NVIDIA RAG Package\n",
+        "\n",
+        "Choose one of the installation options below:\n",
+        "- **Option A**: Install from PyPI (recommended for most users)\n",
+        "- **Option B**: Install from source in development mode (for contributors)\n",
+        "- **Option C**: Build and install from source wheel"
+      ],
+      "id": "c6ce9248"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Option A: Install from PyPI (recommended)\n",
+        "# Uncomment the line below to install from PyPI\n",
+        "# !uv pip install nvidia-rag[all]\n",
+        "\n",
+        "# Option B: Install from source in development mode (for contributors)\n",
+        "# Note: \"..\" refers to the parent directory where pyproject.toml is located\n",
+        "!uv pip install -e \"..[all]\"\n",
+        "\n",
+        "# Option C: Build and install from source wheel\n",
+        "# Uncomment the lines below to build and install from source\n",
+        "# !cd .. && uv build\n",
+        "# !uv pip install ../dist/nvidia_rag-*-py3-none-any.whl[all]"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "e775b4ac"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 1.2. Verify the installation\n",
+        "The location of the package shown in the output of this command should be inside the virtual environment.\n",
+        "\n",
+        "Location: `<workspace_path>/rag/.venv/lib/python3.12/site-packages`"
+      ],
+      "id": "7cdd2bd9"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!uv pip show nvidia_rag | grep Location"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "08c40dab"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 2. Setting up the dependencies"
+      ],
+      "id": "ff09d666"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "After the environment for the python package is set up, launch all the dependent services and NIMs that the pipeline depends on.\n",
+        "\n",
+        "Fulfill the [prerequisites here](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/deploy-docker-self-hosted.md) to set up docker on your system."
+      ],
+      "id": "efdd89dc"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 2.1. Setup the default configurations"
+      ],
+      "id": "84bf4f5f"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!uv pip install python-dotenv\n",
+        "import os\n",
+        "from getpass import getpass\n",
+        "\n",
+        "from dotenv import load_dotenv"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "1b5162b4"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Provide your NGC_API_KEY after executing the cell below. You can obtain a key by following steps [here](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/api-key.md)."
+      ],
+      "id": "ec509cc9"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# del os.environ['NVIDIA_API_KEY']  ## delete key and reset if needed\n",
+        "if os.environ.get(\"NGC_API_KEY\", \"\").startswith(\"nvapi-\"):\n",
+        "    print(\"Valid NGC_API_KEY already in environment. Delete to reset\")\n",
+        "else:\n",
+        "    candidate_api_key = getpass(\"NVAPI Key (starts with nvapi-): \")\n",
+        "    assert candidate_api_key.startswith(\"nvapi-\"), (\n",
+        "        f\"{candidate_api_key[:5]}... is not a valid key\"\n",
+        "    )\n",
+        "    os.environ[\"NGC_API_KEY\"] = candidate_api_key"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "d60f81ff"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Login to nvcr.io which is needed for pulling the containers of dependencies"
+      ],
+      "id": "70dec262"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!echo \"${NGC_API_KEY}\" | docker login nvcr.io -u '$oauthtoken' --password-stdin"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "7fec18c6"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 2.2. Setup the Elasticsearch vector DB services\n",
+        "Elasticsearch is the default vector store.\n",
+        "See [change-vectordb.md](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/change-vectordb.md) to switch to Milvus if needed."
+      ],
+      "id": "593ac9b0"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "os.environ[\"VECTORSTORE_GPU_DEVICE_ID\"] = \"0\""
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "b5fa2f5d"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!docker compose -f ../deploy/compose/vectordb.yaml up -d"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "51c7b137"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 2.3. Setup the NIMs"
+      ],
+      "id": "3969aa2c"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### Option 1: Deploy on-prem models"
+      ],
+      "id": "99abdce4"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Move to Option 2 if you are interested in using cloud models.\n",
+        "\n",
+        "Ensure you meet [the hardware requirements](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/support-matrix.md). By default the NIMs are configured to use 2xH100."
+      ],
+      "id": "4bb2ea98"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Create the model cache directory\n",
+        "!mkdir -p ~/.cache/model-cache"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "816b14c7"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Set the MODEL_DIRECTORY environment variable in the Python kernel\n",
+        "import os\n",
+        "\n",
+        "os.environ[\"MODEL_DIRECTORY\"] = os.path.expanduser(\"~/.cache/model-cache\")\n",
+        "print(\"MODEL_DIRECTORY set to:\", os.environ[\"MODEL_DIRECTORY\"])"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "50299ae0"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Configure GPU IDs for the various microservices if needed\n",
+        "os.environ[\"EMBEDDING_MS_GPU_ID\"] = \"0\"\n",
+        "os.environ[\"RANKING_MS_GPU_ID\"] = \"0\"\n",
+        "os.environ[\"YOLOX_MS_GPU_ID\"] = \"0\"\n",
+        "os.environ[\"YOLOX_GRAPHICS_MS_GPU_ID\"] = \"0\"\n",
+        "os.environ[\"YOLOX_TABLE_MS_GPU_ID\"] = \"0\"\n",
+        "os.environ[\"OCR_MS_GPU_ID\"] = \"0\"\n",
+        "os.environ[\"LLM_MS_GPU_ID\"] = \"1\""
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "f577f8ff"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# ⚠️ Deploying NIMs - This may take a while as models download. If kernel times out, just rerun this cell.\n",
+        "!USERID=$(id -u) docker compose -f ../deploy/compose/nims.yaml up -d"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "1c621259"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Watch the status of running containers (run this cell repeatedly or in a terminal)\n",
+        "!docker ps"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "af5e0f6f"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Set deployment mode for on-prem NIMs\n",
+        "DEPLOYMENT_MODE = \"on_prem\""
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "2ba63d1d"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Ensure all the below are running and healthy before proceeding further\n",
+        "```output\n",
+        "NAMES                           STATUS\n",
+        "nemotron-ranking-ms        Up ... (healthy)\n",
+        "compose-page-elements-1         Up ...\n",
+        "compose-nemotron-ocr-1     Up ...\n",
+        "compose-graphic-elements-1      Up ...\n",
+        "compose-table-structure-1       Up ...\n",
+        "nemotron-vlm-embedding-ms  Up ... (healthy)\n",
+        "nim-llm-ms                      Up ... (healthy)\n",
+        "```"
+      ],
+      "id": "9fed48c0"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### Option 2: Using Nvidia Hosted models"
+      ],
+      "id": "dbac5b7a"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "DEPLOYMENT_MODE = \"cloud\"\n",
+        "\n",
+        "# Set deployment mode for NVIDIA hosted cloud APIs\n",
+        "os.environ[\"OCR_HTTP_ENDPOINT\"] = \"https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-ocr-v1\"\n",
+        "os.environ[\"OCR_INFER_PROTOCOL\"] = \"http\"\n",
+        "os.environ[\"YOLOX_HTTP_ENDPOINT\"] = (\n",
+        "    \"https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-page-elements-v3\"\n",
+        ")\n",
+        "os.environ[\"YOLOX_INFER_PROTOCOL\"] = \"http\"\n",
+        "os.environ[\"YOLOX_GRAPHIC_ELEMENTS_HTTP_ENDPOINT\"] = (\n",
+        "    \"https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-graphic-elements-v1\"\n",
+        ")\n",
+        "os.environ[\"YOLOX_GRAPHIC_ELEMENTS_INFER_PROTOCOL\"] = \"http\"\n",
+        "os.environ[\"YOLOX_TABLE_STRUCTURE_HTTP_ENDPOINT\"] = (\n",
+        "    \"https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-table-structure-v1\"\n",
+        ")\n",
+        "os.environ[\"YOLOX_TABLE_STRUCTURE_INFER_PROTOCOL\"] = \"http\""
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "2d529315"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 2.3.1. Configure embedding endpoints for NV-Ingest\n",
+        "\n",
+        "NV-Ingest reads `APP_EMBEDDINGS_*` at **container startup**. Set these before starting the runtime so ingestion and health checks use the VLM embedding NIM (`nemotron-vlm-embedding-ms`), not the legacy text-only `nemotron-embedding-ms` service."
+      ],
+      "id": "d7afa514"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Override stale embedding env (e.g. from variables.env or notebooks/.env_library).\n",
+        "load_dotenv(dotenv_path=\"../deploy/compose/.env\", override=False)\n",
+        "\n",
+        "deployment_mode = globals().get(\"DEPLOYMENT_MODE\", \"on_prem\")\n",
+        "if deployment_mode == \"cloud\":\n",
+        "    os.environ[\"APP_EMBEDDINGS_SERVERURL\"] = \"https://integrate.api.nvidia.com/v1\"\n",
+        "    os.environ[\"APP_EMBEDDINGS_MODELNAME\"] = \"nvidia/llama-nemotron-embed-vl-1b-v2\"\n",
+        "    print(\"✓ Embedding: NVIDIA API catalog\")\n",
+        "else:\n",
+        "    os.environ[\"APP_EMBEDDINGS_SERVERURL\"] = \"nemotron-vlm-embedding-ms:8000/v1\"\n",
+        "    os.environ[\"APP_EMBEDDINGS_MODELNAME\"] = \"nvidia/llama-nemotron-embed-vl-1b-v2\"\n",
+        "    print(\"✓ Embedding: on-prem VLM NIM (nemotron-vlm-embedding-ms)\")\n",
+        "\n",
+        "print(f\"  APP_EMBEDDINGS_SERVERURL={os.environ['APP_EMBEDDINGS_SERVERURL']}\")\n",
+        "print(f\"  APP_EMBEDDINGS_MODELNAME={os.environ['APP_EMBEDDINGS_MODELNAME']}\")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "2bca97f1"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 2.4. Setup the Nvidia Ingest runtime and redis service"
+      ],
+      "id": "d5b176dc"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# --force-recreate ensures NV-Ingest picks up APP_EMBEDDINGS_* set above\n",
+        "!docker compose -f ../deploy/compose/docker-compose-ingestor-server.yaml up nv-ingest-ms-runtime redis -d --force-recreate"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "be355c11"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 2.5. Load optional profiles if needed"
+      ],
+      "id": "cbc0ef32"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Load accuracy profile\n",
+        "# load_dotenv(dotenv_path='../deploy/compose/accuracy_profile.env', override=True)\n",
+        "\n",
+        "# OR load perf profile\n",
+        "# load_dotenv(dotenv_path='../deploy/compose/perf_profile.env', override=True)"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "4c1fca90"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 3. Import libraries and view defaults\n",
+        "\n",
+        "After setting up the python package and starting all dependent services, we can now import the libraries and view default configuration for summarization."
+      ],
+      "id": "12b33ced"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 3.1. Set logging level\n",
+        "\n",
+        "First let's set the required logging level. Set to INFO for displaying basic important logs. Set to DEBUG for full verbosity."
+      ],
+      "id": "0f067c70"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import logging\n",
+        "import os\n",
+        "\n",
+        "# Set the log level via environment variable before importing nvidia_rag\n",
+        "# This ensures the package respects our log level setting\n",
+        "LOGLEVEL = logging.WARNING  # Set to INFO, DEBUG, WARNING or ERROR\n",
+        "os.environ[\"LOGLEVEL\"] = logging.getLevelName(LOGLEVEL)\n",
+        "\n",
+        "# Configure logging\n",
+        "logging.basicConfig(level=LOGLEVEL, force=True)\n",
+        "\n",
+        "# Set log levels for specific loggers after package import\n",
+        "for name in logging.root.manager.loggerDict:\n",
+        "    if name == \"nvidia_rag\" or name.startswith(\"nvidia_rag.\"):\n",
+        "        logging.getLogger(name).setLevel(LOGLEVEL)\n",
+        "    if name == \"nv_ingest_client\" or name.startswith(\"nv_ingest_client.\"):\n",
+        "        logging.getLogger(name).setLevel(LOGLEVEL)"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "f15e1d4f"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 3.2. Import the packages and initialize configuration\n",
+        "You can import both or either one based on your requirements. `NvidiaRAG()` exposes APIs to interact with the uploaded documents or retrieve summaries and `NvidiaRAGIngestor()` exposes APIs for document upload, management and summary generation."
+      ],
+      "id": "5be07e0e"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "from nvidia_rag import NvidiaRAG, NvidiaRAGIngestor\n",
+        "from nvidia_rag.utils.configuration import NvidiaRAGConfig\n",
+        "from nvidia_rag.rag_server.response_generator import retrieve_summary\n",
+        "\n",
+        "# Get the configuration object\n",
+        "config = NvidiaRAGConfig.from_yaml(\"config.yaml\")\n",
+        "\n",
+        "# Update config for cloud deployment if using Option 2\n",
+        "if DEPLOYMENT_MODE == \"cloud\":\n",
+        "    config.embeddings.server_url = \"https://integrate.api.nvidia.com/v1\"\n",
+        "    config.embeddings.model_name = \"nvidia/llama-nemotron-embed-vl-1b-v2\"\n",
+        "    config.llm.server_url = \"\"  # Empty uses NVIDIA API catalog\n",
+        "    config.ranking.server_url = \"https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-nemotron-rerank-1b-v2/reranking/v1\"\n",
+        "    config.summarizer.server_url = \"\"  # Empty uses NVIDIA API catalog\n",
+        "else:\n",
+        "    config.embeddings.server_url = \"nemotron-vlm-embedding-ms:8000/v1\"\n",
+        "    config.embeddings.model_name = \"nvidia/llama-nemotron-embed-vl-1b-v2\"\n",
+        "    config.ranking.server_url = \"nemotron-ranking-ms:8000\"\n",
+        "    config.summarizer.server_url = \"nim-llm:8000\"\n",
+        "    config.llm.server_url = \"nim-llm:8000\"\n",
+        "\n",
+        "# Initialize NvidiaRAG and NvidiaRAGIngestor with config\n",
+        "# For summarization customization, pass prompts to NvidiaRAGIngestor:\n",
+        "#   - A path to a YAML/JSON file: prompts=\"custom_prompts.yaml\"\n",
+        "#   - A dictionary: prompts={\"document_summary_prompt\": {...}}\n",
+        "rag = NvidiaRAG(config=config)\n",
+        "ingestor = NvidiaRAGIngestor(config=config)"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "47db7b83"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 3.3. View Default Summarizer LLM Settings\n",
+        "\n",
+        "Let's see what LLM model and parameters are used by default for summarization."
+      ],
+      "id": "8fceebee"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "print(\"=\" * 70)\n",
+        "print(\"DEFAULT SUMMARIZER LLM CONFIGURATION\")\n",
+        "print(\"=\" * 70)\n",
+        "print(f\"Model:             {config.summarizer.model_name}\")\n",
+        "print(f\"Server URL:        {config.summarizer.server_url}\")\n",
+        "print(f\"Temperature:       {config.summarizer.temperature}\")\n",
+        "print(f\"Top P:             {config.summarizer.top_p}\")\n",
+        "print(f\"Max Parallel:      {config.summarizer.max_parallelization}\")\n",
+        "print(f\"Max Chunk Length:  {config.summarizer.max_chunk_length}\")\n",
+        "print(f\"Chunk Overlap:     {config.summarizer.chunk_overlap}\")\n",
+        "print(\"=\" * 70)"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "5b53e5bf"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 3.4. View Default Summarization Prompts\n",
+        "\n",
+        "The prompt template controls how the LLM generates summaries. Let's see the default prompts."
+      ],
+      "id": "d50f697c"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import json\n",
+        "\n",
+        "# Access prompts from the NvidiaRAGIngestor instance (initialized with defaults)\n",
+        "# Summarization is handled by NvidiaRAGIngestor, so view prompts from ingestor\n",
+        "print(\"=\" * 70)\n",
+        "print(\"DEFAULT DOCUMENT SUMMARY PROMPT\")\n",
+        "print(\"=\" * 70)\n",
+        "print(json.dumps(ingestor.prompts[\"document_summary_prompt\"], indent=2))\n",
+        "print(\"=\" * 70)\n",
+        "\n",
+        "print(\"\\n\" + \"=\" * 70)\n",
+        "print(\"DEFAULT ITERATIVE SUMMARY PROMPT\")\n",
+        "print(\"=\" * 70)\n",
+        "print(json.dumps(ingestor.prompts[\"iterative_summary_prompt\"], indent=2))\n",
+        "print(\"=\" * 70)"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "b6cbb7d0"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "This will display the default prompts used for:\n",
+        "- **document_summary_prompt**: Summarizing a single document or chunk (used for full multimodal extraction)\n",
+        "- **shallow_summary_prompt**: Summarizing with fast text-only extraction (used when `shallow_summary: true`)\n",
+        "- **iterative_summary_prompt**: Combining multiple summaries for large documents\n",
+        "\n",
+        "The system automatically selects the appropriate prompt based on extraction mode and document size."
+      ],
+      "id": "fce20869"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---"
+      ],
+      "id": "3eefeb2b"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Part 2: Library Mode - Change Configuration\n",
+        "Now let's see how to modify these settings programmatically in library mode.\n",
+        "\n",
+        "### 1. Change LLM Model and Parameters\n",
+        "\n",
+        "You can change the model and sampling parameters dynamically."
+      ],
+      "id": "27ec763e"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Change to a different model (e.g., Llama 3.1 70B)\n",
+        "config.summarizer.model_name = \"meta/llama-3.1-70b-instruct\"\n",
+        "config.summarizer.server_url = \"\"\n",
+        "\n",
+        "# Lower temperature for more deterministic, focused summaries\n",
+        "config.summarizer.temperature = 0.2\n",
+        "\n",
+        "# Adjust top_p for nucleus sampling\n",
+        "config.summarizer.top_p = 0.7\n",
+        "\n",
+        "# Configure global rate limiting (max parallel summary tasks across all workers)\n",
+        "# Prevents overwhelming GPU/API with too many concurrent LLM calls\n",
+        "config.summarizer.max_parallelization = 10  # Default: 20\n",
+        "\n",
+        "print(\"✅ Updated Summarizer Configuration:\")\n",
+        "print(f\"   Model:       {config.summarizer.model_name}\")\n",
+        "print(f\"   Server URL:  {config.summarizer.server_url}\")\n",
+        "print(f\"   Temperature: {config.summarizer.temperature}\")\n",
+        "print(f\"   Top P:       {config.summarizer.top_p}\")\n",
+        "print(f\"   Max Parallel:{config.summarizer.max_parallelization}\")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "6cc84ba0"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 2. Customize Summarization Prompts\n",
+        "\n",
+        "Customize the prompt to change the style and focus of summaries by passing prompts during `NvidiaRAGIngestor` initialization.\n",
+        "\n",
+        "This is the **recommended approach** for library mode - pass prompts directly to the constructor for clean, instance-specific configuration.\n",
+        "\n",
+        "> **Note**: Summarization is handled by `NvidiaRAGIngestor`, so prompts for summarization should be passed to `NvidiaRAGIngestor`, not `NvidiaRAG`."
+      ],
+      "id": "15dabf4c"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Define custom prompts as a dictionary\n",
+        "custom_prompts = {\n",
+        "    \"document_summary_prompt\": {\n",
+        "        \"system\": \"/no_think\",\n",
+        "        \"human\": \"\"\"You are a documentation specialist.\n",
+        "\n",
+        "Create a clear, summary that:\n",
+        "1. Identifies the main topic and purpose\n",
+        "2. Lists key concepts or features\n",
+        "3. Highlights important procedures or steps  \n",
+        "4. Notes any warnings or critical information\n",
+        "\n",
+        "Keep the summary concise.\n",
+        "\n",
+        "Text to summarize:\n",
+        "{document_text}\n",
+        "\n",
+        "Summary:\"\"\"\n",
+        "    }\n",
+        "}\n",
+        "\n",
+        "# Create NvidiaRAGIngestor instance with custom prompts (Recommended Approach)\n",
+        "# The prompts are merged with defaults - only specified keys are overridden\n",
+        "ingestor_custom = NvidiaRAGIngestor(config=config, prompts=custom_prompts)\n",
+        "\n",
+        "print(\"✅ NvidiaRAGIngestor initialized with custom prompts\")\n",
+        "print(\"\\nCustom prompt preview (first 200 chars):\")\n",
+        "print(ingestor_custom.prompts[\"document_summary_prompt\"][\"human\"][:200] + \"...\")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "05167610"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### Alternative: Using a YAML File\n",
+        "\n",
+        "You can also pass a path to a YAML file containing your custom prompts:\n",
+        "\n",
+        "```python\n",
+        "# Using a YAML file path\n",
+        "ingestor_from_yaml = NvidiaRAGIngestor(config=config, prompts=\"custom_prompts.yaml\")\n",
+        "```\n",
+        "\n",
+        "The YAML file format should match the structure shown in the Docker Mode section below.\n"
+      ],
+      "id": "a90fa503"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 3. Configure Summary Options"
+      ],
+      "id": "c56d2be2"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "summary_options = {\n",
+        "    # Page filtering: [[1, 10]] (ranges), [[-5, -1]] (last N pages), \"even\"/\"odd\"\n",
+        "    \"page_filter\": [[1, 10]],  # Only pages 1-10\n",
+        "    \n",
+        "    # Fast mode: Text-only extraction first, summary in seconds\n",
+        "    \"shallow_summary\": True,  # Default: False\n",
+        "    \n",
+        "    # Strategy: None (iterative/best), \"single\" (fastest/truncates), \"hierarchical\" (parallel/faster than iterative)\n",
+        "    \"summarization_strategy\": \"hierarchical\"  # Default: None\n",
+        "}\n",
+        "\n",
+        "\n",
+        "print(f\"  • Page Filter: {summary_options['page_filter']}\")\n",
+        "print(f\"  • Shallow Summary: {summary_options['shallow_summary']}\")\n",
+        "print(f\"  • Strategy: {summary_options['summarization_strategy']}\")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "0fce6903"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 4. Complete Workflow Example\n",
+        "\n",
+        "This section demonstrates the end-to-end workflow: create collection → upload documents → check status → retrieve summary → cleanup."
+      ],
+      "id": "ff3be036"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 4.1. Create Collection"
+      ],
+      "id": "c0c75f90"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Create collection\n",
+        "collection_name = \"test_summary\"\n",
+        "response = ingestor.create_collection(\n",
+        "    collection_name=collection_name,\n",
+        "    vdb_endpoint=\"http://localhost:9200\"\n",
+        ")\n",
+        "print(f\"✅ Collection response: {response}\")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "606e67a3"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 4.2. Upload Documents"
+      ],
+      "id": "1ac5baec"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Upload documents with summary options\n",
+        "result = await ingestor.upload_documents(\n",
+        "    filepaths=[\"../data/multimodal/functional_validation.pdf\"],\n",
+        "    collection_name=collection_name,\n",
+        "    generate_summary=True,\n",
+        "    summary_options=summary_options,  # From previous cell\n",
+        "    blocking=False  # Don't wait, check status instead\n",
+        ")\n",
+        "print(f\"✅ Upload started: {result}\")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "cbf50562"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 4.3. Check Status and Get Summary"
+      ],
+      "id": "02afe705"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Check summary status\n",
+        "status = await retrieve_summary(\n",
+        "    collection_name=collection_name,\n",
+        "    file_name=\"functional_validation.pdf\",\n",
+        "    wait=False  # Just check, don't wait\n",
+        ")\n",
+        "print(f\"\\n📊 Status: {status.get('status')}\")\n",
+        "if status.get('status') == 'IN_PROGRESS':\n",
+        "    progress = status.get('progress', {})\n",
+        "    print(f\"   Progress: Chunk {progress.get('current')}/{progress.get('total')}\")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "94cebc0e"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Get summary (blocking - waits until complete)\n",
+        "summary_result = await retrieve_summary(\n",
+        "    collection_name=collection_name,\n",
+        "    file_name=\"functional_validation.pdf\",\n",
+        "    wait=True,\n",
+        "    timeout=300\n",
+        ")\n",
+        "\n",
+        "if summary_result.get('status') == 'SUCCESS':\n",
+        "    print(f\"\\n✅ Summary:\\n{summary_result.get('summary')}\")\n",
+        "else:\n",
+        "    print(f\"\\n❌ {summary_result.get('status')}: {summary_result.get('message')}\")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "301f8dfc"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 4.4. Delete Collection"
+      ],
+      "id": "de34199d"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Delete the test collection\n",
+        "response = ingestor.delete_collections(\n",
+        "    collection_names=[collection_name],\n",
+        "    vdb_endpoint=\"http://localhost:9200\"\n",
+        ")\n",
+        "print(f\"✅ Delete response: {response}\")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "71fe09fe"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---"
+      ],
+      "id": "caea11bf"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Part 3: Docker Mode - Change Configuration via Environment Variables\n",
+        "\n",
+        "When running in Docker mode, you configure the ingestor-server and rag-server containers via environment variables and REST APIs.\n",
+        "\n",
+        "**Prerequisites:**\n",
+        "- If you're starting fresh with Part 3, first complete section **\"2. Setting up the dependencies\"** from Part 1 above to start all required services (Elasticsearch, NV-Ingest, Redis)\n",
+        "- If you completed Part 1, these services are already running"
+      ],
+      "id": "a55c3b72"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 1. Configure via Environment Variables\n",
+        "\n",
+        "Configure the ingestor server by setting environment variables before startup. Adjust these values according to your requirements:"
+      ],
+      "id": "f9e4a17e"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Set environment variables in Python based on mode\n",
+        "if DEPLOYMENT_MODE == \"cloud\":\n",
+        "    os.environ[\"SUMMARY_LLM_SERVERURL\"] = \"\"\n",
+        "    os.environ[\"LLM_SERVER_URL\"] = \"\"\n",
+        "    os.environ[\"APP_EMBEDDINGS_SERVERURL\"] = \"https://integrate.api.nvidia.com/v1\"\n",
+        "    os.environ[\"APP_EMBEDDINGS_MODELNAME\"] = \"nvidia/llama-nemotron-embed-vl-1b-v2\"\n",
+        "    print(\"✓ Configured for NVIDIA cloud APIs\")\n",
+        "else:\n",
+        "    os.environ[\"SUMMARY_LLM_SERVERURL\"] = \"nim-llm:8000\"\n",
+        "    os.environ[\"LLM_SERVER_URL\"] = \"nim-llm:8000\"\n",
+        "    os.environ[\"APP_EMBEDDINGS_SERVERURL\"] = \"nemotron-vlm-embedding-ms:8000/v1\"\n",
+        "    os.environ[\"APP_EMBEDDINGS_MODELNAME\"] = \"nvidia/llama-nemotron-embed-vl-1b-v2\"\n",
+        "    print(\"✓ Configured for on-prem NIMs\")\n",
+        "\n",
+        "os.environ[\"LOGLEVEL\"] = \"INFO\"\n",
+        "\n",
+        "print(\"Environment variables set for deployment mode\")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "4eae9bca"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "%%bash\n",
+        "# Custom Summarization configuration\n",
+        "export SUMMARY_LLM=\"meta/llama-3.1-70b-instruct\"\n",
+        "export SUMMARY_LLM_TEMPERATURE=0.2\n",
+        "export SUMMARY_LLM_TOP_P=0.7\n",
+        "export SUMMARY_LLM_MAX_CHUNK_LENGTH=9000\n",
+        "export SUMMARY_CHUNK_OVERLAP=400\n",
+        "export SUMMARY_MAX_PARALLELIZATION=20\n",
+        "\n",
+        "# Embedding endpoint (inherited from previous cell; fallback to VLM NIM defaults)\n",
+        "export APP_EMBEDDINGS_SERVERURL=\"${APP_EMBEDDINGS_SERVERURL:-nemotron-vlm-embedding-ms:8000/v1}\"\n",
+        "export APP_EMBEDDINGS_MODELNAME=\"${APP_EMBEDDINGS_MODELNAME:-nvidia/llama-nemotron-embed-vl-1b-v2}\"\n",
+        "\n",
+        "# start container (--force-recreate picks up embedding env for health checks)\n",
+        "docker compose -f ../deploy/compose/docker-compose-ingestor-server.yaml up -d --force-recreate ingestor-server\n",
+        "docker compose -f ../deploy/compose/docker-compose-rag-server.yaml up -d --force-recreate rag-server\n",
+        "\n",
+        "echo \"Configure summarization parameters and start container\""
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "920a5ad0"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 2. Custom Prompts via YAML File\n",
+        "\n",
+        "To change prompts in Docker mode, create a custom `prompt.yaml` file and set the `PROMPT_CONFIG_FILE` environment variable.\n",
+        "\n",
+        "#### 2.1. Create Custom Prompt File\n",
+        "\n",
+        "Create your custom prompt file (e.g., `/home/user/my_custom_prompt.yaml`):"
+      ],
+      "id": "7307d496"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Define custom prompt configuration\n",
+        "custom_prompt_content = \"\"\"document_summary_prompt:\n",
+        "  system: |\n",
+        "    /no_think\n",
+        "  \n",
+        "  human: |\n",
+        "    You are a technical documentation specialist.\n",
+        "    \n",
+        "    Create a clear, technical summary that:\n",
+        "    1. Identifies the main topic and purpose\n",
+        "    2. Lists key technical concepts or features\n",
+        "    3. Highlights important procedures or steps\n",
+        "    4. Notes any warnings or critical information\n",
+        "    \n",
+        "    Keep the summary concise and technical.\n",
+        "    \n",
+        "    Text to summarize:\n",
+        "    {document_text}\n",
+        "    \n",
+        "    Technical Summary:\n",
+        "\n",
+        "iterative_summary_prompt:\n",
+        "  system: |\n",
+        "    /no_think\n",
+        "  \n",
+        "  human: |\n",
+        "    You are a technical documentation specialist combining summaries.\n",
+        "    \n",
+        "    Previous Summary:\n",
+        "    {previous_summary}\n",
+        "    \n",
+        "    New chunk:\n",
+        "    {new_chunk}\n",
+        "    \n",
+        "    Create an updated technical summary combining both.\n",
+        "\"\"\"\n",
+        "\n",
+        "# Write the custom prompt file\n",
+        "import os\n",
+        "custom_prompt_path = os.path.expanduser(\"~/my_custom_prompt.yaml\")\n",
+        "with open(custom_prompt_path, \"w\") as f:\n",
+        "    f.write(custom_prompt_content)\n",
+        "\n",
+        "print(f\"Custom prompt file created at: {custom_prompt_path}\")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "73da6ef7"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 2.2. Set Environment Variable and Restart\n",
+        "\n",
+        "Set the environment variable and restart the container:"
+      ],
+      "id": "beffd23e"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "%%bash\n",
+        "# Set path to custom prompt file\n",
+        "export PROMPT_CONFIG_FILE=~/my_custom_prompt.yaml\n",
+        "\n",
+        "# Restart the container (no rebuild needed)\n",
+        "# Note: This inherits NGC_API_KEY from the parent shell if it was set via os.environ earlier\n",
+        "docker compose -f ../deploy/compose/docker-compose-ingestor-server.yaml up -d ingestor-server\n",
+        "\n",
+        "echo \"Ingestor server restarted with custom prompts from: $PROMPT_CONFIG_FILE\""
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "a33369d9"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "**Key Points:**\n",
+        "- The service will merge your custom prompts with the defaults\n",
+        "- Only the prompts you specify will be overridden - all others remain unchanged\n",
+        "- No container rebuild is required, just restart with the new environment variable!\n",
+        "\n",
+        "For more details, see the prompt customization documentation."
+      ],
+      "id": "b25fe3db"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 3. Using Ingestor Server REST APIs\n",
+        "\n",
+        "When running in Docker mode, you interact with the ingestor server via REST APIs. Here's the complete workflow for document summarization using APIs.\n",
+        "\n",
+        "#### Prerequisites\n",
+        "- Ensure ingestor-server and rag-server containers are running\n",
+        "- Replace `localhost` with actual IP if hosted on another system"
+      ],
+      "id": "cb475d78"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Install Dependencies\n",
+        "!uv pip install aiohttp"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "069af221"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import json\n",
+        "import os\n",
+        "import aiohttp\n",
+        "\n",
+        "# Setup base configuration\n",
+        "INGESTOR_BASE_URL = \"http://localhost:8082\"\n",
+        "RAG_BASE_URL = \"http://localhost:8081\"\n",
+        "\n",
+        "\n",
+        "async def print_response(response):\n",
+        "    \"\"\"Helper to print API response.\"\"\"\n",
+        "    try:\n",
+        "        response_json = await response.json()\n",
+        "        print(json.dumps(response_json, indent=2))\n",
+        "    except aiohttp.ClientResponseError:\n",
+        "        print(await response.text())"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "54c02b58"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 3.1. Health Check"
+      ],
+      "id": "ece3f9ed"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "async def check_health():\n",
+        "    \"\"\"Check ingestor server health.\"\"\"\n",
+        "    url = f\"{INGESTOR_BASE_URL}/v1/health\"\n",
+        "    params = {\"check_dependencies\": \"True\"}\n",
+        "    async with aiohttp.ClientSession() as session:\n",
+        "        async with session.get(url, params=params) as response:\n",
+        "            await print_response(response)\n",
+        "\n",
+        "await check_health()"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "e2b9bd62"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 3.2. Create Collection"
+      ],
+      "id": "e56e52f7"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "async def create_collection(collection_name: str):\n",
+        "    \"\"\"Create a collection for document storage.\"\"\"\n",
+        "    data = {\n",
+        "        \"collection_name\": collection_name,\n",
+        "        \"metadata_schema\": []\n",
+        "    }\n",
+        "    \n",
+        "    headers = {\"Content-Type\": \"application/json\"}\n",
+        "    \n",
+        "    async with aiohttp.ClientSession() as session:\n",
+        "        try:\n",
+        "            async with session.post(\n",
+        "                f\"{INGESTOR_BASE_URL}/v1/collection\", \n",
+        "                json=data, \n",
+        "                headers=headers\n",
+        "            ) as response:\n",
+        "                await print_response(response)\n",
+        "        except aiohttp.ClientError as e:\n",
+        "            print(f\"Error: {e}\")\n",
+        "\n",
+        "# Create collection\n",
+        "await create_collection(collection_name=\"test_summary_api\")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "2908a9b7"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 3.3. Upload Documents with Summary Options"
+      ],
+      "id": "9492a594"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "async def upload_with_summary(collection_name: str, filepaths: list):\n",
+        "    \"\"\"Upload documents and generate summaries.\"\"\"\n",
+        "    \n",
+        "    # Configure summary options\n",
+        "    data = {\n",
+        "        \"collection_name\": collection_name,\n",
+        "        \"blocking\": False,  # Non-blocking upload\n",
+        "        \"split_options\": {\"chunk_size\": 512, \"chunk_overlap\": 150},\n",
+        "        \"generate_summary\": True,  # Enable summary generation\n",
+        "        \"summary_options\": {\n",
+        "            \"page_filter\": [[1, 10], [-5, -1]],  # First 10 and last 5 pages\n",
+        "            \"shallow_summary\": True,  # Fast text-only extraction\n",
+        "            \"summarization_strategy\": \"single\"  # fastest strategy other available: \"hierarchical\", None(iterative)\n",
+        "        }\n",
+        "    }\n",
+        "    \n",
+        "    form_data = aiohttp.FormData()\n",
+        "    for file_path in filepaths:\n",
+        "        form_data.add_field(\n",
+        "            \"documents\",\n",
+        "            open(file_path, \"rb\"),\n",
+        "            filename=os.path.basename(file_path),\n",
+        "            content_type=\"application/pdf\",\n",
+        "        )\n",
+        "    \n",
+        "    form_data.add_field(\"data\", json.dumps(data), content_type=\"application/json\")\n",
+        "    \n",
+        "    async with aiohttp.ClientSession() as session:\n",
+        "        try:\n",
+        "            async with session.post(\n",
+        "                f\"{INGESTOR_BASE_URL}/v1/documents\", \n",
+        "                data=form_data\n",
+        "            ) as response:\n",
+        "                await print_response(response)\n",
+        "                response_json = await response.json()\n",
+        "                return response_json.get(\"task_id\")\n",
+        "        except aiohttp.ClientError as e:\n",
+        "            print(f\"Error: {e}\")\n",
+        "            return None\n",
+        "\n",
+        "# Upload documents\n",
+        "task_id = await upload_with_summary(\n",
+        "    collection_name=\"test_summary_api\",\n",
+        "    filepaths=[\"../data/multimodal/functional_validation.pdf\"]\n",
+        ")\n",
+        "print(f\"\\n✅ Upload task_id: {task_id}\")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "8bf7cada"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 3.4. Check Upload Status (Ingestor Server)"
+      ],
+      "id": "1d4c4704"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "async def check_upload_status(task_id: str):\n",
+        "    \"\"\"Check ingestion task status.\"\"\"\n",
+        "    params = {\"task_id\": task_id}\n",
+        "    headers = {\"Content-Type\": \"application/json\"}\n",
+        "    \n",
+        "    async with aiohttp.ClientSession() as session:\n",
+        "        try:\n",
+        "            async with session.get(\n",
+        "                f\"{INGESTOR_BASE_URL}/v1/status\", \n",
+        "                params=params, \n",
+        "                headers=headers\n",
+        "            ) as response:\n",
+        "                await print_response(response)\n",
+        "        except aiohttp.ClientError as e:\n",
+        "            print(f\"Error: {e}\")\n",
+        "\n",
+        "# Check status\n",
+        "if task_id:\n",
+        "    await check_upload_status(task_id=task_id)\n",
+        "else:\n",
+        "    print(\"No task_id available\")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "d1d17b62"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 3.5. Check Summary Status (RAG Server)"
+      ],
+      "id": "9986e2f9"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "async def check_summary_status(collection_name: str, file_name: str):\n",
+        "    \"\"\"Check summary generation status via RAG server.\"\"\"\n",
+        "    params = {\n",
+        "        \"collection_name\": collection_name,\n",
+        "        \"file_name\": file_name,\n",
+        "        \"blocking\": \"false\"  # Just check status, don't wait\n",
+        "    }\n",
+        "    \n",
+        "    url = f\"{RAG_BASE_URL}/v1/summary\"\n",
+        "    \n",
+        "    async with aiohttp.ClientSession() as session:\n",
+        "        try:\n",
+        "            async with session.get(url, params=params) as response:\n",
+        "                await print_response(response)\n",
+        "        except aiohttp.ClientError as e:\n",
+        "            print(f\"Error: {e}\")\n",
+        "\n",
+        "# Check summary status\n",
+        "await check_summary_status(\n",
+        "    collection_name=\"test_summary_api\",\n",
+        "    file_name=\"functional_validation.pdf\"\n",
+        ")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "1b773bfa"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### 3.6. Delete Collection"
+      ],
+      "id": "bcb0e82b"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "async def delete_collections(collection_names: list[str]):\n",
+        "    \"\"\"Delete collections from the vector store.\"\"\"\n",
+        "    url = f\"{INGESTOR_BASE_URL}/v1/collections\"\n",
+        "    \n",
+        "    async with aiohttp.ClientSession() as session:\n",
+        "        try:\n",
+        "            async with session.delete(url, json=collection_names) as response:\n",
+        "                await print_response(response)\n",
+        "        except aiohttp.ClientError as e:\n",
+        "            print(f\"Error: {e}\")\n",
+        "\n",
+        "# Delete the test collection\n",
+        "await delete_collections(collection_names=[\"test_summary_api\"])"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "fa7edca4"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---"
+      ],
+      "id": "5e120e1c"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Summary of Available Configuration Options\n",
+        "\n",
+        "### Summarizer Configuration Fields\n",
+        "\n",
+        "| Field | Environment Variable | Default Value | Description |\n",
+        "|-------|---------------------|---------------|-------------|\n",
+        "| `model_name` | `SUMMARY_LLM` | `nvidia/nemotron-3-super-120b-a12b` | The LLM model used for summarization |\n",
+        "| `server_url` | `SUMMARY_LLM_SERVERURL` | (empty) | Server URL for custom model hosting |\n",
+        "| `temperature` | `SUMMARY_LLM_TEMPERATURE` | `0.0` | Controls randomness (0.0-1.0) |\n",
+        "| `top_p` | `SUMMARY_LLM_TOP_P` | `1.0` | Nucleus sampling parameter (0.0-1.0) |\n",
+        "| `max_chunk_length` | `SUMMARY_LLM_MAX_CHUNK_LENGTH` | `9000` | Maximum chunk size in tokens |\n",
+        "| `chunk_overlap` | `SUMMARY_CHUNK_OVERLAP` | `400` | Overlap between chunks in tokens |\n",
+        "\n",
+        "### Prompt Template Variables\n",
+        "\n",
+        "- **document_summary_prompt**: Use `{document_text}` variable\n",
+        "- **iterative_summary_prompt**: Use `{previous_summary}` and `{new_chunk}` variable\n",
+        "\n",
+        "**Note:** Changes made in library mode take effect immediately without restarting any services. Changes in Docker mode require a container restart but no rebuild."
+      ],
+      "id": "baab41ef"
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/variables.env
+++ b/variables.env
@@ -14,7 +14,7 @@ DATASET_ROOT=ingest
 
 # ==== Endpoints for using on-prem NIMs ====
 APP_LLM_SERVERURL=nim-llm:8000
-APP_EMBEDDINGS_SERVERURL=nemotron-embedding-ms:8000/v1
+APP_EMBEDDINGS_SERVERURL=nemotron-vlm-embedding-ms:8000/v1
 APP_RANKING_SERVERURL=nemotron-ranking-ms:8000
 OCR_GRPC_ENDPOINT=nemotron-ocr:8001
 OCR_HTTP_ENDPOINT=http://nemotron-ocr:8000/v1/infer


### PR DESCRIPTION
## Summary

This PR fixes two v2.6.0 RC1 QA notebook blockers. Each top commit maps to one NVBugs issue:

| Commit | NVBug | Notebook |
|--------|-------|----------|
| `c2abbe3` | [6173763](https://nvbugs.nvidia.com/bug/6173763) | `langchain_nvidia_retriever.ipynb` |
| `ff7dc3d` | [6180461](https://nvbugs.nvidia.com/bug/6180461) | `summarization.ipynb` |

### NVBug 6173763 — LangChain retriever notebook

**Issue:** `[RAG BP][v2.6.0][RC1] Getting error in langchain_nvidia_retriever.ipynb notebook` — failures occurred even when Elasticsearch was healthy and ingestion/retrieval worked in `ingestion_api_usage.ipynb` and `retriever_api_usage.ipynb`.

**Fix (`c2abbe3`):**
- Repair notebook structure and execution flow for `NVIDIARAGRetriever`.
- Point retrieval at the **RAG server** (`:8081` `/v1/search`) using the collection from `ingestion_api_usage.ipynb`.
- Omit `vdb_endpoint` by default so the RAG server uses its configured vector store (avoids mismatched Elasticsearch URL overrides).
- Add examples for custom search parameters, async invoke, and error handling.

### NVBug 6180461 — Summarization notebook

**Issue:** `[RAG BP][v2.6.0][RC1] Observing issues in summarization.ipynb notebook` — health check targeted the legacy text-only embedding NIM (`nemotron-embedding-ms`), and NV-Ingest failed with `Failed to resolve 'nemotron-embedding-ms'`.

**Fix (`ff7dc3d`):**
- Add section **2.3.1** to set `APP_EMBEDDINGS_SERVERURL` / `APP_EMBEDDINGS_MODELNAME` to the **VLM** NIM (`nemotron-vlm-embedding-ms`) **before** starting NV-Ingest.
- Use `--force-recreate` on NV-Ingest / ingestor-server / rag-server so containers pick up embedding env vars.
- Align library-mode and Docker-mode config with `nvidia/llama-nemotron-embed-vl-1b-v2`.
- Update defaults in `notebooks/.env_library` and `variables.env` away from legacy `nemotron-embedding-ms`.