### PR TITLE
agentic-bugfix: NVBug 6189901

### DIFF
--- a/tests/unit/test_utils/test_vdb/test_elastic_vdb.py
+++ b/tests/unit/test_utils/test_vdb/test_elastic_vdb.py
@@ -24,12 +24,11 @@ import pandas as pd
 import pytest
 import requests
 from langchain_core.documents import Document
-from opentelemetry import context as otel_context
-from pydantic import SecretStr
-
 from nvidia_rag.rag_server.response_generator import APIError, ErrorCodeMapping
 from nvidia_rag.utils.vdb.elasticsearch import es_queries
 from nvidia_rag.utils.vdb.elasticsearch.elastic_vdb import ElasticVDB
+from opentelemetry import context as otel_context
+from pydantic import SecretStr
 
 
 class TestElasticVDB(unittest.TestCase):
@@ -1399,7 +1398,9 @@ class TestElasticVDB(unittest.TestCase):
     @patch("nvidia_rag.utils.vdb.elasticsearch.elastic_vdb.ElasticsearchStore")
     @patch("nvidia_rag.utils.vdb.elasticsearch.elastic_vdb.time")
     @patch("nvidia_rag.utils.vdb.elasticsearch.elastic_vdb.otel_context")
-    @patch("nvidia_rag.utils.vdb.elasticsearch.elastic_vdb.get_weighted_hybrid_custom_query")
+    @patch(
+        "nvidia_rag.utils.vdb.elasticsearch.elastic_vdb.get_weighted_hybrid_custom_query"
+    )
     def test_retrieval_langchain_hybrid_weighted_ranker(
         self,
         mock_custom_query,
@@ -1650,7 +1651,9 @@ class TestElasticVDB(unittest.TestCase):
             },
         )
         mock_vectorstore = Mock()
-        mock_vectorstore.similarity_search_by_vector_with_relevance_scores.return_value = [(top_doc, 0.9)]
+        mock_vectorstore.similarity_search_by_vector_with_relevance_scores.return_value = [
+            (top_doc, 0.9)
+        ]
 
         # Chunks returned by the page-level filter query
         page_chunk1 = Document(
@@ -1729,7 +1732,9 @@ class TestElasticVDB(unittest.TestCase):
             },
         )
         mock_vectorstore = Mock()
-        mock_vectorstore.similarity_search_by_vector_with_relevance_scores.return_value = [(top_doc, 0.9)]
+        mock_vectorstore.similarity_search_by_vector_with_relevance_scores.return_value = [
+            (top_doc, 0.9)
+        ]
 
         captured = {}
 
@@ -1780,7 +1785,9 @@ class TestElasticVDB(unittest.TestCase):
             },
         )
         mock_vectorstore = Mock()
-        mock_vectorstore.similarity_search_by_vector_with_relevance_scores.return_value = [(top_doc, 0.9)]
+        mock_vectorstore.similarity_search_by_vector_with_relevance_scores.return_value = [
+            (top_doc, 0.9)
+        ]
 
         captured = {}
 
@@ -1901,7 +1908,9 @@ class TestElasticVDB(unittest.TestCase):
             metadata={"source": {}, "content_metadata": {}},
         )
         mock_vectorstore = Mock()
