### PR TITLE
fix(osrb): Apache 2.0 contribution compliance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,7 +284,8 @@ You should see "Good signature" in the output.
 - Configure pinentry for your environment (GUI vs terminal)
 
 
-## Developer Certificate of Origin
+## Full text of the DCO
+
 Version 1.1
 
 Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,6 @@
+Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -186,7 +189,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 NVIDIA Corporation
+   Copyright 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/deploy/helm/nvidia-blueprint-rag/LICENSE
+++ b/deploy/helm/nvidia-blueprint-rag/LICENSE
@@ -1,3 +1,6 @@
+Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -186,7 +189,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 NVIDIA Corporation
+   Copyright 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,5 @@
-# Copyright (c) '2025-%Y, NVIDIA CORPORATION.  All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,8 +25,8 @@ import os
 import sys
 
 project = " NVIDIA RAG blueprint"
-copyright = "'2025-%Y, NVIDIA Corporation"
-author = "NVIDIA Corporation"
+copyright = "2025, NVIDIA CORPORATION & AFFILIATES"
+author = "NVIDIA CORPORATION & AFFILIATES"
 release = "2.6.0"
 
 # -- General configuration ---------------------------------------------------

--- a/examples/rag_event_ingest/kafka_consumer/config/__init__.py
+++ b/examples/rag_event_ingest/kafka_consumer/config/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # config/__init__.py
 """Configuration package for Kafka MinIO Consumer.
 

--- a/examples/rag_event_ingest/kafka_consumer/config/constants.py
+++ b/examples/rag_event_ingest/kafka_consumer/config/constants.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # config/constants.py
 """Static constants that don't change at runtime.
 

--- a/examples/rag_event_ingest/kafka_consumer/config/settings.py
+++ b/examples/rag_event_ingest/kafka_consumer/config/settings.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # config/settings.py
 """Runtime settings loaded from environment variables."""
 

--- a/examples/rag_event_ingest/kafka_consumer/consumer.py
+++ b/examples/rag_event_ingest/kafka_consumer/consumer.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # consumer.py
 """Kafka consumer for MinIO S3 events."""
 

--- a/examples/rag_event_ingest/kafka_consumer/handlers/__init__.py
+++ b/examples/rag_event_ingest/kafka_consumer/handlers/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # Handlers package
 from .base import BaseHandler
 from .document import DocumentHandler

--- a/examples/rag_event_ingest/kafka_consumer/handlers/base.py
+++ b/examples/rag_event_ingest/kafka_consumer/handlers/base.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # handlers/base.py
 """Base handler abstract class."""
 

--- a/examples/rag_event_ingest/kafka_consumer/handlers/document.py
+++ b/examples/rag_event_ingest/kafka_consumer/handlers/document.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # handlers/document.py
 """Handler for document files (PDF, DOCX, TXT, etc.)."""
 

--- a/examples/rag_event_ingest/kafka_consumer/main.py
+++ b/examples/rag_event_ingest/kafka_consumer/main.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # main.py
 """Entry point for Kafka MinIO consumer."""
 

--- a/examples/rag_event_ingest/kafka_consumer/models/__init__.py
+++ b/examples/rag_event_ingest/kafka_consumer/models/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # Models package
 from .events import S3Event, HandlerResult, IngestionRecord
 

--- a/examples/rag_event_ingest/kafka_consumer/models/events.py
+++ b/examples/rag_event_ingest/kafka_consumer/models/events.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # models/events.py
 """Data models for Kafka consumer events and results."""
 

--- a/examples/rag_event_ingest/kafka_consumer/router.py
+++ b/examples/rag_event_ingest/kafka_consumer/router.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # router.py
 """File routing module for MinIO event processing."""
 

--- a/examples/rag_event_ingest/kafka_consumer/services/__init__.py
+++ b/examples/rag_event_ingest/kafka_consumer/services/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # services/__init__.py
 """External service clients."""
 

--- a/examples/rag_event_ingest/kafka_consumer/services/document_indexer.py
+++ b/examples/rag_event_ingest/kafka_consumer/services/document_indexer.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # services/document_indexer.py
 """Document indexing service for RAG pipeline."""
 

