### PR TITLE
agentic-bugfix: NVBug 6190173

### DIFF
--- a/frontend/src/hooks/__tests__/useSubmitNewCollection.test.tsx
+++ b/frontend/src/hooks/__tests__/useSubmitNewCollection.test.tsx
@@ -1,0 +1,213 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+const mockShowToast = vi.fn();
+vi.mock('../../store/useToastStore', () => ({
+  useToastStore: () => ({ showToast: mockShowToast }),
+}));
+
+const mockAddTaskNotification = vi.fn();
+vi.mock('../../store/useNotificationStore', () => ({
+  useNotificationStore: () => ({ addTaskNotification: mockAddTaskNotification }),
+}));
+
+const mockSetIsLoading = vi.fn();
+const mockSetUploadComplete = vi.fn();
+const mockSetError = vi.fn();
+const mockReset = vi.fn();
+
+interface NewCollectionStoreState {
+  collectionName: string;
+  metadataSchema: unknown[];
+  fileMetadata: Record<string, unknown>;
+  selectedFiles: File[];
+  catalogMetadata: { tags: string[]; description?: string; owner?: string; created_by?: string; business_domain?: string; status?: string };
+  collectionConfig: { generateSummary: boolean };
+  setIsLoading: typeof mockSetIsLoading;
+  setUploadComplete: typeof mockSetUploadComplete;
+  setError: typeof mockSetError;
+  reset: typeof mockReset;
+}
+
+const newCollectionState: NewCollectionStoreState = {
+  collectionName: 'test-collection',
+  metadataSchema: [],
+  fileMetadata: {},
+  selectedFiles: [new File(['hello'], 'test.txt', { type: 'text/plain' })],
+  catalogMetadata: { tags: [] },
+  collectionConfig: { generateSummary: false },
+  setIsLoading: mockSetIsLoading,
+  setUploadComplete: mockSetUploadComplete,
+  setError: mockSetError,
+  reset: mockReset,
+};
+
+vi.mock('../../store/useNewCollectionStore', () => ({
+  useNewCollectionStore: () => newCollectionState,
+}));
+
+vi.mock('../../store/useSettingsStore', () => ({
+  useSettingsStore: () => ({ vdbEndpoint: '' }),
+}));
+
+vi.mock('../../components/notifications/NotificationBell', () => ({
+  openNotificationPanel: vi.fn(),
+}));
+
+import { useSubmitNewCollection } from '../useSubmitNewCollection';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useSubmitNewCollection — error notification surfacing', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchSpy = vi.spyOn(global, 'fetch');
+    newCollectionState.selectedFiles = [new File(['hello'], 'test.txt', { type: 'text/plain' })];
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows a toast when collection creation returns HTTP 503 (Elasticsearch unavailable)', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: async () => ({
+        message:
+          'Vector database (Elasticsearch) is unavailable at http://elasticsearch:9200. Please verify Elasticsearch is running and accessible.',
+      }),
+    } as Response);
+
+    const { result } = renderHook(() => useSubmitNewCollection(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(mockShowToast).toHaveBeenCalledWith(
+      'Vector database (Elasticsearch) is unavailable at http://elasticsearch:9200. Please verify Elasticsearch is running and accessible.',
+      'error',
+    );
+    expect(mockSetError).toHaveBeenCalledWith(
+      'Vector database (Elasticsearch) is unavailable at http://elasticsearch:9200. Please verify Elasticsearch is running and accessible.',
+    );
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('shows a toast with the Pydantic detail message stripped of "Value error, " on HTTP 422', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      json: async () => ({
+        detail: [{ msg: 'Value error, Collection name must be lowercase', type: 'value_error', loc: ['body'] }],
+      }),
+    } as Response);
+
+    const { result } = renderHook(() => useSubmitNewCollection(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(mockShowToast).toHaveBeenCalledWith('Collection name must be lowercase', 'error');
+  });
+
+  it('shows a toast when document upload returns HTTP 500 after collection was created', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ message: 'Collection test-collection created successfully.' }),
+    } as Response);
+    fetchSpy.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({
+        message:
+          'Ingestion of files failed with error: Collection test-collection does not exist. Ensure a collection is created using POST /collection endpoint first.',
+      }),
+    } as Response);
+
+    const { result } = renderHook(() => useSubmitNewCollection(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.stringContaining('Collection test-collection does not exist'),
+      'error',
+    );
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('falls back to default error message when response body is not JSON', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      json: async () => {
+        throw new Error('Unexpected token < in JSON');
+      },
+    } as Response);
+
+    const { result } = renderHook(() => useSubmitNewCollection(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(mockShowToast).toHaveBeenCalledWith('Failed to create collection', 'error');
+  });
+
+  it('shows the upload "Failed to upload documents" fallback when upload response is non-JSON', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ message: 'Collection test-collection created successfully.' }),
+    } as Response);
+    fetchSpy.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      json: async () => {
+        throw new Error('Unexpected token < in JSON');
+      },
+    } as Response);
+
+    const { result } = renderHook(() => useSubmitNewCollection(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(mockShowToast).toHaveBeenCalledWith('Failed to upload documents', 'error');
+  });
+});

--- a/frontend/src/hooks/__tests__/useUploadDocuments.test.ts
+++ b/frontend/src/hooks/__tests__/useUploadDocuments.test.ts
@@ -12,6 +12,14 @@ vi.mock('../../store/useNotificationStore', () => ({
   })
 }));
 
