### PR TITLE
Split captioning VLM (nano-12b) from generation VLM (omni)

### DIFF
--- a/deploy/compose/docker-compose-ingestor-server.yaml
+++ b/deploy/compose/docker-compose-ingestor-server.yaml
@@ -110,9 +110,9 @@ services:
       APP_NVINGEST_SEGMENTAUDIO: ${APP_NVINGEST_SEGMENTAUDIO:-False} # Enable audio segmentation for NV Ingest
 
       ##===NV-Ingest Caption Model configurations====
-      APP_NVINGEST_CAPTIONMODELNAME: ${APP_NVINGEST_CAPTIONMODELNAME:-"nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"}
+      APP_NVINGEST_CAPTIONMODELNAME: ${APP_NVINGEST_CAPTIONMODELNAME:-"nvidia/nemotron-nano-12b-v2-vl"}
       # Incase of nvidia-hosted caption model, use the endpoint url as - https://integrate.api.nvidia.com/v1
-      APP_NVINGEST_CAPTIONENDPOINTURL: ${APP_NVINGEST_CAPTIONENDPOINTURL:-"http://vlm-ms:8000/v1/chat/completions"}
+      APP_NVINGEST_CAPTIONENDPOINTURL: ${APP_NVINGEST_CAPTIONENDPOINTURL:-"http://vlm-captioning-ms:8000/v1/chat/completions"}
 
       ##===NeMo Retriever invoke URLs (HTTP, local NIMs)====
       # Align with YOLOX_*_HTTP_ENDPOINT / OCR_HTTP_ENDPOINT on nv-ingest-ms-runtime (nims.yaml service names).