--- a/examples/rag_event_ingest/kafka_consumer/services/storage.py
+++ b/examples/rag_event_ingest/kafka_consumer/services/storage.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # services/storage.py
 """S3-compatible object storage service."""
 

--- a/examples/rag_react_agent/src/rag_react_agent/__init__.py
+++ b/examples/rag_react_agent/src/rag_react_agent/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/rag_react_agent/src/rag_react_agent/configs/config.yml
+++ b/examples/rag_react_agent/src/rag_react_agent/configs/config.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/rag_react_agent/src/rag_react_agent/register.py
+++ b/examples/rag_react_agent/src/rag_react_agent/register.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/frontend/src/components/chat/__tests__/ChatMessageBubble.test.tsx
+++ b/frontend/src/components/chat/__tests__/ChatMessageBubble.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import ChatMessageBubble from '../ChatMessageBubble';

--- a/frontend/src/components/chat/__tests__/Citations.test.tsx
+++ b/frontend/src/components/chat/__tests__/Citations.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import Citations from '../Citations';

--- a/frontend/src/components/chat/__tests__/MessageActions.test.tsx
+++ b/frontend/src/components/chat/__tests__/MessageActions.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { MessageActions } from '../MessageActions';

--- a/frontend/src/components/chat/__tests__/MessageContent.test.tsx
+++ b/frontend/src/components/chat/__tests__/MessageContent.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '../../../test/utils';
 import { MessageContent } from '../MessageContent';

--- a/frontend/src/components/chat/__tests__/MessageInput.test.tsx
+++ b/frontend/src/components/chat/__tests__/MessageInput.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import MessageInput from '../MessageInput';

--- a/frontend/src/components/chat/__tests__/MessageInputContainer.test.tsx
+++ b/frontend/src/components/chat/__tests__/MessageInputContainer.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import { MessageInputContainer } from '../MessageInputContainer';

--- a/frontend/src/components/chat/__tests__/MessageTextarea.test.tsx
+++ b/frontend/src/components/chat/__tests__/MessageTextarea.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { MessageTextarea } from '../MessageTextarea';

--- a/frontend/src/components/chat/__tests__/StreamingIndicator.test.tsx
+++ b/frontend/src/components/chat/__tests__/StreamingIndicator.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import { StreamingIndicator } from '../StreamingIndicator';

--- a/frontend/src/components/citations/__tests__/CitationButton.test.tsx
+++ b/frontend/src/components/citations/__tests__/CitationButton.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { CitationButton } from '../CitationButton';

--- a/frontend/src/components/citations/__tests__/CitationItem.test.tsx
+++ b/frontend/src/components/citations/__tests__/CitationItem.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import CitationItem from '../CitationItem';

--- a/frontend/src/components/citations/__tests__/CitationMetadata.test.tsx
+++ b/frontend/src/components/citations/__tests__/CitationMetadata.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import { CitationMetadata } from '../CitationMetadata';

--- a/frontend/src/components/citations/__tests__/CitationScore.test.tsx
+++ b/frontend/src/components/citations/__tests__/CitationScore.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import { CitationScore } from '../CitationScore';

--- a/frontend/src/components/citations/__tests__/CitationTextContent.test.tsx
+++ b/frontend/src/components/citations/__tests__/CitationTextContent.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '../../../test/utils';
 import { CitationTextContent } from '../CitationTextContent';

--- a/frontend/src/components/citations/__tests__/CitationVisualContent.test.tsx
+++ b/frontend/src/components/citations/__tests__/CitationVisualContent.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import { CitationVisualContent } from '../CitationVisualContent';

--- a/frontend/src/components/collections/CollectionsGrid.tsx
+++ b/frontend/src/components/collections/CollectionsGrid.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { VerticalNav, Spinner, StatusMessage, Flex } from "@kui/react";
 import { useCollections } from "../../api/useCollectionsApi";
 import type { Collection } from "../../types/collections";