+// Mock the toast store
+const mockShowToast = vi.fn();
+vi.mock('../../store/useToastStore', () => ({
+  useToastStore: () => ({
+    showToast: mockShowToast
+  })
+}));
+
 // Mock fetch globally
 global.fetch = vi.fn();
 
@@ -79,29 +87,158 @@ describe('useUploadDocuments', () => {
 
     const { result } = renderHook(() => useUploadDocuments());
     const onError = vi.fn();
-    
+
     // Start upload
     act(() => {
       result.current.mutate(
-        { 
-          files: [new File(['content'], 'test.txt', { type: 'text/plain' })], 
-          metadata: { collection_name: 'test-collection' } 
+        {
+          files: [new File(['content'], 'test.txt', { type: 'text/plain' })],
+          metadata: { collection_name: 'test-collection' }
         },
         { onError }
       );
     });
-    
+
     // Should be pending
     expect(result.current.isPending).toBe(true);
-    
+
     // Wait for async operation to complete
     await act(async () => {
       await new Promise(resolve => setTimeout(resolve, 0));
     });
-    
+
     // Should no longer be pending after error
     expect(result.current.isPending).toBe(false);
     expect(onError).toHaveBeenCalledWith(mockError);
+    expect(mockShowToast).toHaveBeenCalledWith('Upload failed', 'error');
+  });
+
+  it('surfaces backend message field as toast on HTTP 503 (e.g., Elasticsearch unavailable)', async () => {
+    const mockResponse = {
+      ok: false,
+      status: 503,
+      json: () => Promise.resolve({
+        message: 'Vector database (Elasticsearch) is unavailable at http://elasticsearch:9200. Please verify Elasticsearch is running and accessible.'
+      })
+    };
+    mockFetch.mockResolvedValueOnce(mockResponse);
+
+    const { result } = renderHook(() => useUploadDocuments());
+    const onError = vi.fn();
+
+    act(() => {
+      result.current.mutate(
+        {
+          files: [new File(['content'], 'test.txt', { type: 'text/plain' })],
+          metadata: { collection_name: 'test-collection' }
+        },
+        { onError }
+      );
+    });
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+
+    expect(mockShowToast).toHaveBeenCalledWith(
+      'Vector database (Elasticsearch) is unavailable at http://elasticsearch:9200. Please verify Elasticsearch is running and accessible.',
+      'error'
+    );
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0][0] as Error).message).toBe(
+      'Vector database (Elasticsearch) is unavailable at http://elasticsearch:9200. Please verify Elasticsearch is running and accessible.'
+    );
+  });
+
+  it('surfaces backend message field as toast on HTTP 500 (e.g., missing collection)', async () => {
+    const mockResponse = {
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({
+        message: 'Ingestion of files failed with error: Collection test_collection does not exist. Ensure a collection is created using POST /collection endpoint first.'
+      })
+    };
+    mockFetch.mockResolvedValueOnce(mockResponse);
+
+    const { result } = renderHook(() => useUploadDocuments());
+    const onError = vi.fn();
+
+    act(() => {
+      result.current.mutate(
+        {
+          files: [new File(['content'], 'test.txt')],
+          metadata: { collection_name: 'test_collection' }
+        },
+        { onError }
+      );
+    });
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.stringContaining('Collection test_collection does not exist'),
+      'error'
+    );
+  });
+
+  it('extracts Pydantic detail[0].msg and strips "Value error, " prefix on HTTP 422', async () => {
+    const mockResponse = {
+      ok: false,
+      status: 422,
+      json: () => Promise.resolve({
+        detail: [{ msg: "Value error, Collection name must be lowercase", type: 'value_error', loc: ['body'] }]
+      })
+    };
+    mockFetch.mockResolvedValueOnce(mockResponse);
+
+    const { result } = renderHook(() => useUploadDocuments());
+    const onError = vi.fn();
+
+    act(() => {
+      result.current.mutate(
+        {
+          files: [new File(['content'], 'test.txt')],
+          metadata: { collection_name: 'BadName' }
+        },
+        { onError }
+      );
+    });
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+
+    expect(mockShowToast).toHaveBeenCalledWith('Collection name must be lowercase', 'error');
+  });
+
+  it('falls back to default message when error response body cannot be parsed', async () => {
+    const mockResponse = {
+      ok: false,
+      status: 500,
+      json: () => Promise.reject(new Error('Not JSON'))
+    };
+    mockFetch.mockResolvedValueOnce(mockResponse);
+
+    const { result } = renderHook(() => useUploadDocuments());
+    const onError = vi.fn();
+
+    act(() => {
+      result.current.mutate(
+        {
+          files: [new File(['content'], 'test.txt')],
+          metadata: { collection_name: 'c' }
+        },
+        { onError }
+      );
+    });
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+
+    expect(mockShowToast).toHaveBeenCalledWith('Failed to upload documents', 'error');
   });
 
   it('should handle multiple concurrent uploads correctly', async () => {

--- a/frontend/src/hooks/useSubmitNewCollection.ts
+++ b/frontend/src/hooks/useSubmitNewCollection.ts
@@ -18,6 +18,7 @@ import { useNewCollectionStore } from "../store/useNewCollectionStore";
 import { useCreateCollection } from "../api/useCollectionsApi";
 import { useNotificationStore } from "../store/useNotificationStore";
 import { useSettingsStore } from "../store/useSettingsStore";
+import { useToastStore } from "../store/useToastStore";
 import { openNotificationPanel } from "../components/notifications/NotificationBell";
 import { useQueryClient } from "@tanstack/react-query";
 import type { APIMetadataField } from "../types/collections";
@@ -41,6 +42,7 @@ export function useSubmitNewCollection() {
   } = useNewCollectionStore();
 
   const { addTaskNotification } = useNotificationStore();
+  const { showToast } = useToastStore();
   const createCollection = useCreateCollection();
 
   const submit = async () => {
@@ -207,7 +209,23 @@ export function useSubmitNewCollection() {
           body: formData,
         });
 
-        if (!res.ok) throw new Error("Failed to upload documents");
+        if (!res.ok) {
+          let errorMessage = "Failed to upload documents";
+          try {
+            const errorData = await res.json();
+            if (Array.isArray(errorData.detail)) {
+              const msg = errorData.detail[0]?.msg || errorMessage;
+              errorMessage = msg.replace(/^Value error, /, "");
+            } else if (errorData.detail) {
+              errorMessage = errorData.detail;
+            } else if (errorData.message) {
+              errorMessage = errorData.message;
+            }
+          } catch {
+            // Keep default error message if parsing fails
+          }
+          throw new Error(errorMessage);
+        }
 
         const data = await res.json();
         console.log("📤 Upload response:", data);
@@ -240,7 +258,9 @@ export function useSubmitNewCollection() {
       navigate("/");
     } catch (err: unknown) {
       console.error("💥 Collection submission failed:", err);
-      setError(err instanceof Error ? err.message : "Failed to create collection");
+      const errorMessage = err instanceof Error ? err.message : "Failed to create collection";
+      setError(errorMessage);
+      showToast(errorMessage, "error");
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/hooks/useUploadDocuments.ts
+++ b/frontend/src/hooks/useUploadDocuments.ts
@@ -16,10 +16,12 @@
 import { useState } from "react";
 import { useNotificationStore } from "../store/useNotificationStore";
 import { useCollectionConfigStore } from "../store/useCollectionConfigStore";
+import { useToastStore } from "../store/useToastStore";
 
 export function useUploadDocuments() {
   const { addTaskNotification } = useNotificationStore();
   const { getConfig } = useCollectionConfigStore();
+  const { showToast } = useToastStore();
   const [isPending, setIsPending] = useState(false);
 
   const mutate = (data: { files: File[]; metadata: Record<string, unknown> }, options: { onSuccess?: (data: unknown) => void; onError?: (error: Error) => void }) => {
@@ -28,11 +30,11 @@ export function useUploadDocuments() {
     data.files.forEach((file) => {
       formData.append("documents", file);
     });
-    
+
     // Get collection-specific config for summarization setting
     const collectionName = String(data.metadata.collection_name);
     const collectionConfig = getConfig(collectionName);
-    
+
     formData.append("data", JSON.stringify({ ...data.metadata, generate_summary: collectionConfig.generateSummary }));
 
     fetch(`/api/documents?blocking=false`, {
@@ -40,9 +42,25 @@ export function useUploadDocuments() {
       body: formData,
     })
       .then(async (res) => {
-        if (!res.ok) throw new Error("Failed to upload documents");
+        if (!res.ok) {
+          let errorMessage = "Failed to upload documents";
+          try {
+            const errorData = await res.json();
+            if (Array.isArray(errorData.detail)) {
+              const msg = errorData.detail[0]?.msg || errorMessage;
+              errorMessage = msg.replace(/^Value error, /, "");
+            } else if (errorData.detail) {
+              errorMessage = errorData.detail;
+            } else if (errorData.message) {
+              errorMessage = errorData.message;
+            }
+          } catch {
+            // Keep default error message if parsing fails
+          }
+          throw new Error(errorMessage);
+        }
         const responseData = await res.json();
-        
+
         if (responseData?.task_id) {
           const taskData = {
             id: responseData.task_id,
@@ -51,13 +69,15 @@ export function useUploadDocuments() {
             state: "PENDING" as const,
             created_at: new Date().toISOString(),
           };
-          
+
           addTaskNotification(taskData);
         }
-        
+
         options.onSuccess?.(responseData);
       })
       .catch((error) => {
+        const errorMessage = error instanceof Error ? error.message : "Failed to upload documents";
+        showToast(errorMessage, "error");
         options.onError?.(error);
       })
       .finally(() => {


### PR DESCRIPTION
Auto-generated by **agentic-bugfix** for NVBug `6190173`.

- Source branch: `bugfix/nvbug-6190173-20260520-164007`
- Target branch: `develop`
- Bug ID: `6190173`
- Commit author: `smasurekar`

<details><summary><strong>Full agent report</strong></summary>

# Bug Fix Report — NVBug #6190173

- **Report generated:** 2026-05-20T17:06:37Z
- **Bug source:** NVBugs #6190173
- **Reporter / requester:** Nitesh Jain (niteshj@nvidia.com), assigned to Sumit Bhattacharya
- **Repository:** NVIDIA-AI-Blueprints/rag @ e0f57777e6ca9f8cf48ce41c5ab940493967cca0
- **Branch:** bugfix/nvbug-6190173-20260520-164007
- **Fix status:** VERIFIED (unit + lint pass; FE container rebuilt + deployed; live UI confirmation deferred — see §6)
- **Severity / Priority:** 3-Functionality / P0-Must have
- **Synopsis:** [RAG BP][v2.6.0][RC1] Frontend does not show any failure notification for some failure scenarios

## 1. Reported Symptom

> Repo: https://github.com/NVIDIA-AI-Blueprints/rag/blob/v2.6.0.rc1
>
> 1. For elastic search (default deployment) if we don't run the below commands (elastic container shows unhealthy) and if we try to create collection and upload documents then it does not show any error on UI. We can see error logs in ingestor server logs.
>    ```
>    sudo mkdir -p deploy/compose/volumes/elasticsearch/
>    sudo chown -R 1000:1000 deploy/compose/volumes/elasticsearch/
>    ```
> 2. Other scenario is like when we create collection with capital letter in it for elastic search, it gives error in logs but on UI, it does not give any failure notification.

## 1.5 Custom Instructions

**Source:** inline

**Content:**
```
Use NVIDIA-Hosted (Cloud) docker deployment and for deploy skills check the skill-source folder for skills path
```

Honored as follows:
- Active deployment during reproduction and Phase 5 validation was **NVIDIA-Hosted Cloud** — `docker ps` showed only `rag-frontend`, `rag-server`, `ingestor-server`, `compose-redis-1`, `compose-nv-ingest-ms-runtime-1`, `elasticsearch`, `seaweedfs` (no local `nim-*` containers). Compose source-of-truth was `deploy/compose/nvdev.env` (cloud endpoints at `https://integrate.api.nvidia.com/v1`).
- Skill discovery used `--skills-path skill-source/.agents/skills`. The infrastructure scout, deploy reference for the NVIDIA-Hosted mode, and shutdown / configure routing all resolved through `skill-source/.agents/skills/rag-blueprint/` rather than user-local `~/.claude/skills/`.

## 2. Reproduction & Observed Failure Signal

**Trigger used (Attempt 1, Track A):**
- POST `/v1/documents` to the live ingestor at `http://localhost:8082`, with `data={"collection_name":"nonexistent_xyz","blocking":false,"split_options":{"chunk_size":512,"chunk_overlap":150}}` and a 1-byte text file as `documents=@`.
- POST `/v1/collection` and POST `/v1/documents` to the same ingestor *after stopping the `elasticsearch` container* (`docker stop elasticsearch`) to simulate the bug's scenario 1 (ES unhealthy).
- POST `/v1/collections` with a single-element JSON array `["TestUpperCase"]` to reproduce scenario 2 (uppercase collection name).

**Environment:**
- NVIDIA RAG Blueprint @ commit `e0f5777` on branch `bugfix/nvbug-6190173-20260520-164007`.
- Docker Compose, NVIDIA-Hosted Cloud profile (`deploy/compose/nvdev.env`).
- Services running: `rag-frontend` (8090), `rag-server` (8081), `ingestor-server` (8082), `elasticsearch` (9200, default vector DB), `seaweedfs`, `compose-redis-1`, `compose-nv-ingest-ms-runtime-1`.

**NVBug content retrieved (Track 1C):**
- Description + comments: yes (1 comment from Shubhadeep Das routing to Swapnil Masurekar).
- Attachments fetched: none.
- Attachments skipped: none (NVBug has no attachments).
- Bug filed 2026-05-18; cloned from #6162913.

**Failure signal (verbatim from live system):**

```
# Scenario 1 — ES unhealthy:
$ docker stop elasticsearch
$ curl -X POST http://localhost:8082/v1/collection -d '{"collection_name":"es_down_test"}' ...
HTTP 503
{"message":"Vector database (Elasticsearch) is unavailable at http://elasticsearch:9200. Please verify Elasticsearch is running and accessible."}

$ curl -X POST http://localhost:8082/v1/documents -F documents=@... -F 'data={"collection_name":"x","blocking":false,...}'
HTTP 503
{"message":"Vector database (Elasticsearch) is unavailable at http://elasticsearch:9200. Please verify Elasticsearch is running and accessible."}

# Scenario 1b — missing collection (related backend error path):
$ curl -X POST http://localhost:8082/v1/documents -F documents=@... -F 'data={"collection_name":"nonexistent_xyz","blocking":false,...}'
HTTP 500
{"message":"Ingestion of files failed with error: Collection nonexistent_xyz does not exist. Ensure a collection is created using POST /collection endpoint first."}

# Scenario 2 — uppercase collection name (post commit c941736):
$ curl -X POST 'http://localhost:8082/v1/collections?embedding_dimension=2048' -d '["TestUpperCase"]'
HTTP 200
{"message":"Collection creation process completed.","successful":["TestUpperCase"],"failed":[],"total_success":1,"total_failed":0}
# Ingestor log:
# INFO ... Normalizing collection name 'TestUpperCase' to lowercase 'testuppercase' for Elasticsearch
# (Collection is silently renamed; in pre-c941736 builds the bug filer saw an error log here.)
```

**Layer:** app (ingestor-server `nvidia_rag.ingestor_server`) → propagated to frontend HTTP client; the bug is in the frontend's handling of these responses.

**Why this is the root signal (not a downstream re-raise):** the backend's structured error responses (`{"message": "..."}` for 500/503; `{"detail": [...]}` for 422) are the contract the frontend MUST display. The bug filer's complaint ("does not give any failure notification") is the absence of the corresponding UI surface. The frontend's `useUploadDocuments` hook threw a generic `new Error("Failed to upload documents")` regardless of the backend body and never fired a toast; `useSubmitNewCollection`'s inline upload had the same gap. The toast infrastructure (`useToastStore`, `ToastContainer`) is mounted (`App.tsx:75`) and already used elsewhere (e.g. `MessageInputContainer.tsx:33,66,71,80` for image-upload validation) — it just wasn't being called from these two flows.

## 3. Root Cause

The frontend has two collection/document write entry points — `useUploadDocuments` (used by the "Add Source" drawer in `useCollectionActions.handleUploadDocuments`) and `useSubmitNewCollection` (used by the "New Collection" wizard). Both perform `fetch('/api/documents?blocking=false', ...)`. Both treated `!res.ok` as "throw a hardcoded generic Error" without parsing the backend response body, and neither called `useToastStore.showToast` on rejection. The `Notification` block in `NewCollectionButtons.tsx:257` only renders when `useNewCollectionStore.error` is set, which is only set in `useSubmitNewCollection`'s outer `catch` — and even then it competes with the wizard's "Validation Error" heading, so structured 503/500 backend messages never reach the user as a clear notification, and the "Add Source" drawer path showed nothing at all (its `onError` only `console.error`'d).

The toast notification system that exists for image upload (`MessageInputContainer`) was not wired into these flows.

**Call chain (failing path, pre-fix):**

```
User clicks "Create Collection" or "Add Source"
  → useSubmitNewCollection.submit() / useCollectionActions.handleUploadDocuments()
    → useUploadDocuments.mutate() (or inline fetch in useSubmitNewCollection)
      → fetch('/api/documents?blocking=false', ...)
        → backend returns HTTP 503 {"message": "Vector database (Elasticsearch) is unavailable..."}
      → res.ok is false
      → throw new Error("Failed to upload documents")  ← original backend message DROPPED
    → .catch((error) => options.onError?.(error))     ← no toast fired
  → consumer's onError: console.error(...)             ← user sees nothing
```

**Contributing factors:**
- Uncommitted local changes: none (clean working tree before fix).
- Secondary bugs producing the same symptom: commit `c941736 fix(es-vdb): lowercase collection names for Elasticsearch` (merged 2026-05-19, one day before the bug was filed) silently normalizes uppercase collection names instead of returning an error — that fix removed the "error in logs" half of scenario 2 but did NOT address the bug's actual complaint, which is missing UI notification. Logged in §8.

## 4. Fix Applied

**Files changed:**

| File | Lines | Change |
|---|---|---|
| `frontend/src/hooks/useUploadDocuments.ts` | 17, 19, 41-58, 76-79 | Import `useToastStore`; parse `!res.ok` response body to extract `detail[0].msg` (with `"Value error, "` prefix stripped) / `detail` / `message` and throw with that message; call `showToast(errorMessage, "error")` in `.catch`. |
| `frontend/src/hooks/useSubmitNewCollection.ts` | 20, 46, 210-228, 261-264 | Import `useToastStore`; same error-body parsing in the inline upload `fetch`; call `showToast` alongside `setError` in the outer `catch`. |
| `frontend/src/hooks/__tests__/useUploadDocuments.test.ts` | 15-22, 84-115, 116-242 | Mock `useToastStore`; assert `showToast` is called on existing network-error test; add 4 new tests covering HTTP 503, HTTP 500, HTTP 422 Pydantic, and non-JSON response fallback. |
| `frontend/src/hooks/__tests__/useSubmitNewCollection.test.tsx` (new) | — | 5 new tests covering HTTP 503 on collection create, HTTP 422 Pydantic with `"Value error, "` prefix, HTTP 500 on upload after successful collection create, non-JSON body on collection create, non-JSON body on upload. Mocks `useNavigate`, `useToastStore`, `useNotificationStore`, `useNewCollectionStore`, `useSettingsStore`, `NotificationBell.openNotificationPanel`. |

**Diff:**

```diff
diff --git a/frontend/src/hooks/__tests__/useUploadDocuments.test.ts b/frontend/src/hooks/__tests__/useUploadDocuments.test.ts
index 4710017f..4ade0fe6 100644
--- a/frontend/src/hooks/__tests__/useUploadDocuments.test.ts
+++ b/frontend/src/hooks/__tests__/useUploadDocuments.test.ts
@@ -12,6 +12,14 @@ vi.mock('../../store/useNotificationStore', () => ({
   })
 }));

+// Mock the toast store
+const mockShowToast = vi.fn();
+vi.mock('../../store/useToastStore', () => ({
+  useToastStore: () => ({
+    showToast: mockShowToast
+  })
+}));
+
 // Mock fetch globally
 global.fetch = vi.fn();

@@ -79,28 +87,151 @@ describe('useUploadDocuments', () => {

     const { result } = renderHook(() => useUploadDocuments());
     const onError = vi.fn();
-
-    // Start upload
+    ...
     // Should no longer be pending after error
     expect(result.current.isPending).toBe(false);
     expect(onError).toHaveBeenCalledWith(mockError);
+    expect(mockShowToast).toHaveBeenCalledWith('Upload failed', 'error');
+  });
+
+  // + 4 new tests: HTTP 503, HTTP 500, HTTP 422 (Pydantic), and non-JSON fallback
   });

diff --git a/frontend/src/hooks/useSubmitNewCollection.ts b/frontend/src/hooks/useSubmitNewCollection.ts
@@ -17,6 +17,7 @@ import { useNewCollectionStore } from "../store/useNewCollectionStore";
 import { useCreateCollection } from "../api/useCollectionsApi";
 import { useNotificationStore } from "../store/useNotificationStore";
 import { useSettingsStore } from "../store/useSettingsStore";
+import { useToastStore } from "../store/useToastStore";
 import { openNotificationPanel } from "../components/notifications/NotificationBell";
@@ -43,6 +44,7 @@ export function useSubmitNewCollection() {
   const { addTaskNotification } = useNotificationStore();
+  const { showToast } = useToastStore();
   const createCollection = useCreateCollection();
@@ -208,7 +210,24 @@ export function useSubmitNewCollection() {
-        if (!res.ok) throw new Error("Failed to upload documents");
+        if (!res.ok) {
+          let errorMessage = "Failed to upload documents";
+          try {
+            const errorData = await res.json();
+            if (Array.isArray(errorData.detail)) {
+              const msg = errorData.detail[0]?.msg || errorMessage;
+              errorMessage = msg.replace(/^Value error, /, "");
+            } else if (errorData.detail) {
+              errorMessage = errorData.detail;
+            } else if (errorData.message) {
+              errorMessage = errorData.message;
+            }
+          } catch { /* keep default */ }
+          throw new Error(errorMessage);
+        }
@@ -243,3 +263,5 @@ export function useSubmitNewCollection() {
-      setError(err instanceof Error ? err.message : "Failed to create collection");
+      const errorMessage = err instanceof Error ? err.message : "Failed to create collection";
+      setError(errorMessage);
+      showToast(errorMessage, "error");

diff --git a/frontend/src/hooks/useUploadDocuments.ts b/frontend/src/hooks/useUploadDocuments.ts
@@ -16,11 +16,13 @@
 import { useState } from "react";
 import { useNotificationStore } from "../store/useNotificationStore";
 import { useCollectionConfigStore } from "../store/useCollectionConfigStore";
+import { useToastStore } from "../store/useToastStore";

 export function useUploadDocuments() {
   const { addTaskNotification } = useNotificationStore();
   const { getConfig } = useCollectionConfigStore();
+  const { showToast } = useToastStore();
@@ -40,7 +42,22 @@
       .then(async (res) => {
-        if (!res.ok) throw new Error("Failed to upload documents");
+        if (!res.ok) {
+          let errorMessage = "Failed to upload documents";
+          try {
+            const errorData = await res.json();
+            if (Array.isArray(errorData.detail)) {
+              const msg = errorData.detail[0]?.msg || errorMessage;
+              errorMessage = msg.replace(/^Value error, /, "");
+            } else if (errorData.detail) {
+              errorMessage = errorData.detail;
+            } else if (errorData.message) {
+              errorMessage = errorData.message;
+            }
+          } catch { /* keep default */ }
+          throw new Error(errorMessage);
+        }
@@ -59,6 +76,9 @@
       .catch((error) => {
+        const errorMessage = error instanceof Error ? error.message : "Failed to upload documents";
+        showToast(errorMessage, "error");
         options.onError?.(error);
       })

# Plus new file: frontend/src/hooks/__tests__/useSubmitNewCollection.test.tsx (5 tests, ~210 LOC)
```

**Why this is minimal and safe:**

- The fix is purely additive — no public API changes, no design changes (the toast store and `ToastContainer` already existed and were used by `MessageInputContainer`). Three error-parsing blocks deliberately mirror the existing `useCollectionsApi.useCreateCollection` pattern at `frontend/src/api/useCollectionsApi.ts:67-84` so behavior is uniform across all three write paths (collection create via React Query, inline upload in the wizard, hook-based upload in the drawer).
- `useCollectionActions.handleUploadDocuments` was intentionally NOT changed: it delegates to `useUploadDocuments` which now shows the toast. Adding a second `showToast` in its `onError` would double-fire on the same error.
- No backend code was touched. The backend's response shape (`{message: ...}` for 500/503, `{detail: ...}` for 422) was treated as the contract. The fix is frontend-only, matching the bug's actual symptom (UI notification absent).

## 5. Tests

- **New tests in `frontend/src/hooks/__tests__/useUploadDocuments.test.ts`** — `surfaces backend message field as toast on HTTP 503 (e.g., Elasticsearch unavailable)`, `surfaces backend message field as toast on HTTP 500 (e.g., missing collection)`, `extracts Pydantic detail[0].msg and strips "Value error, " prefix on HTTP 422`, `falls back to default message when error response body cannot be parsed`. Existing test `should set isPending to false after error` extended to assert `showToast('Upload failed', 'error')`.
- **New test file `frontend/src/hooks/__tests__/useSubmitNewCollection.test.tsx`** — `shows a toast when collection creation returns HTTP 503 (Elasticsearch unavailable)`, `shows a toast with the Pydantic detail message stripped of "Value error, " on HTTP 422`, `shows a toast when document upload returns HTTP 500 after collection was created`, `falls back to default error message when response body is not JSON`, `shows the upload "Failed to upload documents" fallback when upload response is non-JSON`.
- **Unit test run:** 751 passed, 0 failed — `pnpm test:run` from `frontend/` (up from 746 pre-fix; 5 new tests in the new file).
- **Lint:** 0 errors, 1 pre-existing warning (`CollectionDrawer.tsx:66` `react-hooks/exhaustive-deps` — unrelated to this change) — `pnpm lint`.
- **TypeScript:** clean — `pnpm exec tsc --noEmit`.

## 6. Live E2E Validation

**Replay trigger (same as Phase 1):**
- POST `/v1/documents` to the live `ingestor-server` (port 8082) through the rebuilt `rag-frontend` reverse proxy at `http://localhost:8090/api/documents`, with `collection_name=nonexistent_xyz` to force HTTP 500.
- POST `/v1/collection` and POST `/v1/documents` after `docker stop elasticsearch` to force HTTP 503.

**Observed result:**
- Backend still returns the same structured error shapes (the fix is frontend-only, by design).
- The rebuilt `rag-frontend` container serves a new JS bundle (`/assets/index-CZUbJBZ6.js`) that contains the new error-parsing strings: grep for `"Failed to upload documents"` finds 2 occurrences (one for each patched hook), and `"Value error, "` finds 2 occurrences (matching the prefix-strip regex in both hooks).
- Unit tests reproduce the failure shape in-process and assert that `showToast(<backend message>, "error")` is called — see §5.

**Evidence:**

```
$ docker stop elasticsearch
$ curl -X POST http://localhost:8090/api/documents -F documents=@/tmp/test.txt \
    -F 'data={"collection_name":"x","blocking":false,...}'
HTTP 503
{"message":"Vector database (Elasticsearch) is unavailable at http://elasticsearch:9200. Please verify Elasticsearch is running and accessible."}

$ docker start elasticsearch && sleep 5

$ JS_URL=$(curl -s http://localhost:8090 | grep -oE '/assets/[^"]*\.js' | head -1)
$ curl -s "http://localhost:8090${JS_URL}" | grep -c "Failed to upload documents"
2     # one per patched hook (useUploadDocuments + useSubmitNewCollection)
$ curl -s "http://localhost:8090${JS_URL}" | grep -o "Value error, " | wc -l
2     # one prefix-strip regex per patched hook

$ docker ps --format "table {{.Names}}\t{{.Status}}"
NAMES                            STATUS
rag-frontend                     Up <recent — post-rebuild>
rag-server                       Up <recent — post-rebuild>
ingestor-server                  Up …
elasticsearch                    Up … (healthy)
...
```

**Honest limitation — browser-driven UI assertion deferred:** this run did not have a Playwright / Selenium tool to drive the actual browser. The fix's runtime behavior is fully covered by the 10 + 5 unit tests on the hooks (which exercise the exact backend response shapes captured from the live system in Phase 1), and the rebuilt FE container ships the new code. A QA pass through the UI is recommended before closing — see §9.

## 6.5 Expert Review

**Aggregated verdict:** approve (after one re-cycle to resolve R5 blocker)
**Cycles used:** 2 of 3

| # | Reviewer | Verdict | Findings |
|---|---|---|---|
| R1 | Root-cause linkage | approve | 1 minor (information disclosure of internal hostname in backend message — backend-side cleanup, out of scope) |
| R2 | Coding conventions | approve | none |
| R3 | Generic code quality | minor | 6 non-blocking suggestions (see below) |
| R4 | Scope discipline | approve | none |
| R5 | Test adequacy | approve (cycle 1: blocker → resolved cycle 2) | 0 (blocker required tests for `useSubmitNewCollection`; resolved by new `useSubmitNewCollection.test.tsx` file) |
| R7 | Custom instructions compliance | approve | none |

**Non-blocking notes (preserved from R3; tracked for follow-up):**

- `frontend/src/hooks/useSubmitNewCollection.ts:261-263` — both `setError(...)` and `showToast(...)` fire on the new-collection wizard, producing duplicate visible feedback (inline `Notification` from `NewCollectionButtons.tsx:257` plus a toast). The toast is the more visible mechanism; consider dropping `setError` in a follow-up, or removing the inline-banner block when a toast is fired.
- `frontend/src/hooks/useUploadDocuments.ts:24` — hook now has a side-effect (toast on error) that every caller inherits implicitly. A JSDoc comment noting "fires `showToast` on error; callers should not double-toast in their own `onError`" would prevent future regressions.
- `frontend/src/store/useToastStore.ts:40-44` — 5-second auto-dismiss may be too short for backend messages of 100+ chars (the Elasticsearch one is 156 chars). Consider scaling duration with message length or disabling auto-dismiss for `status === "error"`. Pre-existing behavior; the fix amplifies it by surfacing longer messages.
- `frontend/src/hooks/useUploadDocuments.ts:55`, `frontend/src/hooks/useSubmitNewCollection.ts:222` — backend `message` field passed through verbatim. The Elasticsearch error includes the internal Docker hostname `http://elasticsearch:9200`. Information-disclosure flag for external/production users; suggest stripping URLs server-side or strip-on-display.
- `frontend/src/hooks/__tests__/useUploadDocuments.test.ts:112-113` — toast/onError ordering is not asserted; the implementation calls `showToast` before `options.onError`, which is intentional but not enforced by test.
- `frontend/src/api/useCollectionsApi.ts:67-84`, `frontend/src/hooks/useUploadDocuments.ts:45-61`, `frontend/src/hooks/useSubmitNewCollection.ts:212-228` — three near-identical error-parsing blocks. Worth extracting into a `frontend/src/utils/parseApiError.ts` helper when next touched.

## 7. Attempt Timeline

| # | Phase | Action | Outcome |
|---|---|---|---|
| 1 | Phase 1 Track 1A | Verified existing deployment healthy (NVIDIA-Hosted Cloud, no NIM containers); did not need to re-deploy from scratch — services were Up 5h | Setup baseline OK |
| 1 | Phase 1 Track 1B | Infrastructure scout — confirmed `uv run pytest`, `ruff check src/`, `pnpm test:run`, `pnpm lint`, and `docker compose up --build rag-frontend` as the verification mechanisms | Returned full toolchain map |
| 1 | Phase 1 Track 1C | Fetched NVBug 6190173 via `scripts/maas/nvbugs_mcp.py get-bug-details` (NVBugs MCP not surfaced as an MCP tool in this environment, but the helper CLI worked via service-account auth) | Description + 1 comment retrieved; no attachments |
| 1 | Phase 1 Track 1A — Repro Attempt 1 | (a) POST `/v1/collections ["TestUpperCase"]` → HTTP 200 silent normalize (post-c941736). (b) POST `/v1/documents` to nonexistent collection → HTTP 500 `{"message":"Ingestion of files failed..."}`. (c) `docker stop elasticsearch` then POST `/v1/collection`+`/v1/documents` → HTTP 503 `{"message":"Vector database (Elasticsearch) is unavailable..."}` | Failure signal CONFIRMED on first attempt — Track A engaged |
| 2 | Phase 2 | Two parallel `Explore` subagents — error-string grep across `frontend/src/` + existing-test inventory. Found the gap: `useUploadDocuments` and `useSubmitNewCollection`'s inline fetch both throw a generic Error and never call `showToast`; `useToastStore`+`ToastContainer` already exist and are used by image upload | Root cause identified |
| 3 | Phase 3 | Planned minimal fix: inline error parsing matching `useCollectionsApi`'s pattern + `showToast` in catch. No new abstraction. Deliberately skipped `useCollectionActions.handleUploadDocuments` to avoid double-toast | Plan ready |
| 4 | Phase 4 | Applied edits to `useUploadDocuments.ts`, `useSubmitNewCollection.ts`, extended `useUploadDocuments.test.ts` with 4 new error-path tests | Files modified |
| 5 | Phase 5 (cycle 1) | `pnpm test:run` → 746 passed. `pnpm lint` → 1 pre-existing warning. `pnpm exec tsc --noEmit` → clean. Rebuilt `rag-frontend` container with new code; verified new strings present in served bundle | Validation PASS |
| 6 | Phase 6 (cycle 1) | 6 reviewer subagents dispatched in parallel (R1-R5 + R7). R5 returned **blocker** — missing tests for `useSubmitNewCollection`. R3 returned minor (non-blocking). Others approved | One blocker — re-cycle |
| 3' | Phase 3 (cycle 2) | Re-planned: add new `useSubmitNewCollection.test.tsx` with 5 tests covering each error path R5 enumerated | Plan ready |
| 4' | Phase 4 (cycle 2) | Created `frontend/src/hooks/__tests__/useSubmitNewCollection.test.tsx` (~210 LOC, 5 tests). Mocked `useNavigate`, `useToastStore`, `useNotificationStore`, `useNewCollectionStore`, `useSettingsStore`, `NotificationBell.openNotificationPanel` | File added |
| 5' | Phase 5 (cycle 2) | `pnpm exec vitest run useSubmitNewCollection.test.tsx` → 5 pass. Full suite → 751 pass. Lint unchanged | Validation PASS |
| 6' | Phase 6 (cycle 2) | R5 blocker resolved by inspection (all five required cases now covered); other reviewer findings unchanged (all approve or minor non-blocking) | Aggregated verdict: approve |

## 8. Incidental Findings

- **Commit `c941736 fix(es-vdb): lowercase collection names for Elasticsearch`** (2026-05-19) — merged after this bug was filed but masks half of scenario 2: it silently lowercases user-supplied collection names rather than returning an error. The bug filer's complaint was about missing UI notification, not about the normalization itself, so this is a **separate design question** that the human owner should review: should uppercase names be rejected with a 422 (and now shown via the new toast), accepted but flagged with a notification ("Collection 'MyName' was created as 'myname'"), or silently normalized as today? Suggested severity: 4-Corruption (user creates `MyCollection`, gets `mycollection` silently, then can't find their data by the name they typed) — but out of scope for the assigned P0.
- **Other untoasted error paths in `useCollectionActions.ts`** — `deleteCollectionWithoutConfirm` (no `onError` handler at all), `handleDeleteAllDocuments.onError` (only updates task state), `useDeleteCollection` / `useDeleteAllDocuments` / `useDeleteDocument` callers — none surface a toast. The bug is scoped to "create collection / upload documents" so these were intentionally left alone, but they have the same shape of defect. Suggested follow-up: a dedicated bug or umbrella task to add toast plumbing for the delete/update flows.
- **Backend error messages leak internal Docker hostnames** — e.g., `http://elasticsearch:9200`. Surfacing these verbatim in toasts (which the fix now does) makes the leak more visible. Suggested follow-up: strip URLs in `ingestor-server`'s error response builder.
- **`useToastStore` auto-dismiss is a hardcoded 5 s** — likely too short for 100+ char backend errors. Cross-referenced in §6.5 R3 notes.
- **`frontend/src/hooks/useNewCollectionForm.ts`** — separate hook with the same legacy `throw new Error("Failed to upload documents")` shape. `Grep` finds no importers (dead code). Worth removing in a tidy-up pass.

## 9. Follow-ups for the Human

- [ ] Review and commit the fix (DCO sign-off required per CONTRIBUTING.md).
- [ ] Run a manual UI pass: (a) start FE, (b) stop `elasticsearch`, (c) try "Create Collection" + "Add Source" in the UI, (d) confirm a toast appears bottom-right with the backend's message, (e) restart `elasticsearch` and verify normal flow works.
- [ ] Decide whether commit `c941736`'s silent normalization is the desired behavior for uppercase collection names, or whether to reject + surface via the new toast (see §8).
- [ ] (Out of scope for this run, but related) Decide if delete/update flows should also toast on error.
- [ ] Open the bug-fix-report and set BugAction / Disposition on NVBug 6190173 manually — `--no-nvbugs-update` was passed so no comment was posted.

## 10. NVBugs Audit Trail

- **NVBug ID:** 6190173
- **Comment posted:** no — `--no-nvbugs-update` was passed by the user; the NVBug page remains unmodified.
- **BugAction / Disposition:** left unchanged — currently `Dev - Open - To fix` / `Open issue`. Human to set after reviewing this report.

</details>
