### PR TITLE
fix(rag): reject non-positive timeout in get_summary (NVBug 6035874)

### DIFF
--- a/src/nvidia_rag/rag_server/main.py
+++ b/src/nvidia_rag/rag_server/main.py
@@ -1602,6 +1602,13 @@ class NvidiaRAG:
         timeout: int = 300,
     ) -> dict[str, Any]:
         """Get the summary of a document."""
+        from nvidia_rag.rag_server.validation import (
+            invalid_summary_timeout_response,
+            is_invalid_summary_timeout,
+        )
+
+        if is_invalid_summary_timeout(timeout):
+            return invalid_summary_timeout_response(timeout)
 
         summary_response = await retrieve_summary(
             collection_name=collection_name,

--- a/src/nvidia_rag/rag_server/server.py
+++ b/src/nvidia_rag/rag_server/server.py
@@ -2166,7 +2166,8 @@ async def vector_store_search(
             "content": {
                 "application/json": {
                     "example": {
-                        "message": "Invalid timeout value. Timeout must be a non-negative integer.",
+                        "message": "Invalid timeout value. Timeout must be a positive integer.",
+                        "status": "FAILED",
                         "error": "Provided timeout value: -1",
                     }
                 }
@@ -2224,14 +2225,16 @@ async def get_summary(
 ) -> JSONResponse:
     "Retrieve document summary from the collection. Fetches pre-generated summaries with support for both blocking and non-blocking modes."
 
-    # Convert float timeout to int and validate to avoid negative values
+    from nvidia_rag.rag_server.validation import (
+        invalid_summary_timeout_response,
+        is_invalid_summary_timeout,
+    )
+
+    # Convert float timeout to int and validate positive values
     timeout = int(timeout)
-    if timeout < 0:
+    if is_invalid_summary_timeout(timeout):
         return JSONResponse(
-            content={
-                "message": "Invalid timeout value. Timeout must be a non-negative integer.",
-                "error": f"Provided timeout value: {timeout}",
-            },
+            content=invalid_summary_timeout_response(timeout),
             status_code=ErrorCodeMapping.BAD_REQUEST,
         )
 

--- a/src/nvidia_rag/rag_server/validation.py
+++ b/src/nvidia_rag/rag_server/validation.py
@@ -162,3 +162,22 @@ def validate_vdb_top_k(vdb_top_k: int) -> int:
             f"The /v1/generate and /v1/search request schemas enforce the same upper bound."
         )
     return vdb_top_k
+
+
+SUMMARY_TIMEOUT_INVALID_MESSAGE = (
+    "Invalid timeout value. Timeout must be a positive integer."
+)
+
+
+def invalid_summary_timeout_response(timeout: int) -> dict[str, str]:
+    """Build the standard FAILED response for invalid get_summary timeout values."""
+    return {
+        "message": SUMMARY_TIMEOUT_INVALID_MESSAGE,
+        "status": "FAILED",
+        "error": f"Provided timeout value: {timeout}",
+    }
+
+
+def is_invalid_summary_timeout(timeout: int) -> bool:
+    """Return True when timeout is zero or negative."""
+    return timeout <= 0

--- a/tests/unit/test_rag_server/test_rag_main_integration.py
+++ b/tests/unit/test_rag_server/test_rag_main_integration.py
@@ -384,6 +384,24 @@ class TestNvidiaRAGGetSummaryWorking:
                 timeout=600,
             )
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("timeout", [-3, 0])
+    async def test_get_summary_rejects_invalid_timeout(self, timeout):
+        """Test get_summary returns FAILED for non-positive timeout values."""
+        rag = NvidiaRAG()
+
+        with patch("nvidia_rag.rag_server.main.retrieve_summary") as mock_retrieve:
+            result = await rag.get_summary(
+                "test_collection", "test_document", timeout=timeout
+            )
+
+        assert result["status"] == "FAILED"
+        assert result["message"] == (
+            "Invalid timeout value. Timeout must be a positive integer."
+        )
+        assert result["error"] == f"Provided timeout value: {timeout}"
+        mock_retrieve.assert_not_called()
+
 
 class TestNvidiaRAGPrivateMethodsWorking:
     """Working test cases for private methods in NvidiaRAG class."""

--- a/tests/unit/test_rag_server/test_summary_endpoint.py
+++ b/tests/unit/test_rag_server/test_summary_endpoint.py
@@ -175,22 +175,24 @@ class TestSummaryEndpointTimeoutValidation:
         response_data = response.json()
         assert "message" in response_data
         assert "Invalid timeout value" in response_data["message"]
-        assert "non-negative integer" in response_data["message"]
+        assert "positive integer" in response_data["message"]
+        assert response_data["status"] == "FAILED"
         assert "error" in response_data
         assert response_data["error"] == "Provided timeout value: -1"
 
-    def test_zero_timeout_is_valid(self, client, valid_summary_params):
-        """Test that zero timeout is valid (edge case)"""
-        mock_nvidia_rag_summary.set_get_summary_success()
-
+    def test_zero_timeout_returns_400(self, client, valid_summary_params):
+        """Test that zero timeout values return 400 Bad Request"""
         params = valid_summary_params.copy()
         params["timeout"] = 0
 
         response = client.get("/v1/summary", params=params)
 
-        assert response.status_code == ErrorCodeMapping.SUCCESS
+        assert response.status_code == ErrorCodeMapping.BAD_REQUEST
         response_data = response.json()
-        assert response_data["status"] == "SUCCESS"
+        assert "Invalid timeout value" in response_data["message"]
+        assert "positive integer" in response_data["message"]
+        assert response_data["status"] == "FAILED"
+        assert response_data["error"] == "Provided timeout value: 0"
 
     def test_default_timeout_is_valid(self, client, valid_summary_params):
         """Test that default timeout (300) is valid"""


### PR DESCRIPTION
## Summary

- Reject zero and negative `timeout` values in `NvidiaRAG.get_summary()` (library mode) and the `/v1/summary` HTTP endpoint.
- Return `status: FAILED` with message: `Invalid timeout value. Timeout must be a positive integer.`
- Add shared validation helpers in `validation.py` and unit tests for library and API paths.

## NVBugs

- **6035874** — [RAG BP][main] [Library] Negative timeout value doesn't throw any error for getSummary api
- Cloned from **5504607** (Swagger/API variant)

## Test plan

- [x] `tests/unit/test_rag_server/test_summary_endpoint.py::TestSummaryEndpointTimeoutValidation` — negative and zero timeout return 400 + FAILED
- [x] `tests/unit/test_rag_server/test_rag_main_integration.py::TestNvidiaRAGGetSummaryWorking::test_get_summary_rejects_invalid_timeout` — library path for `timeout` in `{-3, 0}`
- [ ] Full unit suite: `uv run pytest tests/unit/test_rag_server/test_summary_endpoint.py tests/unit/test_rag_server/test_rag_main_integration.py -q`