-        mock_vectorstore.similarity_search_by_vector_with_relevance_scores.return_value = [(bad_doc, 0.9)]
+        mock_vectorstore.similarity_search_by_vector_with_relevance_scores.return_value = [
+            (bad_doc, 0.9)
+        ]
 
         result = elastic_vdb.retrieval_image_langchain(
             query="img",
@@ -1949,6 +1958,117 @@ class TestElasticVDB(unittest.TestCase):
 
         # ElasticsearchStore must have been constructed (via get_langchain_vectorstore)
         mock_es_store_class.assert_called_once()
+
+
+class TestElasticVDBIndexNameNormalization(unittest.TestCase):
+    """Regression tests for NVBug 6189901 / PR #572 — Elasticsearch index
+    names containing uppercase characters previously caused
+    ``BadRequestError(400, 'invalid_index_name_exception', 'Invalid index
+    name [<Name>], must be lowercase')``. The fix routes every entry point
+    through ``ElasticVDB._normalize_index_name``.
+    """
+
+    def test_normalize_index_name_uppercase(self):
+        """Uppercase name from the original bug report is lowercased."""
+        self.assertEqual(
+            ElasticVDB._normalize_index_name("BulkIngestion"), "bulkingestion"
+        )
+
+    def test_normalize_index_name_all_caps(self):
+        """All-caps name is lowercased."""
+        self.assertEqual(ElasticVDB._normalize_index_name("ALLCAPS"), "allcaps")
+
+    def test_normalize_index_name_already_lowercase(self):
+        """Already-lowercase name is returned unchanged (idempotent)."""
+        self.assertEqual(
+            ElasticVDB._normalize_index_name("already_lower"), "already_lower"
+        )
+
+    def test_normalize_index_name_mixed_with_digits_and_underscore(self):
+        """Digits and underscores are preserved; only letter case is changed."""
+        self.assertEqual(
+            ElasticVDB._normalize_index_name("Test123_Collection"),
+            "test123_collection",
+        )
+
+    def test_normalize_index_name_none_is_passthrough(self):
+        """``None`` is returned unchanged so bypass_validation paths still work."""
+        self.assertIsNone(ElasticVDB._normalize_index_name(None))
+
+    def test_normalize_index_name_empty_string_is_passthrough(self):
+        """Empty string is returned unchanged (mirrors the ``None`` contract)."""
+        self.assertEqual(ElasticVDB._normalize_index_name(""), "")
+
+    def test_normalize_index_name_is_idempotent(self):
+        """Applying the helper twice yields the same canonical form."""
+        once = ElasticVDB._normalize_index_name("MiXeD_CaSe")
+        twice = ElasticVDB._normalize_index_name(once)
+        self.assertEqual(once, twice)
+        self.assertEqual(once, "mixed_case")
+
+    @patch("nvidia_rag.utils.vdb.elasticsearch.elastic_vdb.Elasticsearch")
+    @patch("nvidia_rag.utils.vdb.elasticsearch.elastic_vdb.VectorStore")
+    def test_constructor_normalizes_index_name(
+        self, mock_vector_store, mock_elasticsearch
+    ):
+        """Constructor stores ``self.index_name`` as the lowercase form so
+        every later operation references the same canonical index that
+        Elasticsearch actually creates.
+        """
+        mock_config = Mock()
+        mock_config.embeddings.dimensions = 768
+        mock_config.vector_store.api_key = None
+        mock_config.vector_store.api_key_id = ""
+        mock_config.vector_store.api_key_secret = None
+        mock_config.vector_store.username = ""
+        mock_config.vector_store.password = None
+        mock_config.vector_store.enable_gpu_index = False
+
+        mock_es_connection = Mock()
+        mock_es_connection.options.return_value = mock_es_connection
+        mock_elasticsearch.return_value = mock_es_connection
+        mock_vector_store.return_value = Mock()
+
+        vdb = ElasticVDB(
+            index_name="BulkIngestion",
+            es_url="http://localhost:9200",
+            config=mock_config,
+        )
+
+        self.assertEqual(vdb.index_name, "bulkingestion")
+        self.assertEqual(vdb.collection_name, "bulkingestion")
+
+    @patch("nvidia_rag.utils.vdb.elasticsearch.elastic_vdb.Elasticsearch")
+    @patch("nvidia_rag.utils.vdb.elasticsearch.elastic_vdb.VectorStore")
+    def test_collection_name_setter_normalizes(
+        self, mock_vector_store, mock_elasticsearch
+    ):
+        """Assigning a mixed-case name through the ``collection_name`` setter
+        also routes through normalization.
+        """
+        mock_config = Mock()
+        mock_config.embeddings.dimensions = 768
+        mock_config.vector_store.api_key = None
+        mock_config.vector_store.api_key_id = ""
+        mock_config.vector_store.api_key_secret = None
+        mock_config.vector_store.username = ""
+        mock_config.vector_store.password = None
+        mock_config.vector_store.enable_gpu_index = False
+
+        mock_es_connection = Mock()
+        mock_es_connection.options.return_value = mock_es_connection
+        mock_elasticsearch.return_value = mock_es_connection
+        mock_vector_store.return_value = Mock()
+
+        vdb = ElasticVDB(
+            index_name="initial_lower",
+            es_url="http://localhost:9200",
+            config=mock_config,
+        )
+        vdb.collection_name = "ResetWithCaps"
+
+        self.assertEqual(vdb.index_name, "resetwithcaps")
+        self.assertEqual(vdb.collection_name, "resetwithcaps")
 
 
 class TestEsQueries(unittest.TestCase):


### PR DESCRIPTION
Auto-generated by **agentic-bugfix** for NVBug `6189901`.

- Source branch: `bugfix/nvbug-6189901-20260520-111858`
- Target branch: `develop`
- Bug ID: `6189901`
- Commit author: `agentic-bug-fix`

<details><summary><strong>Full agent report</strong></summary>

# Bug Fix Report — NVBug 6189901

**Track:** A (Verified Fix)
**Status:** VERIFIED — fix already present in branch; regression tests added on top
**Bug ID:** NVBug 6189901 — `[RAG BP][v2.6.0][RC1] Uppercase letter in collection_name is not allowed with elasticsearch vdb`
**Repo / Branch:** `NVIDIA-AI-Blueprints/rag` @ `bugfix/nvbug-6189901-20260520-111858` (up to date with `origin/develop`)
**Date:** 2026-05-20
**Run flags:** `--no-nvbugs-update --skills-path skill-source/.agents/skills --instructions "Use NVIDIA-Hosted (Cloud) docker deployment and for deploy skills check the skill-source folder for skills path"`
**NVBug comment update:** SKIPPED per `--no-nvbugs-update`

---

## 1. Summary

NVBug 6189901 reports that creating an ES-backed RAG collection with an uppercase name (e.g. `BulkIngestion`) fails with:

> `elasticsearch.BadRequestError: BadRequestError(400, 'invalid_index_name_exception', 'Invalid index name [BulkIngestion], must be lowercase')`

The root-cause fix — **PR #572 / commit `c941736` (`fix(es-vdb): lowercase collection names for Elasticsearch`)** — was already merged into `develop` on 2026-05-19, before this bugfix branch (`bugfix/nvbug-6189901-20260520-111858`, cut on 2026-05-20) was created. The fix is in the working tree.

Live reproduction against an NVIDIA-Hosted (Cloud) Docker deployment confirms the fix works end-to-end: `POST /v1/collection` with `BulkIngestion` returns `200 OK`, and the underlying ES index is created as `bulkingestion`. List/delete operations route through the same normalization helper, so the user-visible name is consistently lowercased.

The only delta this run introduces is **a new regression-test class** (`TestElasticVDBIndexNameNormalization`, 9 tests) that directly exercises `ElasticVDB._normalize_index_name` plus the constructor and `collection_name` setter. Phase 6 Expert Review (R5) flagged the absence of these tests as a blocker.

### 1.5 User instructions (`--instructions`)
> *Use NVIDIA-Hosted (Cloud) docker deployment and for deploy skills check the skill-source folder for skills path*

Honored — deployment used `deploy/compose/nvdev.env` + cloud NIM endpoints (no local NIMs), and bootstrap consulted `skill-source/.agents/skills/rag-blueprint/` (`rag-blueprint` SKILL.md → `references/deploy/docker-nvidia-hosted.md`).

---

## 2. Reproduction — Track A

### 2.1 Setup
- Default deployment route was NVIDIA-Hosted Cloud Docker (per user instruction).
- Sourced `deploy/compose/nvdev.env`; exported `NGC_API_KEY` from `NVIDIA_API_KEY`.
- `docker login nvcr.io` succeeded.
- Brought up: `vectordb.yaml` (elasticsearch + seaweedfs), `docker-compose-ingestor-server.yaml` (ingestor + nv-ingest + redis), `docker-compose-rag-server.yaml` (rag-server + rag-frontend). All healthy.
- `APP_VECTORSTORE_NAME` default = `elasticsearch` (confirmed at `deploy/compose/docker-compose-*.yaml:39-40` and `src/nvidia_rag/utils/configuration.py:43`).

### 2.2 Attempt 1 — outcome
Issued the failing case from the bug description:

```bash
curl -s -X POST 'http://localhost:8082/v1/collection' \
  -H 'Content-Type: application/json' \
  -d '{"collection_name": "BulkIngestion", "embedding_dimension": 2048, "metadata_schema": []}'
```

Response — `200 OK`:

```json
{"message":"Collection BulkIngestion created successfully.","collection_name":"BulkIngestion"}
```

Ingestor log (verbatim):

```
INFO:nvidia_rag.ingestor_server.main:Creating collection BulkIngestion
INFO:nvidia_rag.utils.vdb.elasticsearch.elastic_vdb:Normalizing collection name 'BulkIngestion' to lowercase 'bulkingestion' for Elasticsearch (uppercase letters are not permitted in index names)
INFO:nvidia_rag.utils.vdb.elasticsearch.elastic_vdb:Metadata schema added to the ES index bulkingestion. …
INFO:     172.18.0.1:44812 - "POST /v1/collection HTTP/1.1" 200 OK
```

ES indices after the create:

```
yellow open bulkingestion   …
yellow open metadata_schema …
yellow open document_info   …
```

**Classification:** `no error observed` — the original failure no longer reproduces. The skill's Gap Analysis treats this as a non-trivial outcome.

### 2.3 Gap Analysis (single specific blocker)
> *Attempt 1 hit `no error observed` because the fix from PR #572 (commit `c941736`) was already merged into both `develop` and this bugfix branch before the skill was invoked. The bug, as originally reported, is no longer reachable from this codebase. There is no remaining defect to reproduce.*

User was asked (`AskUserQuestion`) how to proceed — declined to answer. Skill defaulted to **verification path**: confirm the fix is comprehensive, run automated tests, and report.

### 2.4 Supplementary live verification (still Attempt 1)
To confirm the fix covers more than just `create`:

| Operation | Input | Outcome |
|---|---|---|
| `POST /v1/collection` (`BulkIngestion`) | uppercase | 200 OK, ES index `bulkingestion` |
| `POST /v1/collection` (`ALLCAPS`) | all-caps | 200 OK, ES index `allcaps` |
| `GET /v1/collections` | — | Returns normalized lowercase names (`bulkingestion`, `allcaps`) |
| `DELETE /v1/collections` with `["BulkIngestion","ALLCAPS"]` | mixed-case | `successful: ["bulkingestion","allcaps"]` |
| ES `/_cat/indices` post-delete | — | both indices removed |

Fix is consistent across `create / list / delete`.

### 2.7 NVBug content retrieved
- **Title:** `[RAG BP][v2.6.0][RC1] Uppercase letter in collection_name is not allowed with elasticsearch vdb`
- **Severity:** 3 – Functionality • **DaysOpen:** 2
- **Description:** Verbatim stack trace from `elasticsearch.BadRequestError(400, 'invalid_index_name_exception', 'Invalid index name [BulkIngestion], must be lowercase')` at `nvidia_rag/ingestor_server/main.py:1300` → `nvidia_rag/utils/vdb/elasticsearch/elastic_vdb.py:479 _create_index_if_not_exists`.
- **Comments:** *“Fixed in following PR: https://github.com/NVIDIA-AI-Blueprints/rag/pull/572”*.
- **Attachments:** none.

---

## 3. Root cause

Elasticsearch rejects index names containing uppercase letters with `invalid_index_name_exception` (HTTP 400). The ES VDB module (`src/nvidia_rag/utils/vdb/elasticsearch/elastic_vdb.py`) passed `collection_name` through to ES unchanged. Any mixed-case name therefore failed at `es_store._create_index_if_not_exists()`.

Secondary issue: in `src/nvidia_rag/ingestor_server/main.py`, the dedup short-circuit on collection re-create used `get_collection().return_value` string-matching against the raw input — a second POST with the same mixed-case name would bypass the already-exists branch and double-write metadata/document-info entries on top of the existing (normalized) index.

---

## 4. Fix (already merged — PR #572, commit `c941736`)

**Files in the upstream fix:**

| File | Change |
|---|---|
| `src/nvidia_rag/utils/vdb/elasticsearch/elastic_vdb.py` | +`_normalize_index_name(name)` @ L238 (static, returns `name.lower()` or passthrough for `None` / `""`). Called from `__init__` (L136), `collection_name` setter (L261), `_check_index_exists` (L293), and all 15+ public operations: `create_collection`, `check_collection_exists`, `delete_collections`, `get_documents`, `delete_documents`, `add_metadata_schema`, `get_metadata_schema`, `add_document_info`, `get_document_info`, `get_all_document_info`, `retrieval_langchain`, `get_chunks`, `hybrid_retrieval`, `get_langchain_vectorstore`. |
| `src/nvidia_rag/ingestor_server/main.py` | Dedup short-circuit @ L1308 switched from raw `get_collection()` string-match to `vdb_op.check_collection_exists(collection_name)`, which routes through `_normalize_index_name`. |

**This run's only change** is new test coverage:

| File | Change | Lines |
|---|---|---|
| `tests/unit/test_utils/test_vdb/test_elastic_vdb.py` | + new class `TestElasticVDBIndexNameNormalization` with 9 regression tests; ruff `--fix` + `format` applied to the whole file (import-sort + line-length reformat). | +128, -8 |

### 4.1 Why these tests
Before this run, the only ES uppercase-related coverage was indirect (via mocked `check_collection_exists` in `tests/unit/test_ingestor_server/test_ingestor_library.py` etc.). `_normalize_index_name` itself had no direct unit. A future refactor of the helper could silently re-introduce NVBug 6189901; Phase 6 Expert Review (R5) flagged that as a blocker. The new tests exercise:

1. The original failing input `"BulkIngestion"` → `"bulkingestion"`.
2. All-caps input.
3. Idempotency on already-lowercase input.
4. Mixed alphanumeric + underscore input.
5. `None` passthrough (preserves `bypass_validation` style paths).
6. Empty-string passthrough.
7. Double-application invariance.
8. Constructor lowercases `index_name` (so subsequent operations are consistent).
9. `collection_name` setter routes through normalization.

---

## 5. Validation

| Validation | Command | Result |
|---|---|---|
| E2E (live) | curl `POST /v1/collection`, `GET /v1/collections`, `DELETE /v1/collections` against running ingestor on port 8082 with NVIDIA-Hosted NIMs | **PASS** — 200 OK for `BulkIngestion`, `ALLCAPS`; ES indices created/deleted as expected (§2.4) |
| Unit — new class | `pytest tests/unit/test_utils/test_vdb/test_elastic_vdb.py::TestElasticVDBIndexNameNormalization` | **9 passed** |
| Unit — full ES VDB suite | `pytest tests/unit/test_utils/test_vdb/test_elastic_vdb.py` | **61 passed** (52 pre-existing + 9 new) |
| Unit — ingestor changes from PR #572 | `pytest tests/unit/test_ingestor_server/test_ingestor_library.py tests/unit/test_ingestor_server/test_ingestor_main_document_operations.py tests/unit/test_ingestor_server/test_system_managed_fields_integration.py` | **78 passed, 1 failed** (pre-existing — see §5.1) |
| Lint | `ruff check tests/unit/test_utils/test_vdb/test_elastic_vdb.py` | clean |
| Format | `ruff format --check tests/unit/test_utils/test_vdb/test_elastic_vdb.py` | clean |

### 5.1 Known pre-existing failures (not caused by this run)
- `tests/unit/test_ingestor_server/test_ingestor_library.py::test_validate_directory_traversal_attack_success`: depends on a relative path `../rag/data/multimodal/woods_frost.docx` that the test environment cannot resolve. Verified by checking out `c941736^` and running the same test — it also fails on the parent commit, so this failure is **unrelated to NVBug 6189901 or PR #572**.
- `src/nvidia_rag/ingestor_server/main.py:177` `F821 Undefined name 'NemoRetrieverHandler'` (string-literal forward reference) and a pre-existing format drift in `elastic_vdb.py` / `ingestor_server/main.py` also exist on the parent commit — **unrelated**.

---

## 6. Files Changed (this run)

```
tests/unit/test_utils/test_vdb/test_elastic_vdb.py  | 136 +++++++++++++++++++--
1 file changed, 128 insertions(+), 8 deletions(-)
```

No `src/` changes. No deployment/config changes. No deletions.

### 6.5 Expert Review — Phase 6 verdicts

| Reviewer | Lens | Cycle 1 | Cycle 2 | Notes |
|---|---|---|---|---|
| R1 | Root-cause linkage | **PASS** | — | `_normalize_index_name` called at every read/write entry point in `elastic_vdb.py`; no bypass paths. |
| R2 | Coding conventions | **PASS** | — | Type hints present, naming consistent with module (`_check_index_exists`, `_get_es_store`, etc.), docstrings in module style, 88-char compliant. |
| R3 | Generic code quality | **MAJOR** (advisory) | **carried** | R3 noted that `check_collection_exists` (L541) and `delete_collections` (L588) call `_normalize_index_name` and then delegate to `_check_index_exists` (L293) which normalizes *again*. Idempotent and harmless, but redundant. Not blocking — the helper is a pure 2-line `.lower()` call and the double-application is invariant. **Not addressed in this run** (would require code change inside the already-merged fix; out of bug-fix scope). Recommend a follow-up cleanup PR if a maintainer wants to remove the redundancy. |
| R4 | Scope discipline | **PASS** | — | PR #572 touches only ES paths + 3 test files; Milvus / LanceDB untouched (correct — Milvus allows uppercase). |
| R5 | Test adequacy | **BLOCKER** (no direct unit for `_normalize_index_name`) | **PASS** after new tests added | Closed by `TestElasticVDBIndexNameNormalization` (9 tests). |

**Cycles used:** 2 of 3 (R5 BLOCKER → Phase 3 → Phase 4 → Phase 5 → Phase 6 → PASS).

---

## 7. Risk

- Behaviour-changing for users that depended on case-sensitive collection retrieval — there is none. Pre-fix, any uppercase write *failed* and any lookup that included a creation step also failed. The fix transparently lowercases; existing lowercase collections continue to function unchanged.
- ES does *not* enforce other invalid-name rules beyond what the existing validator chain catches (e.g. names beginning with `-`, `_`, `+`, or being `.` / `..`, or containing `*`, `\\`, `<`, `>`, `?`, `|`, `,`, `"`, `/`). Out of scope for NVBug 6189901, but worth a follow-up if not already caught upstream of the VDB module.

---

## 8. Next Steps for the User

1. Decide whether to merge the new test class into `develop` / cherry-pick into `release-2.6.0` (it is a strict additive change and validates the already-shipped fix).
2. Optional: address R3's double-normalization redundancy in a follow-up cleanup PR (no behavioural change, just removing a `self._normalize_index_name(...)` wrapper from `check_collection_exists` / `delete_collections` because `_check_index_exists` already normalizes).
3. Optional: extend validation to other ES-illegal characters at the VDB boundary if input-validation is desired at that layer.

---

## 9. Incidental findings

- `tests/unit/test_ingestor_server/test_ingestor_library.py::test_validate_directory_traversal_attack_success` is environment-fragile (relies on cwd having a sibling `../rag/data/multimodal/woods_frost.docx`). Not caused by NVBug 6189901; worth a separate ticket.
- `F821 NemoRetrieverHandler` in `src/nvidia_rag/ingestor_server/main.py:177` is a string-literal forward reference; ruff's pyflakes can't see through it. Pre-existing.

---

## 10. Audit trail

- Phase 1 — Setup invoked via `skill-source/.agents/skills/rag-blueprint/references/deploy/docker-nvidia-hosted.md`; Track 1B infrastructure scout dispatched as `explore` subagent; Track 1C NVBug content fetched via `scripts/maas/nvbugs_mcp.py get-bug-details --bug-id 6189901 --include-attachments`.
- Phase 6 — 5 reviewer subagents (R1–R5) dispatched in parallel; R5 re-dispatched in cycle 2 after new tests were added.
- NVBug update: **skipped** (`--no-nvbugs-update`).

</details>
