### PR TITLE
feat(ci): enable copy-pr-bot for automated PR mirroring

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,0 +1,14 @@
+# copy-pr-bot configuration for NVIDIA-AI-Blueprints/rag
+# Docs: https://docs.gha-runners.nvidia.com/platform/apps/copy-pr-bot/
+#
+# All NVIDIA org members with write access are auto-trusted and auto-vetters.
+# No individual names needed — scales to any number of contributors.
+# Commit signing required for trusted-change classification.
+# See: https://docs.github.com/en/authentication/managing-commit-signature-verification
+#
+# Only add to additional_vetters if someone needs vetting rights
+# but has read-only repo access (rare for internal repos).
+
+enabled: true
+auto_sync_draft: false
+auto_sync_ready: true


### PR DESCRIPTION
Activates copy-pr-bot on NVIDIA-AI-Blueprints/rag. All NVIDIA org members with write access are auto-trusted — no individual names needed. Requires signed commits for trusted-change classification.

Must be on the default branch (main) per copy-pr-bot requirements. The skill eval workflows (skills-eval.yml) live on develop where PRs are based.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.