--- a/frontend/src/components/collections/__tests__/CollectionChips.test.tsx
+++ b/frontend/src/components/collections/__tests__/CollectionChips.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { CollectionChips } from '../CollectionChips';

--- a/frontend/src/components/collections/__tests__/CollectionDrawer.test.tsx
+++ b/frontend/src/components/collections/__tests__/CollectionDrawer.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import CollectionDrawer from '../CollectionDrawer';

--- a/frontend/src/components/collections/__tests__/CollectionItem.test.tsx
+++ b/frontend/src/components/collections/__tests__/CollectionItem.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { CollectionItem } from '../CollectionItem';

--- a/frontend/src/components/collections/__tests__/CollectionList.test.tsx
+++ b/frontend/src/components/collections/__tests__/CollectionList.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import CollectionList from '../CollectionList';

--- a/frontend/src/components/collections/__tests__/CollectionsGrid.test.tsx
+++ b/frontend/src/components/collections/__tests__/CollectionsGrid.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import { CollectionsGrid } from '../CollectionsGrid';

--- a/frontend/src/components/collections/__tests__/NewCollectionButton.test.tsx
+++ b/frontend/src/components/collections/__tests__/NewCollectionButton.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { NewCollectionButton } from '../NewCollectionButton';

--- a/frontend/src/components/collections/__tests__/NewCollectionButtons.test.tsx
+++ b/frontend/src/components/collections/__tests__/NewCollectionButtons.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import NewCollectionButtons from '../NewCollectionButtons';

--- a/frontend/src/components/drawer/__tests__/DrawerActions.test.tsx
+++ b/frontend/src/components/drawer/__tests__/DrawerActions.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { DrawerActions } from '../DrawerActions';

--- a/frontend/src/components/drawer/__tests__/SidebarDrawer.test.tsx
+++ b/frontend/src/components/drawer/__tests__/SidebarDrawer.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import SidebarDrawer from '../SidebarDrawer';

--- a/frontend/src/components/drawer/__tests__/UploaderSection.test.tsx
+++ b/frontend/src/components/drawer/__tests__/UploaderSection.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { UploaderSection } from '../UploaderSection';

--- a/frontend/src/components/files/FileCard.tsx
+++ b/frontend/src/components/files/FileCard.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { useCallback, useState } from "react";
 import { useNewCollectionStore } from "../../store/useNewCollectionStore";
 import { MetadataField } from "./MetadataField";

--- a/frontend/src/components/files/MetadataField.tsx
+++ b/frontend/src/components/files/MetadataField.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useCallback, useMemo } from "react";
 import { Button, FormField, TextInput, Switch, Flex, Text, Tag } from "@kui/react";
 import { X, Plus } from "lucide-react";

--- a/frontend/src/components/files/NvidiaUpload.tsx
+++ b/frontend/src/components/files/NvidiaUpload.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useRef } from 'react';
 import { FileUploadZone } from './FileUploadZone';
 import { FileList } from './FileList';

--- a/frontend/src/components/files/__tests__/FileCard.test.tsx
+++ b/frontend/src/components/files/__tests__/FileCard.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { FileCard } from '../FileCard';

--- a/frontend/src/components/files/__tests__/FileInput.test.tsx
+++ b/frontend/src/components/files/__tests__/FileInput.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent } from '../../../test/utils';
 import { FileInput } from '../FileInput';

--- a/frontend/src/components/files/__tests__/FileItem.test.tsx
+++ b/frontend/src/components/files/__tests__/FileItem.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { FileItem } from '../FileItem';

--- a/frontend/src/components/files/__tests__/FileList.test.tsx
+++ b/frontend/src/components/files/__tests__/FileList.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { FileList } from '../FileList';

--- a/frontend/src/components/files/__tests__/FileMetadataForm.test.tsx
+++ b/frontend/src/components/files/__tests__/FileMetadataForm.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import { FileMetadataForm } from '../FileMetadataForm';

--- a/frontend/src/components/files/__tests__/FileUploadZone.test.tsx
+++ b/frontend/src/components/files/__tests__/FileUploadZone.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { FileUploadZone } from '../FileUploadZone';

