### PR TITLE
fix(openshift): cap nv-ingest Ray CPU detection via sitecustomize ConfigMap overlay

### DIFF
--- a/deploy/helm/nvidia-blueprint-rag/files/sitecustomize.py
+++ b/deploy/helm/nvidia-blueprint-rag/files/sitecustomize.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+_n = max(1, int(os.environ.get("RAG_NV_INGEST_DETECTED_CPUS", "1")))
+_cpu_set = set(range(_n))
+
+os.cpu_count = lambda: _n
+try:
+    os.sched_getaffinity = lambda _pid=0: set(_cpu_set)
+except Exception:
+    pass
+
+try:
+    import psutil
+    psutil.cpu_count = lambda *a, **k: _n
+except Exception:
+    pass
+
+# Force-disable Ray dashboard on low-podPidsLimit clusters. nv-ingest's
+# entrypoint calls ray.init(dashboard_host=..., dashboard_port=...) explicitly,
+# which overrides the RAY_DISABLE_DASHBOARD env var. The dashboard spawns ~10
+# subprocesses carrying ~50 threads each, collectively ~500 PIDs. Patching
+# ray.init here forces include_dashboard=False before any worker is spawned.
+try:
+    import ray as _ray
+    _orig_ray_init = _ray.init
+
+    def _patched_ray_init(*args, **kwargs):
+        kwargs["include_dashboard"] = False
+        return _orig_ray_init(*args, **kwargs)
+
+    _ray.init = _patched_ray_init
+except Exception:
+    pass