@@ -261,8 +261,8 @@ services:
       - YOLOX_TABLE_STRUCTURE_HTTP_ENDPOINT=${YOLOX_TABLE_STRUCTURE_HTTP_ENDPOINT:-http://table-structure:8000/v1/infer}
       - YOLOX_TABLE_STRUCTURE_INFER_PROTOCOL=${YOLOX_TABLE_STRUCTURE_INFER_PROTOCOL:-grpc}
       # Incase of nvidia-hosted caption model, use the endpoint url as - https://integrate.api.nvidia.com/v1/chat/completions
-      - VLM_CAPTION_ENDPOINT=${VLM_CAPTION_ENDPOINT:-http://vlm-ms:8000/v1/chat/completions}
-      - VLM_CAPTION_MODEL_NAME=${VLM_CAPTION_MODEL_NAME:-nvidia/nemotron-3-nano-omni-30b-a3b-reasoning}
+      - VLM_CAPTION_ENDPOINT=${VLM_CAPTION_ENDPOINT:-http://vlm-captioning-ms:8000/v1/chat/completions}
+      - VLM_CAPTION_MODEL_NAME=${VLM_CAPTION_MODEL_NAME:-nvidia/nemotron-nano-12b-v2-vl}
       - MODEL_PREDOWNLOAD_PATH=${MODEL_PREDOWNLOAD_PATH:-/workspace/models/}
       - COMPONENTS_TO_READY_CHECK=ALL
     healthcheck:

--- a/deploy/compose/nims.yaml
+++ b/deploy/compose/nims.yaml
@@ -329,6 +329,7 @@ services:
               capabilities: [gpu]
     profiles: ["audio"]
 
+  # Nemotron Omni — used for generation.
   vlm-ms:
     container_name: nemotron-3-nano-omni-30b-a3b-reasoning
     image: nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:1.7.0-variant
@@ -359,6 +360,37 @@ services:
               device_ids: ['${VLM_MS_GPU_ID:-5}']
               capabilities: [gpu]
     profiles: ["vlm-only", "vlm-generation", "vlm-rag"]
+
+  # Nemotron Nano 12B — used for image captioning.
+  vlm-captioning-ms:
+    container_name: nemotron-nano-12b-v2-vl
+    image: nvcr.io/nim/nvidia/nemotron-nano-12b-v2-vl:${VLM_CAPTIONING_TAG:-1.6.0}
+    volumes:
+    - ${MODEL_DIRECTORY:-./}:/opt/nim/.cache
+    ports:
+    - "1978:8000"
+    expose:
+    - "8000"
+    environment:
+      NGC_API_KEY: ${NGC_API_KEY}
+      NIM_HTTP_API_PORT: 8000
+      NIM_TRITON_LOG_VERBOSE: 1
+      CUDA_VISIBLE_DEVICES: 0
+    user: "0"
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import requests; requests.get('http://localhost:8000/v1/health/ready')"]
+      interval: 10s
+      timeout: 20s
+      retries: 100
+    shm_size: 32GB
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ['${VLM_CAPTIONING_MS_GPU_ID:-6}']
+              capabilities: [gpu]
+    profiles: ["ingest", "vlm-rag", "vlm-generation"]
 
 networks:
   default:

--- a/deploy/compose/nvdev.env
+++ b/deploy/compose/nvdev.env
@@ -75,14 +75,16 @@ export NV_INGEST_MAX_UTIL=8
 # export NEMOTRON_PARSE_INFER_PROTOCOL=http # Uncomment to use NEMOTRON_PARSE protocol
 # export APP_NVINGEST_PDFEXTRACTMETHOD=nemotron_parse
 
-# VLM generation feature
+# VLM generation feature — Nemotron Omni (chat / RAG answering)
 export APP_VLM_SERVERURL="https://integrate.api.nvidia.com/v1"
 export APP_VLM_MODELNAME="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
 # export ENABLE_VLM_INFERENCE="true" # Uncomment to use VLM generation
 
 # Image captioning feature
-export APP_NVINGEST_CAPTIONMODELNAME="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
+export APP_NVINGEST_CAPTIONMODELNAME="nvidia/nemotron-nano-12b-v2-vl"
 export APP_NVINGEST_CAPTIONENDPOINTURL="https://integrate.api.nvidia.com/v1/chat/completions"
+export VLM_CAPTION_MODEL_NAME="nvidia/nemotron-nano-12b-v2-vl"
+export VLM_CAPTION_ENDPOINT="https://integrate.api.nvidia.com/v1/chat/completions"
 # export APP_NVINGEST_EXTRACTIMAGES="True" # Uncomment to use image captioning
 
 # Nemoguardrails feature

--- a/deploy/helm/nvidia-blueprint-rag/templates/vlm-captioning-nim.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/templates/vlm-captioning-nim.yaml
@@ -1,0 +1,61 @@
+{{- $nimVlmCaptioning := index .Values.nimOperator "nim-vlm-captioning" -}}
+{{- if and (.Capabilities.APIVersions.Has "apps.nvidia.com/v1alpha1") (eq $nimVlmCaptioning.enabled true) }}
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMCache
+metadata:
+  name: {{ $nimVlmCaptioning.service.name }}-cache
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  source:
+    ngc:
+      modelPuller: "{{ $nimVlmCaptioning.image.repository }}:{{ $nimVlmCaptioning.image.tag }}"
+      pullSecret: {{ .Values.imagePullSecret.name }}
+      authSecret: {{ .Values.ngcApiSecret.name }}
+  storage:
+    pvc:
+      create: {{ $nimVlmCaptioning.storage.pvc.create | default true }}
+      {{- if $nimVlmCaptioning.storage.pvc.storageClass }}
+      storageClass: {{ $nimVlmCaptioning.storage.pvc.storageClass }}
+      {{- end }}
+      size: {{ $nimVlmCaptioning.storage.pvc.size | default "50Gi" }}
+      volumeAccessMode: {{ $nimVlmCaptioning.storage.pvc.volumeAccessMode | default "ReadWriteMany" }}
+  resources: {}
+---
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMService
+metadata:
+  name: {{ $nimVlmCaptioning.service.name }}
+spec:
+  image:
+    repository: {{ $nimVlmCaptioning.image.repository }}
+    tag: {{ $nimVlmCaptioning.image.tag }}
+    pullPolicy: {{ $nimVlmCaptioning.image.pullPolicy | default "IfNotPresent" }}
+    pullSecrets:
+      - {{ .Values.imagePullSecret.name }}
+  authSecret: {{ .Values.ngcApiSecret.name }}
+  storage:
+    nimCache:
+      name: {{ $nimVlmCaptioning.service.name }}-cache
+  env:
+{{ toYaml $nimVlmCaptioning.env | nindent 4 }}
+  replicas: {{ $nimVlmCaptioning.replicas | default 1 }}
+  {{- with $nimVlmCaptioning.nodeSelector }}
+  nodeSelector:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+{{- if .Values.nimOperator.draResources.enabled }}
+  draResources:
+{{ toYaml $nimVlmCaptioning.draResources | nindent 4 }}
+{{- end }}
+{{- if not .Values.nimOperator.draResources.enabled }}
+  resources:
+{{ toYaml $nimVlmCaptioning.resources | nindent 4 }}
+{{- end }}
+  {{- with $nimVlmCaptioning.tolerations }}
+  tolerations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  expose:
+{{ toYaml $nimVlmCaptioning.expose | nindent 4 }}
+{{- end }}

--- a/deploy/helm/nvidia-blueprint-rag/values.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/values.yaml
@@ -424,8 +424,8 @@ ingestor-server:
     APP_NVINGEST_TEXTDEPTH: "page"  # Extract text by "page" or "document"
 
     # === NV-Ingest caption configurations ===
-    APP_NVINGEST_CAPTIONMODELNAME: "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"  # Model name for captioning
-    APP_NVINGEST_CAPTIONENDPOINTURL: ""  # Endpoint URL for captioning model
+    APP_NVINGEST_CAPTIONMODELNAME: "nvidia/nemotron-nano-12b-v2-vl"  # Model name for captioning
+    APP_NVINGEST_CAPTIONENDPOINTURL: "http://nim-vlm-captioning:8000/v1/chat/completions"  # Endpoint URL for captioning model
 
     # NeMo Retriever invoke URLs (HTTP) for local NIMs (see rag-nv-ingest YOLOX_*_HTTP_ENDPOINT)
     APP_NVINGEST_PAGEELEMENTSURL: "http://nemotron-page-elements-v3:8000/v1/infer"
@@ -1025,7 +1025,7 @@ nimOperator:
         grpcPort: 8001
 
   # subsection: nim-vlm
-  # NIM Vision-Language (VLM)
+  # Nemotron Omni — used for generation.
   nim-vlm:
     enabled: false
     replicas: 1
@@ -1044,6 +1044,38 @@ nimOperator:
     tolerations: []
 #    draResources:
 #      - resourceClaimName: rag-claim
+    storage:
+      pvc:
+        create: true
+        size: "50Gi"
+        volumeAccessMode: ReadWriteOnce
+        storageClass: ""
+    env: []
+    expose:
+      service:
+        name: http
+        type: ClusterIP
+        port: 8000
+        grpcPort: 8001
+
+  # subsection: nim-vlm-captioning
+  # Nemotron Nano 12B — used for image captioning.
+  nim-vlm-captioning:
+    enabled: false
+    replicas: 1
+    service:
+      name: "nim-vlm-captioning"
+    image:
+      repository: nvcr.io/nim/nvidia/nemotron-nano-12b-v2-vl
+      tag: "1.6.0"
+      pullPolicy: IfNotPresent
+    resources:
+      limits:
+        nvidia.com/gpu: 1
+      requests:
+        nvidia.com/gpu: 1
+    nodeSelector: {}
+    tolerations: []
     storage:
       pvc:
         create: true
@@ -1143,8 +1175,8 @@ nv-ingest:
     YOLOX_TABLE_STRUCTURE_INFER_PROTOCOL: grpc
 
     # Captioning
-    VLM_CAPTION_MODEL_NAME: nvidia/nemotron-3-nano-omni-30b-a3b-reasoning
-    VLM_CAPTION_ENDPOINT: http://nim-vlm:8000/v1/chat/completions
+    VLM_CAPTION_MODEL_NAME: nvidia/nemotron-nano-12b-v2-vl
+    VLM_CAPTION_ENDPOINT: http://nim-vlm-captioning:8000/v1/chat/completions
 
     # Audio service
     AUDIO_GRPC_ENDPOINT: nv-ingest-riva-nim:50051

--- a/docs/vlm.md
+++ b/docs/vlm.md
@@ -187,6 +187,105 @@ Continue with [Deploy with Docker (NVIDIA-Hosted Models)](deploy-docker-nvidia-h
    Keep user questions as self-contained as possible, especially in long-running conversations. Use retrieval and prompt tuning to focus the most relevant context for the VLM.
    :::
 
+## Separate VLMs for Generation and Captioning
+
+This blueprint uses two distinct VLM NIMs by default — one for chat / RAG answering and one for ingestion-time image captioning. The two services are configured independently so each can be scaled, replaced, or pointed at a different endpoint without affecting the other.
+
+| Role | Default model | Compose service | Helm chart key |
+|------|---------------|-----------------|----------------|
+| Generation (chat / RAG answering) | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` | `vlm-ms` | `nimOperator.nim-vlm` |
+| Ingestion-time image captioning | `nvidia/nemotron-nano-12b-v2-vl` | `vlm-captioning-ms` | `nimOperator.nim-vlm-captioning` |
+
+### Configure the generation VLM
+
+Set the generation VLM via `APP_VLM_MODELNAME` and `APP_VLM_SERVERURL`. With Docker Compose:
+
+```bash
+export APP_VLM_MODELNAME="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
+export APP_VLM_SERVERURL="http://vlm-ms:8000/v1"
+docker compose -f deploy/compose/docker-compose-rag-server.yaml up -d
+```
+
+With Helm, in `values.yaml`:
+
+```yaml
+envVars:
+  APP_VLM_MODELNAME: "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
+  APP_VLM_SERVERURL: "http://nim-vlm:8000/v1"
+
+nimOperator:
+  nim-vlm:
+    enabled: true
+```
+
+### Configure the captioning VLM
+
+The captioning model is consumed by both the ingestor-server and the upstream `nv-ingest-ms-runtime`, so set both pairs of env vars to the same values.
+
+With Docker Compose:
+
+```bash
+export APP_NVINGEST_CAPTIONMODELNAME="nvidia/nemotron-nano-12b-v2-vl"
+export APP_NVINGEST_CAPTIONENDPOINTURL="http://vlm-captioning-ms:8000/v1/chat/completions"
+export VLM_CAPTION_MODEL_NAME="nvidia/nemotron-nano-12b-v2-vl"
+export VLM_CAPTION_ENDPOINT="http://vlm-captioning-ms:8000/v1/chat/completions"
+docker compose -f deploy/compose/nims.yaml --profile vlm-rag up -d   # starts vlm-captioning-ms
+docker compose -f deploy/compose/docker-compose-ingestor-server.yaml up -d
+```
+
+With Helm, in `values.yaml`:
+
+```yaml
+nimOperator:
+  nim-vlm-captioning:
+    enabled: true
+
+ingestor-server:
+  envVars:
+    APP_NVINGEST_CAPTIONMODELNAME: "nvidia/nemotron-nano-12b-v2-vl"
+    APP_NVINGEST_CAPTIONENDPOINTURL: "http://nim-vlm-captioning:8000/v1/chat/completions"
+
+nv-ingest:
+  envVars:
+    VLM_CAPTION_MODEL_NAME: nvidia/nemotron-nano-12b-v2-vl
+    VLM_CAPTION_ENDPOINT: http://nim-vlm-captioning:8000/v1/chat/completions
+```
+
+### Use a single shared VLM for both roles
+
+If you want to run only one VLM container and use it for both generation and captioning, point the captioning endpoints at the generation service and disable the dedicated captioning NIM.
+
+With Docker Compose:
+
+```bash
+export APP_NVINGEST_CAPTIONENDPOINTURL="http://vlm-ms:8000/v1/chat/completions"
+export VLM_CAPTION_ENDPOINT="http://vlm-ms:8000/v1/chat/completions"
+# Bring up generation only (skip the vlm-captioning-ms profile)
+docker compose -f deploy/compose/nims.yaml --profile vlm-generation up -d
+```
+
+With Helm, in `values.yaml`:
+
+```yaml
+nimOperator:
+  nim-vlm-captioning:
+    enabled: false
+
+ingestor-server:
+  envVars:
+    APP_NVINGEST_CAPTIONENDPOINTURL: "http://nim-vlm:8000/v1/chat/completions"
+
+nv-ingest:
+  envVars:
+    VLM_CAPTION_ENDPOINT: http://nim-vlm:8000/v1/chat/completions
+```
+
+In this mode set `APP_NVINGEST_CAPTIONMODELNAME` and `VLM_CAPTION_MODEL_NAME` to whatever model the generation NIM serves.
+
+### NVIDIA-hosted endpoints
+
+To use NVIDIA-hosted endpoints for either role, point the corresponding `*_SERVERURL` / `*_ENDPOINTURL` at `https://integrate.api.nvidia.com/v1` (chat completions: `https://integrate.api.nvidia.com/v1/chat/completions`). Both `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` and `nvidia/nemotron-nano-12b-v2-vl` are available there.
+
 ## VLM to LLM Fallback (Optional)
 
 By default, with VLM enabled, the RAG server uses VLM for all generation tasks. The `VLM_TO_LLM_FALLBACK` environment variable controls behavior for text-only queries (no images in query, messages, or retrieved context).


### PR DESCRIPTION
Nemotron Omni's reasoning behavior is currently unregulated for the NV-Ingest captioning task (bug 6130091): it can return only reasoning_content with empty response_content for some images, which surfaces in the pipeline as missing captions and was the reason the Vidore v3 industrial evaluation could not complete.

Until NV-Ingest exposes captioning-side reasoning knobs, run captioning on a separate, stable VLM:

  - Generation (chat / RAG answering): Nemotron Omni — vlm-ms (compose) / nim-vlm (helm). Unchanged default.
  - Ingestion-time captioning: Nemotron Nano 12B v2-VL — new vlm-captioning-ms (compose) / nim-vlm-captioning (helm).

The captioning service is opt-in (enabled: false by default in helm, profile-gated in compose) so existing single-VLM deployments are not affected; docs/change-model.md explains how to opt back into a single shared VLM if desired.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.