--- a/frontend/src/components/files/__tests__/FileUploaderWithMetadata.test.tsx
+++ b/frontend/src/components/files/__tests__/FileUploaderWithMetadata.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import FileUploaderWithMetadata from '../FileUploaderWithMetadata';

--- a/frontend/src/components/files/__tests__/FilesList.test.tsx
+++ b/frontend/src/components/files/__tests__/FilesList.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import { FilesList } from '../FilesList';

--- a/frontend/src/components/files/__tests__/MetadataField.test.tsx
+++ b/frontend/src/components/files/__tests__/MetadataField.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { MetadataField } from '../MetadataField';

--- a/frontend/src/components/files/__tests__/NvidiaUpload.test.tsx
+++ b/frontend/src/components/files/__tests__/NvidiaUpload.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import NvidiaUpload from '../NvidiaUpload';

--- a/frontend/src/components/layout/__tests__/Header.test.tsx
+++ b/frontend/src/components/layout/__tests__/Header.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import Header from '../Header';

--- a/frontend/src/components/layout/__tests__/Layout.test.tsx
+++ b/frontend/src/components/layout/__tests__/Layout.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import Layout from '../Layout';

--- a/frontend/src/components/layout/__tests__/StatusMessages.test.tsx
+++ b/frontend/src/components/layout/__tests__/StatusMessages.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import StatusMessages from '../StatusMessages';

--- a/frontend/src/components/modals/__tests__/FeatureWarningModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/FeatureWarningModal.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { FeatureWarningModal } from '../FeatureWarningModal';

--- a/frontend/src/components/modals/__tests__/SettingsModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/SettingsModal.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '../../../test/utils';
 

--- a/frontend/src/components/notifications/__tests__/NotificationBadge.test.tsx
+++ b/frontend/src/components/notifications/__tests__/NotificationBadge.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import { NotificationBadge } from '../NotificationBadge';

--- a/frontend/src/components/notifications/__tests__/NotificationBell.test.tsx
+++ b/frontend/src/components/notifications/__tests__/NotificationBell.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import NotificationBell from '../NotificationBell';

--- a/frontend/src/components/notifications/__tests__/NotificationDropdown.test.tsx
+++ b/frontend/src/components/notifications/__tests__/NotificationDropdown.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { NotificationDropdown } from '../NotificationDropdown';

--- a/frontend/src/components/notifications/__tests__/TaskPoller.test.tsx
+++ b/frontend/src/components/notifications/__tests__/TaskPoller.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi } from 'vitest';
 import { render } from '../../../test/utils';
 import { TaskPoller } from '../TaskPoller';

--- a/frontend/src/components/schema/FieldDisplayCard.tsx
+++ b/frontend/src/components/schema/FieldDisplayCard.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { useCallback } from "react";
 import type { UIMetadataField, MetadataFieldType } from "../../types/collections";
 import { 

--- a/frontend/src/components/schema/__tests__/FieldDisplayCard.test.tsx
+++ b/frontend/src/components/schema/__tests__/FieldDisplayCard.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { FieldDisplayCard } from '../FieldDisplayCard';

--- a/frontend/src/components/schema/__tests__/FieldEditForm.test.tsx
+++ b/frontend/src/components/schema/__tests__/FieldEditForm.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { FieldEditForm } from '../FieldEditForm';

--- a/frontend/src/components/schema/__tests__/FieldsList.test.tsx
+++ b/frontend/src/components/schema/__tests__/FieldsList.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi } from 'vitest';
 import { render } from '../../../test/utils';
 import { FieldsList } from '../FieldsList';

--- a/frontend/src/components/schema/__tests__/MetadataSchemaEditor.test.tsx
+++ b/frontend/src/components/schema/__tests__/MetadataSchemaEditor.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import MetadataSchemaEditor from '../MetadataSchemaEditor';

--- a/frontend/src/components/schema/__tests__/NewFieldForm.test.tsx
+++ b/frontend/src/components/schema/__tests__/NewFieldForm.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import { NewFieldForm } from '../NewFieldForm';