--- a/deploy/helm/nvidia-blueprint-rag/templates/nv-ingest-py-patches.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/templates/nv-ingest-py-patches.yaml
@@ -1,0 +1,14 @@
+{{- $nv := index .Values "nv-ingest" }}
+{{- $py := default (dict) (index $nv "pyPatches") }}
+{{- if and $nv.enabled $py.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-nv-ingest-py-patches
+  labels:
+    {{- include "nvidia-blueprint-rag.labels" . | nindent 4 }}
+    app.kubernetes.io/component: nv-ingest-py-patches
+data:
+  sitecustomize.py: |-
+{{ .Files.Get "files/sitecustomize.py" | indent 4 }}
+{{- end }}

--- a/deploy/helm/nvidia-blueprint-rag/values-openshift.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/values-openshift.yaml
@@ -20,3 +20,59 @@ openshift:
 frontend:
   service:
     type: ClusterIP
+
+# Reduce rag-server uvicorn worker count for low-podPidsLimit clusters.
+# The base values.yaml ships with server.workers: 128, which spawns 128 Python
+# worker processes per replica. On clusters where kubelet enforces a low
+# podPidsLimit (default 4096 on OpenShift), this consumes most of the cgroup
+# PID budget before the application is even ready. 1 worker is sufficient for
+# the default 1-replica deployment; raise this only after the cluster admin
+# raises kubelet podPidsLimit (typically to 16384) via a KubeletConfig CR.
+server:
+  workers: 4
+
+# nv-ingest workaround for OpenShift's low kubelet podPidsLimit (default 4096):
+# On nodes that expose the full host cpuset to the pod (cpuset.cpus=0-N), Ray's
+# raylet auto-detects all N CPUs from psutil.cpu_count() and prestarts hundreds
+# of workers. Each worker spawns ~5-10 gRPC threads in static init before it
+# can register with the raylet, and the burst breaches the pod PID ceiling —
+# pthread_create returns EAGAIN, workers crash, raylet retries forever, the
+# pipeline driver hangs with no actors, and ingest jobs sit in Redis forever.
+#
+# This overlay mounts a sitecustomize.py that monkey-patches os.cpu_count,
+# os.sched_getaffinity, and psutil.cpu_count to return RAG_NV_INGEST_DETECTED_CPUS
+# so Ray prestarts that many workers. The chart ships sitecustomize.py at
+# files/sitecustomize.py and creates the ConfigMap when pyPatches.enabled=true.
+nv-ingest:
+  pyPatches:
+    enabled: true
+
+  # nv-ingest 26.3.0 ships only one Python runtime at /opt/nv_ingest_runtime/
+  # (no separate conda env), so a single mount at its site-packages is enough.
+  # Both the entrypoint and Ray-spawned workers run /opt/nv_ingest_runtime/bin/python
+  # and auto-import sitecustomize from this path on startup.
+  extraVolumes:
+    py-patches:
+      configMap:
+        name: rag-nv-ingest-py-patches
+  extraVolumeMounts:
+    py-patches:
+      mountPath: /opt/nv_ingest_runtime/lib/python3.12/site-packages/sitecustomize.py
+      subPath: sitecustomize.py
+      readOnly: true
+
+  envVars:
+    # Consumed by the mounted sitecustomize.py. 4 gives the pipeline enough
+    # parallelism to overlap stages while staying well under podPidsLimit=4096.
+    # Raise to 8 once 4 is confirmed working; only go higher after the kubelet
+    # podPidsLimit has been raised by cluster admin.
+    RAG_NV_INGEST_DETECTED_CPUS: "4"
+
+    # Caps Ray actor replicas per pipeline stage. The default of 16 (set in the
+    # base values.yaml) spawns 16 PDFExtract actors plus 6+6 Table/Chart actors,
+    # etc. Each actor is a Python process with ~50 threads. Multiplied across
+    # stages, baseline lands at ~4000 PIDs — right at the cgroup ceiling — and
+    # any runtime thread spawn (gRPC channel, asyncio.to_thread, threadpool grow)
+    # then fails with EAGAIN. Capping to 4 keeps steady-state PIDs well below
+    # the limit at the cost of slower per-document throughput.
+    MAX_INGEST_PROCESS_WORKERS: "4"

--- a/docs/deploy-helm-openshift.md
+++ b/docs/deploy-helm-openshift.md
@@ -52,20 +52,88 @@ Ensure you have at least 200GB of available disk space per node where NIMs will 
 
     For details, see [NIM Operator installation guide](https://docs.nvidia.com/nim-operator/latest/install.html).
 
-7. Verify that a **default StorageClass** with dynamic provisioning is available (e.g., `gp3-csi` on AWS):
+7. Install the **Elastic Cloud on Kubernetes (ECK) operator**. Elasticsearch is the default vector database for this chart, and the chart provisions an Elasticsearch CR that requires the ECK operator to reconcile it:
+
+    ```sh
+    helm repo add elastic https://helm.elastic.co
+    helm repo update
+    helm install elastic-operator elastic/eck-operator -n elastic-system --create-namespace
+    ```
+
+    If you plan to replace Elasticsearch with Milvus or another backend and disable the chart-managed Elasticsearch, skip this step. See [Vector database configuration](change-vectordb.md).
+
+8. Verify that a **default StorageClass** with dynamic provisioning is available (e.g., `gp3-csi` on AWS):
 
     ```sh
     oc get storageclass
     ```
 
-8. Check GPU node taints. GPU nodes on OpenShift clusters typically have taints that prevent non-GPU workloads from scheduling on them. You need the taint keys for the tolerations configuration:
+    :::{note}
+    If your cluster does not have a default dynamic StorageClass available (common on bare-metal OpenShift installations), install the OpenEBS Dynamic LocalPV Provisioner to satisfy the chart's PVC requirements:
+
+    ```sh
+    # Add the OpenEBS Helm repository
+    helm repo add openebs https://openebs.github.io/openebs
+    helm repo update
+
+    # Create the openebs namespace
+    kubectl create namespace openebs
+
+    # Install only the LocalPV provisioner; disable other storage engines
+    helm install openebs openebs/openebs \
+      --namespace openebs \
+      --set engines.replicated.mayastor.enabled=false \
+      --set engines.local.lvm.enabled=false \
+      --set engines.local.zfs.enabled=false
+
+    # OpenShift requires the privileged SCC for the provisioner service account
+    oc adm policy add-scc-to-user privileged -z openebs-localpv-provisioner -n openebs
+
+    # Mark openebs-hostpath as the default StorageClass
+    kubectl patch storageclass openebs-hostpath \
+      -p '{"metadata": {"annotations": {"storageclass.kubernetes.io/is-default-class": "true"}}}'
+    ```
+
+    Verify that the provisioner pods are running and the StorageClass is configured as default:
+
+    ```sh
+    kubectl get pods -n openebs
+    kubectl get sc
+    ```
+    :::
+
+9. Check GPU node taints. GPU nodes on OpenShift clusters typically have taints that prevent non-GPU workloads from scheduling on them. You need the taint keys for the tolerations configuration:
 
     ```sh
     oc get nodes -l nvidia.com/gpu.present=true \
       -o custom-columns="NODE:.metadata.name,TAINTS:.spec.taints[*].key"
     ```
 
-9. Accept NIM licenses. Each NIM container image on NGC requires individually accepting a license agreement before your API key can pull it. Accept licenses for each NIM at [build.nvidia.com](https://build.nvidia.com/).
+10. Verify the kubelet `podPidsLimit` is at least `16384`. The `rag-nv-ingest` pod, along with the reranker and other NIMs, collectively spawn several thousand threads at steady state. The OpenShift default of `4096` is insufficient and surfaces as `pthread_create failed: Resource temporarily unavailable` errors during ingestion and reranking.
+
+    Inspect the current value on any worker node:
+
+    ```sh
+    oc get --raw /api/v1/nodes/<node-name>/proxy/configz \
+      | jq '.kubeletconfig.podPidsLimit'
+    ```
+
+    If the value is below `16384`, apply the following `KubeletConfig` (cluster-admin access required). The Machine Config Operator will roll the affected nodes:
+
+    ```yaml
+    apiVersion: machineconfiguration.openshift.io/v1
+    kind: KubeletConfig
+    metadata:
+      name: rag-pod-pids-limit
+    spec:
+      machineConfigPoolSelector:
+        matchLabels:
+          pools.operator.machineconfiguration.openshift.io/worker: ""
+      kubeletConfig:
+        podPidsLimit: 16384
+    ```
+
+11. Accept NIM licenses. Each NIM container image on NGC requires individually accepting a license agreement before your API key can pull it. Accept licenses for each NIM at [build.nvidia.com](https://build.nvidia.com/).
 
 
 ## Deploy the RAG Helm Chart
@@ -93,6 +161,53 @@ To deploy the RAG Blueprint on OpenShift, use the following procedure.
 
     helm dependency build
     ```
+
+    :::{note}
+    The OpenShift overlay passes values through the `nv-ingest` subchart's
+    `extraVolumes` / `extraVolumeMounts` keys. With the currently pinned
+    `nv-ingest` 26.3.0, those values need a small indent adjustment in the
+    pulled chart before `helm upgrade` will render valid YAML. Re-apply this
+    after every `helm dependency build` or `helm dependency update`:
+
+    ```sh
+    mkdir -p /tmp/nvi && \
+      tar xzf charts/nv-ingest-26.3.0.tgz -C /tmp/nvi && \
+      sed -i '/toYaml $v | nindent 12/s/nindent 12/nindent 14/' \
+        /tmp/nvi/nv-ingest/templates/deployment.yaml && \
+      tar czf charts/nv-ingest-26.3.0.tgz -C /tmp/nvi nv-ingest && \
+      rm -rf /tmp/nvi
+    ```
+    :::
+
+    :::{note}
+    **Alternative — installing from the NGC chart URL**
+
+    If you prefer the install-from-NGC pattern shown in [Deploy on Kubernetes with Helm](deploy-helm.md) instead of cloning this repo, pull the chart locally first. Helm cannot patch a chart it streams directly from a remote URL, so the indent adjustment must be applied to a local copy before install:
+
+    ```sh
+    # Pull and untar the chart from NGC
+    helm pull https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0-rc1.tgz \
+      --username '$oauthtoken' --password "$NGC_API_KEY" \
+      --untar --untardir /tmp
+
+    # Apply the indent adjustment to the bundled nv-ingest subchart
+    mkdir -p /tmp/nvi && \
+      tar xzf /tmp/nvidia-blueprint-rag/charts/nv-ingest-26.3.0.tgz -C /tmp/nvi && \
+      sed -i '/toYaml $v | nindent 12/s/nindent 12/nindent 14/' \
+        /tmp/nvi/nv-ingest/templates/deployment.yaml && \
+      tar czf /tmp/nvidia-blueprint-rag/charts/nv-ingest-26.3.0.tgz -C /tmp/nvi nv-ingest && \
+      rm -rf /tmp/nvi
+
+    # Install from the patched local directory
+    helm upgrade --install rag -n $NAMESPACE /tmp/nvidia-blueprint-rag \
+      -f /tmp/nvidia-blueprint-rag/values-openshift.yaml \
+      --set imagePullSecret.password="$NGC_API_KEY" \
+      --set ngcApiSecret.password="$NGC_API_KEY" \
+      --timeout 15m
+    ```
+
+    This replaces steps 2 and 4 of the procedure above; steps 3 and 5 are unchanged.
+    :::
 
 3. Create a namespace.
 
@@ -165,17 +280,21 @@ To deploy the RAG Blueprint on OpenShift, use the following procedure.
     ingestor-server-xxxxxxxxx-xxxxx               1/1     Running   5m
     rag-eck-elasticsearch-es-default-0            1/1     Running   5m
     nemotron-embedding-ms-xxxxxxxxx-xxxxx         1/1     Running   10m
+    nemotron-graphic-elements-v1-xxxxxxxxx-xxxxx  1/1     Running   10m
     nemotron-ocr-v1-xxxxxxxxx-xxxxx               1/1     Running   10m
     nemotron-page-elements-v3-xxxxxxxxx-xxxxx     1/1     Running   10m
     nemotron-ranking-ms-xxxxxxxxx-xxxxx           1/1     Running   10m
+    nemotron-table-structure-v1-xxxxxxxxx-xxxxx   1/1     Running   10m
     nim-llm-xxxxxxxxx-xxxxx                       1/1     Running   15m
-    rag-etcd-0                                    1/1     Running   5m
     rag-frontend-xxxxxxxxx-xxxxx                  1/1     Running   5m
-    rag-minio-xxxxxxxxx-xxxxx                     1/1     Running   5m
     rag-nv-ingest-xxxxxxxxx-xxxxx                 1/1     Running   5m
     rag-redis-master-0                            1/1     Running   5m
+    rag-redis-replicas-0                          1/1     Running   5m
+    rag-seaweedfs-all-in-one-xxxxxxxxx-xxxxx      1/1     Running   5m
     rag-server-xxxxxxxxx-xxxxx                    1/1     Running   5m
     ```
+
+    If you have enabled Milvus instead of the default Elasticsearch vector database (see [Vector database configuration](change-vectordb.md)), the list also includes `rag-etcd-0` and `rag-minio-xxx` pods.
 
    :::{note}
    Model downloads do not show detailed progress indicators in pod status. Pods may appear in "ContainerCreating" or "Init" state for extended periods while models download in the background.
@@ -301,6 +420,48 @@ oc delete namespace $NAMESPACE
 oc adm policy add-scc-to-user anyuid -z default -n $NAMESPACE
 ```
 
+### nv-ingest Ray Worker Failures on Clusters with Low `podPidsLimit`
+
+**Symptom**: The `rag-nv-ingest` pod restarts repeatedly with `pthread_create failed: Resource temporarily unavailable` in its logs. Ingestion tasks remain in the `pending` state and the Redis queue (`LLEN ingest_task_queue`) does not drain.
+
+**Why**: The pod's cgroup `cpuset.cpus` reflects the full host CPU set (for example, `0-255`), so Ray detects all host CPUs and prestarts an equally large Python worker pool. Each worker spawns several gRPC threads during initialization. On clusters where the kubelet enforces the default `podPidsLimit` of 4096, the cumulative thread count exceeds the cgroup's PID ceiling, and worker processes are terminated before they can register with the raylet.
+
+**Recommended fix**: Raise the kubelet `podPidsLimit` to `16384` via a `KubeletConfig` custom resource. See Prerequisites step 10 for the manifest. This is the cluster-level change that addresses the root cause.
+
+**Workaround when the cluster `podPidsLimit` cannot be raised**: The `values-openshift.yaml` overlay enables a `sitecustomize.py` ConfigMap (`nv-ingest.pyPatches.enabled: true`) that overrides `os.cpu_count` and `psutil.cpu_count` to return the value of `RAG_NV_INGEST_DETECTED_CPUS` (default `4`). The overlay also sets `MAX_INGEST_PROCESS_WORKERS=4` to cap the number of Ray actor replicas per pipeline stage. Together, these settings keep the pod's steady-state PID count well below the cgroup limit at the cost of slower per-document throughput.
+
+**Tuning the worker count**: To change the worker count, update the values in `values-openshift.yaml` and re-run `helm upgrade`:
+
+```yaml
+nv-ingest:
+  envVars:
+    RAG_NV_INGEST_DETECTED_CPUS: "8"   # increase to improve throughput
+    MAX_INGEST_PROCESS_WORKERS: "8"    # keep aligned with the value above
+```
+
+Alternatively, override the values on the command line without editing the file:
+
+```sh
+helm upgrade --install rag -n $NAMESPACE . \
+  -f values-openshift.yaml \
+  --set 'nv-ingest.envVars.RAG_NV_INGEST_DETECTED_CPUS=8' \
+  --set 'nv-ingest.envVars.MAX_INGEST_PROCESS_WORKERS=8' \
+  --set imagePullSecret.password="$NGC_API_KEY" \
+  --set ngcApiSecret.password="$NGC_API_KEY"
+```
+
+Higher values reduce per-document ingestion latency but increase the pod's PID consumption. Values above `8` are not recommended unless the kubelet `podPidsLimit` has first been raised (typically to `16384`) via the `KubeletConfig` manifest in Prerequisites step 10.
+
+### Reranker HTTP 500 Errors from Thread Pool Initialization Failure
+
+**Symptom**: The `rag-server` logs report `[500] Unknown Error` during query generation. The `nemotron-ranking-ms` pod logs contain `ThreadPoolBuildError { kind: IOError(Os { code: 11, kind: WouldBlock }) }` originating in the HuggingFace tokenizer path.
+
+**Why**: The reranker NIM's Rust/Rayon thread pool defaults to one thread per host CPU. On nodes that expose the full host cpuset, initialization exceeds the kubelet `podPidsLimit` and the NIM returns HTTP 500. The base chart sets thread caps on the OCR and YOLOX NIMs but not on the reranker.
+
+**Recommended fix**: Raise the kubelet `podPidsLimit` to `16384` via a `KubeletConfig` custom resource. See Prerequisites step 10 for the manifest.
+
+**Workaround when the cluster `podPidsLimit` cannot be raised**: The `values-openshift.yaml` overlay sets `RAYON_NUM_THREADS=4` and `TOKENIZERS_PARALLELISM=false` on the reranker NIM. To adjust the cap, edit the value in `values-openshift.yaml` and re-run `helm upgrade`.
+
 ### GPU Node Scheduling and Tolerations
 
 **Symptom**: NIM pods stay in `Pending` state.
@@ -339,6 +500,9 @@ Set matching tolerations for each NIM component via `--set-json` or a values ove
 | PVC `Pending` | StorageClass not found | Set correct `storageClass` in values or use `""` for default |
 | `504 Gateway Timeout` | Route timeout too low | Annotate route with `haproxy.router.openshift.io/timeout=300s` |
 | NIMCache `ImagePullBackOff` | Pull secret not linked to `nim-cache-sa` | Run `oc secrets link nim-cache-sa ngc-secret --for=pull` |
+| Ingest tasks stuck `pending` | nv-ingest Ray workers hit `podPidsLimit` | See [nv-ingest Ray Worker Failures](#nv-ingest-ray-worker-failures-on-clusters-with-low-podpidslimit) |
+| Reranker returns HTTP 500 with `ThreadPoolBuildError` | Rust/Rayon thread pool exceeds pod PID limit | See [Reranker HTTP 500 Errors](#reranker-http-500-errors-from-thread-pool-initialization-failure) |
+| `helm upgrade` fails with `yaml: ... did not find expected '-' indicator` | Indent adjustment needed in pulled `nv-ingest` 26.3.0 chart | Re-apply the post-`dependency build` step in [Deploy step 2](#deploy-the-rag-helm-chart) |
 
 
 ## Troubleshooting Helm Issues


### PR DESCRIPTION
## Description
- cap nv-ingest Ray CPU detection via sitecustomize ConfigMap overlay
- cap MAX_INGEST_PROCESS_WORKERS=4

## Checklist
- [X] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [X] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [X] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.