--- a/frontend/src/components/settings/__tests__/AdvancedSection.test.tsx
+++ b/frontend/src/components/settings/__tests__/AdvancedSection.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import userEvent from '@testing-library/user-event';

--- a/frontend/src/components/settings/__tests__/EndpointsSection.test.tsx
+++ b/frontend/src/components/settings/__tests__/EndpointsSection.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { EndpointsSection } from '../EndpointsSection';

--- a/frontend/src/components/settings/__tests__/FeatureTogglesSection.test.tsx
+++ b/frontend/src/components/settings/__tests__/FeatureTogglesSection.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { FeatureTogglesSection } from '../FeatureTogglesSection';

--- a/frontend/src/components/settings/__tests__/ModelsSection.test.tsx
+++ b/frontend/src/components/settings/__tests__/ModelsSection.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { ModelsSection } from '../ModelsSection';

--- a/frontend/src/components/settings/__tests__/RagConfigSection.test.tsx
+++ b/frontend/src/components/settings/__tests__/RagConfigSection.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import { RagConfigSection } from '../RagConfigSection';

--- a/frontend/src/components/settings/__tests__/SettingsHeader.test.tsx
+++ b/frontend/src/components/settings/__tests__/SettingsHeader.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import { SettingsHeader } from '../SettingsHeader';

--- a/frontend/src/components/settings/__tests__/SettingsSection.test.tsx
+++ b/frontend/src/components/settings/__tests__/SettingsSection.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { SettingsSection, AdvancedSettingsSection } from '../SettingsSection';

--- a/frontend/src/components/tasks/__tests__/DocumentItem.test.tsx
+++ b/frontend/src/components/tasks/__tests__/DocumentItem.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '../../../test/utils';
 import userEvent from '@testing-library/user-event';

--- a/frontend/src/components/tasks/__tests__/DocumentsList.test.tsx
+++ b/frontend/src/components/tasks/__tests__/DocumentsList.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import { DocumentsList } from '../DocumentsList';

--- a/frontend/src/components/tasks/__tests__/TaskDisplay.test.tsx
+++ b/frontend/src/components/tasks/__tests__/TaskDisplay.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { TaskDisplay } from '../TaskDisplay';

--- a/frontend/src/components/tasks/__tests__/TaskStatusIcons.test.tsx
+++ b/frontend/src/components/tasks/__tests__/TaskStatusIcons.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import { TaskStatusIcon } from '../TaskStatusIcons';

--- a/frontend/src/components/ui/__tests__/ErrorState.test.tsx
+++ b/frontend/src/components/ui/__tests__/ErrorState.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '../../../test/utils';
 import { ErrorState } from '../ErrorState';

--- a/frontend/src/components/ui/__tests__/LoadingState.test.tsx
+++ b/frontend/src/components/ui/__tests__/LoadingState.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '../../../test/utils';
 import { LoadingState } from '../LoadingState';

--- a/frontend/src/hooks/__tests__/useFileValidation.test.ts
+++ b/frontend/src/hooks/__tests__/useFileValidation.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useFileValidation } from '../useFileValidation';

--- a/frontend/src/hooks/__tests__/useUploadDocuments.test.ts
+++ b/frontend/src/hooks/__tests__/useUploadDocuments.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useUploadDocuments } from '../useUploadDocuments';

--- a/frontend/src/hooks/useFileUpload.ts
+++ b/frontend/src/hooks/useFileUpload.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { useCallback } from "react";
 import { useNewCollectionStore } from "../store/useNewCollectionStore";
 

--- a/frontend/src/pages/__tests__/Chat.test.tsx
+++ b/frontend/src/pages/__tests__/Chat.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '../../test/utils';
 import Chat from '../Chat';

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Vite environment type definitions for the frontend application.
  * 

--- a/scripts/extract_python_licenses.py
+++ b/scripts/extract_python_licenses.py
@@ -1,18 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 """
 Extract Python package licenses for legal compliance.

--- a/src/nvidia_rag/rag_server/agentic_rag/__init__.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/nvidia_rag/rag_server/agentic_rag/agentic_rag.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/agentic_rag.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/nvidia_rag/rag_server/agentic_rag/builder.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/builder.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/nvidia_rag/rag_server/agentic_rag/prompt.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/prompt.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/nvidia_rag/rag_server/agentic_rag/runner.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/runner.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/nvidia_rag/rag_server/agentic_rag/streaming.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/streaming.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/nvidia_rag/rag_server/agentic_rag/tracing.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/tracing.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/nvidia_rag/utils/agentic_rag_config.py
+++ b/src/nvidia_rag/utils/agentic_rag_config.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/nvidia_rag/utils/reranker.py
+++ b/src/nvidia_rag/utils/reranker.py
@@ -1,4 +1,3 @@
-
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # Tests package

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,1 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # Integration test package

--- a/tests/integration/test_cases/__init__.py
+++ b/tests/integration/test_cases/__init__.py
@@ -1,1 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # Test cases package

--- a/tests/integration/test_cases/custom_metadata.py
+++ b/tests/integration/test_cases/custom_metadata.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 """
 Integration tests for custom metadata support.
 

--- a/tests/integration/utils/__init__.py
+++ b/tests/integration/utils/__init__.py
@@ -1,1 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # Utilities package

--- a/tests/unit/test_compose_helm_parity/test_compose_helm_parity.py
+++ b/tests/unit/test_compose_helm_parity/test_compose_helm_parity.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 import fnmatch
 import re
 from pathlib import Path

--- a/tests/unit/test_deploy/test_seaweedfs_deploy_config.py
+++ b/tests/unit/test_deploy/test_seaweedfs_deploy_config.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 import json
 import re
 from pathlib import Path

--- a/tests/unit/test_metadata_validation/test_filter_validator.py
+++ b/tests/unit/test_metadata_validation/test_filter_validator.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 """
 Comprehensive unit tests for filter expression validation.
 

--- a/tests/unit/test_metadata_validation/test_metadata_validator.py
+++ b/tests/unit/test_metadata_validation/test_metadata_validator.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 """
 Comprehensive unit tests for MetadataValidator class.
 Tests all metadata types and validation scenarios without requiring running servers.

--- a/tests/unit/test_observability/test_langchain_callback_handler.py
+++ b/tests/unit/test_observability/test_langchain_callback_handler.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: Apache-2.0
 
 from types import SimpleNamespace

--- a/tests/unit/test_observability/test_otel_metrics.py
+++ b/tests/unit/test_observability/test_otel_metrics.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import types

--- a/tests/unit/test_rag_perf/__init__.py
+++ b/tests/unit/test_rag_perf/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/unit/test_rag_server/test_agentic_rag.py
+++ b/tests/unit/test_rag_server/test_agentic_rag.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unit/test_utils/test_object_store.py
+++ b/tests/unit/test_utils/test_object_store.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 import importlib
 import sys
 from io import BytesIO


### PR DESCRIPTION
## Summary

Brings the RAG blueprint repository into alignment with OSRB Apache 2.0 contribution requirements ([Apache2 License](https://nvidia.atlassian.net/wiki/spaces/OSS/pages/3205043483), [CLAs and DCO](https://nvidia.atlassian.net/wiki/spaces/OSS/pages/3205224326)).

- Add required `Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.` preamble to root and Helm `LICENSE` files; correct appendix copyright entity string.
- Rename `CONTRIBUTING.md` DCO section to **Full text of the DCO** (DCO 1.1 body unchanged; sign-off requirements unchanged).
- Add or fix SPDX headers (`SPDX-FileCopyrightText` + `Apache-2.0`) across Python and TypeScript sources in `src/`, `tests/`, `scripts/`, `examples/`, `docs/`, and `frontend/src/`.
- Normalize copyright formatting (remove erroneous comma after year in agentic-rag files; fix `docs/conf.py` and Sphinx metadata; deduplicate headers in `scripts/extract_python_licenses.py`).

Signed-off-by: Shubhadeep Das <shubhadeepd@nvidia.com>