### PR TITLE
agentic-bugfix: NVBug 6191270

### DIFF
--- a/src/nvidia_rag/rag_server/response_generator.py
+++ b/src/nvidia_rag/rag_server/response_generator.py
@@ -37,6 +37,7 @@ from uuid import uuid4
 
 import bleach
 from langchain_core.documents import Document
+from minio.error import S3Error
 from pydantic import BaseModel, Field, validator
 from pymilvus.exceptions import MilvusException, MilvusUnavailableException
 
@@ -46,6 +47,22 @@ from nvidia_rag.utils.object_store import (
     get_unique_thumbnail_id,
 )
 from nvidia_rag.utils.observability.otel_metrics import OtelMetrics
+
+
+def _is_missing_object_error(exc: BaseException) -> bool:
+    """Return True when ``exc`` represents 'object key not present in storage'.
+
+    The intermittent ES/object-store desync described in NVBug 6191270 produces an
+    expected NoSuchKey for S3 backends (and FileNotFoundError for the filesystem
+    backend). Callers downgrade the log for this case so the noisy stack trace
+    does not mask other failures (auth, network, etc.).
+    """
+    if isinstance(exc, FileNotFoundError):
+        return True
+    if isinstance(exc, S3Error) and getattr(exc, "code", None) == "NoSuchKey":
+        return True
+    return False
+
 
 logger = logging.getLogger(__name__)
 
@@ -993,9 +1010,16 @@ def prepare_citations(
                             content_metadata=doc.metadata.get("content_metadata"),
                         )
                 except Exception as e:
-                    logger.exception(
-                        f"Error pulling content from object storage for image/table/chart for citations: {e}"
-                    )
+                    if _is_missing_object_error(e):
+                        logger.warning(
+                            "Object not found in object storage for image/table/chart "
+                            "citation; skipping citation. source_location=%s",
+                            source_location,
+                        )
+                    else:
+                        logger.exception(
+                            f"Error pulling content from object storage for image/table/chart for citations: {e}"
+                        )
                     content = ""
                     source_metadata = SourceMetadata(
                         description=doc.page_content,
@@ -1135,12 +1159,19 @@ def prepare_citations_nrl(
                     )
                     content = base64.b64encode(raw_bytes).decode("ascii")
                 except Exception as exc:
-                    logger.exception(
-                        "[Prepare Citations NRL] Failed to fetch asset from object storage"
-                        " (uri=%s): %s",
-                        stored_image_uri,
-                        exc,
-                    )
+                    if _is_missing_object_error(exc):
+                        logger.warning(
+                            "[Prepare Citations NRL] Object not found in object "
+                            "storage; skipping chunk. uri=%s",
+                            stored_image_uri,
+                        )
+                    else:
+                        logger.exception(
+                            "[Prepare Citations NRL] Failed to fetch asset from object storage"
+                            " (uri=%s): %s",
+                            stored_image_uri,
+                            exc,
+                        )
                     content = ""
             # When citations are disabled, content stays empty and the chunk
             # is skipped by the guard below, so no object-store call is made.

--- a/tests/unit/test_rag_server/test_response_generator.py
+++ b/tests/unit/test_rag_server/test_response_generator.py
@@ -20,6 +20,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from langchain_core.messages import AIMessageChunk
+from minio.error import S3Error
 from pydantic import ValidationError
 from pymilvus.exceptions import MilvusException, MilvusUnavailableException
 
@@ -46,6 +47,7 @@ from nvidia_rag.rag_server.response_generator import (
     generate_answer,
     generate_answer_async,
     prepare_citations,
+    prepare_citations_nrl,
     prepare_llm_request,
     retrieve_summary,
 )
@@ -1138,6 +1140,77 @@ class TestPrepareCitationsErrorHandling:
             # When object-store fetch fails, content is empty, so citation is not added
             assert result.total_results == 0
 
+    # UNVERIFIED: could not run live; recommended fix only.
+    # Tracks the log-level demotion from NVBug 6191270 — the underlying ES /
+    # object-store desync is intermittent and was not live-reproduced in the
+    # docker NVIDIA-Hosted deployment used for this run.
+    def test_prepare_citations_nosuchkey_is_warning_not_error(self, caplog):
+        """NoSuchKey from S3 must log at WARNING (not ERROR) — NVBug 6191270."""
+        mock_doc = Mock()
+        mock_doc.page_content = "Test content"
+        mock_doc.metadata = {
+            "source": {
+                "source_id": "test.pdf",
+                "source_location": "s3://default-bucket/coll/file.pdf/43.png",
+            },
+            "content_metadata": {
+                "type": "structured",
+                "subtype": "chart",
+                "page_number": 43,
+                "location": [],
+            },
+            "collection_name": "test_collection",
+        }
+
+        not_found = S3Error(
+            code="NoSuchKey",
+            message="The specified key does not exist.",
+            resource="/default-bucket/coll/file.pdf/43.png",
+            request_id="req-1",
+            host_id=None,
+            response=Mock(),
+            bucket_name="default-bucket",
+            object_name="coll/file.pdf/43.png",
+        )
+
+        with patch(
+            "nvidia_rag.rag_server.response_generator.get_object_store_operator_instance"
+        ) as mock_object_store_getter:
+            mock_object_store = Mock()
+            mock_object_store.get_object_from_uri.side_effect = not_found
+            mock_object_store_getter.return_value = mock_object_store
+
+            with caplog.at_level(
+                "WARNING", logger="nvidia_rag.rag_server.response_generator"
+            ):
+                result = prepare_citations([mock_doc], enable_citations=True)
+
+            assert isinstance(result, Citations)
+            # Drop-on-empty-content behavior is preserved (intentional per the
+            # inline comment in prepare_citations to avoid UI errors).
+            assert result.total_results == 0
+
+            # The whole point of the fix: NoSuchKey is a WARNING, not an ERROR.
+            error_records = [
+                r
+                for r in caplog.records
+                if r.name == "nvidia_rag.rag_server.response_generator"
+                and r.levelname == "ERROR"
+            ]
+            warning_records = [
+                r
+                for r in caplog.records
+                if r.name == "nvidia_rag.rag_server.response_generator"
+                and r.levelname == "WARNING"
+            ]
+            assert not error_records, (
+                "NoSuchKey citation miss must not log at ERROR; got: "
+                f"{[r.getMessage() for r in error_records]}"
+            )
+            assert (
+                warning_records
+            ), "NoSuchKey citation miss must log at WARNING; no warning emitted"
+
     def test_prepare_citations_with_document_type_audio(self):
         """Test prepare_citations with audio document type"""
         mock_doc = Mock()
@@ -1152,6 +1225,75 @@ class TestPrepareCitationsErrorHandling:
         assert isinstance(result, Citations)
         assert result.total_results == 1
         assert result.results[0].document_type == "audio"
+
+    # UNVERIFIED: could not run live; recommended fix only.
+    # Mirrors test_prepare_citations_nosuchkey_is_warning_not_error for the
+    # NRL/LanceDB ingestion code path, which has the same log-level demotion
+    # applied per NVBug 6191270.
+    def test_prepare_citations_nrl_nosuchkey_is_warning_not_error(self, caplog):
+        """NoSuchKey from S3 must log at WARNING (not ERROR) — NRL variant."""
+        mock_doc = Mock()
+        mock_doc.page_content = "Visual asset fallback text"
+        mock_doc.metadata = {
+            "stored_image_uri": "s3://default-bucket/coll/file.pdf/43.png",
+            "content_type": "chart",
+            "filename": "file.pdf",
+            "path": "/tmp/file.pdf",
+            "source": "/tmp/file.pdf",
+            "source_id": "file.pdf",
+            "page_number": 43,
+            "pdf_page": "file_43",
+            "pdf_basename": "file",
+            "bbox_xyxy_norm": "[0,0,1,1]",
+            "metadata": {},
+        }
+
+        not_found = S3Error(
+            code="NoSuchKey",
+            message="The specified key does not exist.",
+            resource="/default-bucket/coll/file.pdf/43.png",
+            request_id="req-1",
+            host_id=None,
+            response=Mock(),
+            bucket_name="default-bucket",
+            object_name="coll/file.pdf/43.png",
+        )
+
+        with patch(
+            "nvidia_rag.rag_server.response_generator.get_object_store_operator_instance"
+        ) as mock_object_store_getter:
+            mock_object_store = Mock()
+            mock_object_store.get_object_from_uri.side_effect = not_found
+            mock_object_store_getter.return_value = mock_object_store
+
+            with caplog.at_level(
+                "WARNING", logger="nvidia_rag.rag_server.response_generator"
+            ):
+                result = prepare_citations_nrl([mock_doc], enable_citations=True)
+
+            assert isinstance(result, Citations)
+            # NRL also drops chunks with empty content; preserved behavior.
+            assert result.total_results == 0
+
+            error_records = [
+                r
+                for r in caplog.records
+                if r.name == "nvidia_rag.rag_server.response_generator"
+                and r.levelname == "ERROR"
+            ]
+            warning_records = [
+                r
+                for r in caplog.records
+                if r.name == "nvidia_rag.rag_server.response_generator"
+                and r.levelname == "WARNING"
+            ]
+            assert not error_records, (
+                "NRL NoSuchKey miss must not log at ERROR; got: "
+                f"{[r.getMessage() for r in error_records]}"
+            )
+            assert (
+                warning_records
+            ), "NRL NoSuchKey miss must log at WARNING; no warning emitted"
 
 
 class TestRetrieveSummaryEdgeCases:


### PR DESCRIPTION
Auto-generated by **agentic-bugfix** for NVBug `6191270`.

- Source branch: `bugfix/nvbug-6191270-20260520-170947`
- Target branch: `develop`
- Bug ID: `6191270`
- Commit author: `smasurekar`

<details><summary><strong>Full agent report</strong></summary>

> **RECOMMENDATION ONLY — reproduction was not possible.**
> Fix applied to workspace but **NOT live-verified**. The user must verify this change against the live system when the environment is available. See §2.5 for why reproduction could not be completed.

# Bug Fix Report — NVBug 6191270 ([RAG BP][v2.6.0][RC1] Intermittent S3 NoSuchKey in generation pipeline)

- **Report generated:** 2026-05-20T22:58:00+05:30
- **Bug source:** NVBugs #6191270
- **Reporter / requester:** Atharva Kulkarni (re-report), Shubhadeep Das (initial)
- **Repository:** NVIDIA-AI-Blueprints/rag @ e0f57777e6ca9f8cf48ce41c5ab940493967cca0
- **Branch:** bugfix/nvbug-6191270-20260520-170947
- **Fix status:** RECOMMENDATION (UNVERIFIED) — reproduction was not possible; fix applied to workspace only

## 1. Reported Symptom

Intermittent `minio.error.S3Error: S3 operation failed; code: NoSuchKey, message: The specified key does not exist.` raised in `rag-server` logs when the response generator tries to fetch the backing image bytes for an image / table / chart citation. The user's stack trace pointed at `nvidia_rag.rag_server.response_generator:prepare_citations` → `nvidia_rag.utils.object_store:get_object_from_uri` → `minio.api:get_object`, with example resource `default-bucket/agentic_rag/Global_Multimodal_data.pptx/43.png`. The reporter notes the issue is "very rare" but later (Comment 2) suggested a probable repro: deploy via Helm → ingest documents → query OK → uninstall Helm chart **without** deleting PVCs → reinstall → query the same collection → intermittent NoSuchKey.

## 1.5 Custom Instructions

**Source:** inline
**Content:**
```
Use NVIDIA-Hosted (Cloud) docker deployment and for deploy skills check the skill-source folder for skills path
```

## 2. Reproduction Attempts

**Trigger used:**
1. `POST /v1/collections?collection_type=text&embedding_dimension=2048` (ingestor) to create `repro_6191270`.
2. `POST /v1/documents` (ingestor) uploading `./data/multimodal/multimodal_test.pdf` (3 text, 2 tables, 3 charts → 5 PNGs written to SeaweedFS at `default-bucket/repro_6191270/multimodal_test.pdf/{3..7}.png`).
3. `POST /v1/generate` (rag-server) querying citations for chart/table content.
4. `docker compose -f deploy/compose/{vectordb,docker-compose-ingestor-server,docker-compose-rag-server}.yaml down` (preserves all `rag-vol-*` named volumes — analog of "helm uninstall without deleting PVCs").
5. `docker compose -f .../{vectordb,ingestor,rag-server}.yaml up -d`.
6. Re-query the same `repro_6191270` collection.

**Environment:** Docker NVIDIA-Hosted (Cloud) deployment, `deploy/compose/nvdev.env`, NVIDIA API Catalog endpoints, Elasticsearch + SeaweedFS, NVIDIA_API_KEY set, single host.

**Attempts log:**

| # | Inputs / gap closure applied | Observed outcome | Failure mode |
|---|---|---|---|
| 1 | As-reported: docker down/up cycle preserving named volumes, then query the same collection. `ENABLE_VLM_INFERENCE=False` (default). | Query returned 8 citations (3 text / 2 table / 3 chart) but with empty image content — no S3 fetch was attempted because `prepare_citations` either did not enter the fetch branch for those citations or `source_location` was missing in the SSE-streamed result. No S3 error appeared in `rag-server` logs. | `no error observed` |
| 2 | Gap closure: enable VLM image fetching (`ENABLE_VLM_INFERENCE=True`, `ENABLE_VLM_RERANKER_IMAGE_INPUT=True`, `APP_VLM_APIKEY` set). Recreate rag-server, re-run the down/up cycle and re-query. | All 5 structured citations now returned valid base64 JPEG content (`/9j/4AAQSkZJRgA...`) — i.e. `prepare_citations` → `get_object_from_uri` ran successfully end-to-end. No `NoSuchKey` error. | `no error observed` |

## 2.5 Why reproduction was not possible

The bug is described by the original reporter as "intermittent — observed only once," and Comment 2's "probable repro steps" are explicitly **probable**, not deterministic. The mechanism that produces the S3↔ES desync (lost objects in the object-store PVC after a Helm uninstall, or an ingest-time race that commits an ES row whose `source_location` points at an object that was never written) does not occur in the docker NVIDIA-Hosted deployment used for this run: SeaweedFS retained all 5 expected images across the `docker compose down → up` cycle, and Elasticsearch retained the matching `metadata.source.source_location` URIs (verified directly: `s3://default-bucket/repro_6191270/multimodal_test.pdf/3.png` etc.). Without the underlying race or Helm/PVC asymmetry, the failing line in `prepare_citations` cannot be hit live. Switching to a real Helm deployment to attempt the exact-steps reproduction would have violated the user's `--instructions` ("Use NVIDIA-Hosted (Cloud) docker deployment").

**User was asked:** "Reproduction Attempt 1 ran cleanly: no S3 NoSuchKey error. The `prepare_citations` → `get_object_from_uri(source_location)` path from the bug stack trace was never triggered because none of the citations carried a `source_location` URI. How should I close the gap for Attempt 2 — (a) enable VLM and retry, (b) switch to Helm and follow the exact bug repro, (c) skip to Track B?"
**User's response:** could not provide — the question was dispatched but the user did not select an option; the skill defaulted to (a) per the user's original `--instructions` and proceeded.

**NVBug attachments (from Phase 1 Track 1C):**

| File | Size | Retrieved? | Note |
|---|---|---|---|
| rag-server-error-logs.txt | 19.5 KB | no | SSO-gated; user did not paste |
| ingestor-server-s3-logs.txt | 92.6 KB | no | SSO-gated; user did not paste |
| nv-ingest-s3-logs.txt | 1.1 KB | no | SSO-gated; user did not paste |
| rag-server-s3-logs.txt | 1027.7 KB | no | SSO-gated; user did not paste |

## 3. Hypothesized Root Cause (not live-verified)

**Suspected** intermittent state desync between Elasticsearch (which retains `metadata.source.source_location` URIs after a redeploy or after re-ingest of a collection) and the object store (SeaweedFS/MinIO, which under some conditions does **not** retain the matching PNG bytes — for example after a Helm uninstall that did not delete the object-store PVC but lost some files inside it, or after a re-ingest that re-allocated element IDs while old ES rows still reference the old IDs). The exact mechanism (ingestion-time race vs PVC retention asymmetry vs nv-ingest element-ID allocation drift) **cannot be confirmed** without (a) live-reproducing the failure or (b) inspecting the attached `rag-server-s3-logs.txt` / `ingestor-server-s3-logs.txt`, neither of which the skill has.

The defect this fix actually addresses is narrower than the root cause: when the underlying desync fires (whatever the cause), `prepare_citations` and `prepare_citations_nrl` currently emit a noisy ERROR-level stack trace via `logger.exception(...)`. The surrounding code already gracefully drops the affected citation (`content = ""` → guard at the end of the loop), so the *only* user-visible defect that is actionable from static analysis alone is the log level. Fixing the underlying desync would require touching nv-ingest internals or PVC retention semantics — those are design changes outside the scope of this fix.

**Candidate root causes considered:**

| # | Hypothesis | Evidence | Ranked |
|---|---|---|---|
| A | `prepare_citations` / `prepare_citations_nrl` use `logger.exception(...)` for what is a benign "object not in storage" condition the surrounding code already swallows; the citation is silently dropped, but the noisy ERROR log mis-signals a system failure. (User-visible defect.) | response_generator.py:996 and :1138 use `logger.exception`. `get_payload` in object_store.py:118-124 already uses WARNING for the same shape of failure. vlm_reranker.py:212 uses WARNING. vlm.py:423,463 silently continue. | **primary** |
| B | Push the swallow down into `S3ObjectStoreOperator.get_object_from_uri` itself: return `b""` or raise a typed `ObjectNotFoundError` so the four callers don't each need to know about NoSuchKey. | object_store.py:99-111 propagates raw `minio.error.S3Error`; the `get_payload` pattern at :113-124 shows the codebase has the precedent of low-level swallow for some methods. | secondary — rejected, would break the existing "low-level raise, high-level handle" contract that all four callers already implement. |
| C | Fix the underlying ES↔object-store desync: make ingestion atomic (or add a post-hoc reconciliation pass), so ES never references an object that does not exist. | nvingest.py:267-280 chains `.store()` before `.vdb_upload()` but the actual ordering and retry semantics live inside `nv-ingest-client`. No compensating cleanup is visible in this repo. | secondary — explicitly **out of scope**: this is a design change and the root mechanism is in nv-ingest internals, not this repo. |
| D | The same fetch + base64 pattern lives in sibling code paths (vlm reranker, summary, document_search) that would also throw NoSuchKey under the same desync. | All other sites (vlm.py:406,448; vlm_reranker.py:203; response_generator.py:1359,1432,1458) are already wrapped in `try/except` and either `continue` silently, return `None`, or rely on `get_payload`'s internal swallow. | refuted — H4 found no undefended siblings. |

**Evidence gaps** (per Track B honesty rule #6 — these cannot be cited as support, they are gaps):
- Attachment `rag-server-s3-logs.txt` (1.0 MB) would likely show the exact log lines around when the NoSuchKey fires, including any preceding events (ingestion completion, container restart) that would discriminate between hypotheses A, B, and C; not fetched (SSO-gated; user skipped).
- Attachment `ingestor-server-s3-logs.txt` (92.6 KB) would likely show whether the ingestor confirmed each `put_object` against ES or only against the in-process pipeline; not fetched (SSO-gated; user skipped).
- The `rag-server` runtime path during the helm-uninstall/reinstall transition is not observable statically; we cannot tell whether SeaweedFS PVC retention loses objects deterministically or only under specific failure modes.
- Whether nv-ingest's element-ID allocation is deterministic across re-ingests of the same `<collection, file>` is not visible from this repo (it lives in `nv_ingest_client`).

**Call chain (static):**
```
POST /v1/generate
  → generate_answer_async
  → prepare_citations  (response_generator.py:901)
  → get_object_store_operator_instance().get_object_from_uri(source_location)
  → S3ObjectStoreOperator.get_object_from_uri  (object_store.py:99)
  → minio.Minio.get_object  (raises S3Error code=NoSuchKey for missing key)
  → except Exception → logger.exception(...) ← noisy ERROR (the defect)
  → content = "" → citation dropped at the final guard
```

The NRL variant (`prepare_citations_nrl`) has the same shape at `response_generator.py:1051+`, fetching `stored_image_uri` instead of `source_location`.

**Contributing factors (if any):**
- Uncommitted local changes: no (clean working tree before the run).
- Secondary hypotheses not addressed by this fix: B (object-store push-down) and C (atomic ingest). Both are explicitly secondary and out of scope. The human should still verify that the actual desync does not have a separate fix obligation.

## 4. Fix Applied (to workspace; uncommitted)

**Files changed:**

| File | Lines | Change |
|---|---|---|
| `src/nvidia_rag/rag_server/response_generator.py` | 40, 52-64, 1010-1027, 1161-1174 | Added `from minio.error import S3Error`. Added module-level helper `_is_missing_object_error(exc) -> bool` returning True for `FileNotFoundError` (filesystem operator) or `minio.error.S3Error` with `code == "NoSuchKey"` (S3 operator). Updated both `except Exception` blocks (in `prepare_citations` and `prepare_citations_nrl`) to demote to `logger.warning(...)` when the helper returns True; other exceptions remain at `logger.exception(...)`. Citation-drop behavior preserved. |
| `tests/unit/test_rag_server/test_response_generator.py` | 23, 50, 1142-1212, 1228-1296 | Added `from minio.error import S3Error`; added `prepare_citations_nrl` to imports; added two parallel tests (`test_prepare_citations_nosuchkey_is_warning_not_error` and `test_prepare_citations_nrl_nosuchkey_is_warning_not_error`) that mock a real `S3Error(code="NoSuchKey", ...)`, assert the citation is still dropped, and use `caplog` to assert WARNING was emitted and ERROR was not. Both carry the `# UNVERIFIED: could not run live; recommended fix only` marker. |

**Diff:**

```diff
diff --git a/src/nvidia_rag/rag_server/response_generator.py b/src/nvidia_rag/rag_server/response_generator.py
@@ -37,6 +37,7 @@ from uuid import uuid4
 import bleach
 from langchain_core.documents import Document
+from minio.error import S3Error
 from pydantic import BaseModel, Field, validator
 from pymilvus.exceptions import MilvusException, MilvusUnavailableException
@@ -47,6 +48,22 @@ from nvidia_rag.utils.object_store import (
 )
 from nvidia_rag.utils.observability.otel_metrics import OtelMetrics

+
+def _is_missing_object_error(exc: BaseException) -> bool:
+    """Return True when ``exc`` represents 'object key not present in storage'.
+
+    The intermittent ES/object-store desync described in NVBug 6191270 produces an
+    expected NoSuchKey for S3 backends (and FileNotFoundError for the filesystem
+    backend). Callers downgrade the log for this case so the noisy stack trace
+    does not mask other failures (auth, network, etc.).
+    """
+    if isinstance(exc, FileNotFoundError):
+        return True
+    if isinstance(exc, S3Error) and getattr(exc, "code", None) == "NoSuchKey":
+        return True
+    return False
+
+
 logger = logging.getLogger(__name__)
@@ -993,9 +1010,16 @@ def prepare_citations(
                 except Exception as e:
-                    logger.exception(
-                        f"Error pulling content from object storage for image/table/chart for citations: {e}"
-                    )
+                    if _is_missing_object_error(e):
+                        logger.warning(
+                            "Object not found in object storage for image/table/chart "
+                            "citation; skipping citation. source_location=%s",
+                            source_location,
+                        )
+                    else:
+                        logger.exception(
+                            f"Error pulling content from object storage for image/table/chart for citations: {e}"
+                        )
                     content = ""
@@ -1135,12 +1159,19 @@ def prepare_citations_nrl(
                 except Exception as exc:
-                    logger.exception(
-                        "[Prepare Citations NRL] Failed to fetch asset from object storage"
-                        " (uri=%s): %s",
-                        stored_image_uri,
-                        exc,
-                    )
+                    if _is_missing_object_error(exc):
+                        logger.warning(
+                            "[Prepare Citations NRL] Object not found in object "
+                            "storage; skipping chunk. uri=%s",
+                            stored_image_uri,
+                        )
+                    else:
+                        logger.exception(
+                            "[Prepare Citations NRL] Failed to fetch asset from object storage"
+                            " (uri=%s): %s",
+                            stored_image_uri,
+                            exc,
+                        )
                     content = ""
```

(Full diff including the two new unit tests is available via `git diff` in the workspace.)

**Why this is minimal and safe:** no design change. The fix is a one-helper + two-branch-demote change confined to one file in `src/`, plus two parallel unit tests. It does not modify the public API, schemas, storage contracts, or the existing citation-drop behavior (intentional per the inline comment "may cause an error in the UI client"). All other exception types (auth failures, network errors, non-S3 backends) continue to log at ERROR with full stack trace via `logger.exception(...)`.

**Failure modes this fix addresses:**
- `minio.error.S3Error` with `code == "NoSuchKey"` raised inside `prepare_citations` for nv-ingest image/table/chart citations: log demoted from ERROR to WARNING.
- Same condition raised inside `prepare_citations_nrl` for NRL/LanceDB visual chunks: log demoted from ERROR to WARNING.
- `FileNotFoundError` raised by `FilesystemObjectStoreOperator.get_object_from_uri` for the same kind of missing-object condition: log demoted from ERROR to WARNING.

**Failure modes this fix does NOT address:**
- The underlying ES↔object-store desync that causes the NoSuchKey in the first place (root mechanism in nv-ingest or PVC retention — out of scope).
- Other call sites that fetch from object storage (vlm.py, vlm_reranker.py, retrieve_summary) — H4 confirmed they already handle the failure gracefully via existing `try/except` or `get_payload`'s internal swallow.
- The citation-drop behavior itself (the chart/table citation still disappears from the user-visible response when the object is missing; the inline comment shows this is intentional to avoid UI errors).

## 5. Tests

- **New tests:**
  - `tests/unit/test_rag_server/test_response_generator.py::TestPrepareCitationsErrorHandling::test_prepare_citations_nosuchkey_is_warning_not_error` — asserts that a real `S3Error(code="NoSuchKey", ...)` causes `prepare_citations` to log at WARNING and emit no ERROR records, while still dropping the empty-content citation. Marked `# UNVERIFIED: could not run live; recommended fix only`.
  - `tests/unit/test_rag_server/test_response_generator.py::TestPrepareCitationsErrorHandling::test_prepare_citations_nrl_nosuchkey_is_warning_not_error` — same assertions against `prepare_citations_nrl` using the NRL metadata schema (`stored_image_uri`, `content_type`). Marked `# UNVERIFIED: could not run live; recommended fix only`.
- **Unit test run:** 1466 passed, 1 pre-existing failure unrelated to this fix (`test_validate_directory_traversal_attack_success` — also fails on develop without my changes), 1 xfailed. Command: `uv run pytest -q tests/unit/test_rag_server tests/unit/test_ingestor_server tests/unit/test_utils --ignore=tests/unit/test_ingestor_server/test_nemo_retriever --ignore=tests/unit/test_utils/test_vdb/test_lancedb_vdb.py`.
- **Targeted test_response_generator.py file:** 83 passed (4 of which exercise `TestPrepareCitationsErrorHandling`, including the 2 new tests).
- **Lint:** pre-existing `I001` (import block un-sorted) on the test file is unchanged from develop baseline (verified by `git stash` + `ruff check` on clean tree). No new lint errors introduced by this fix. Command: `uv run ruff check src/nvidia_rag/rag_server/response_generator.py tests/unit/test_rag_server/test_response_generator.py`.
- **Format:** pre-existing single-line format issue at `test_response_generator.py:857` is in a section untouched by this fix (also fails on develop without my changes).

## 6. Live E2E Validation

**SKIPPED** — see §2.5. User must verify this recommendation against the live system when the environment is available.

**Suggested verification steps for the user:**

1. On a Helm deployment of the RAG Blueprint, follow the bug's "probable repro" verbatim: install → ingest a multimodal document with images/tables/charts → query the collection → confirm no S3 errors → `helm uninstall <release>` **without** deleting PVCs → `helm install <release>` against the same PVCs → query the same collection → tail `rag-server` logs.
2. When the NoSuchKey condition fires (intermittent — may need to retry the repro under realistic load), the log line should now read `WARNING:nvidia_rag.rag_server.response_generator:Object not found in object storage for image/table/chart citation; skipping citation. source_location=<uri>` instead of `ERROR:... Error pulling content from object storage for image/table/chart for citations: S3 operation failed; code: NoSuchKey, ...` with a multi-line traceback.
3. Confirm the user-visible behavior is unchanged: the affected citation is still absent from the response (the system always dropped it), and the answer still streams. This is the intentional "drop on empty content" path documented in the inline comment in `prepare_citations`.
4. Separately, open a follow-up bug to investigate hypothesis C (the underlying ES↔object-store desync) once attachments `rag-server-s3-logs.txt` and `ingestor-server-s3-logs.txt` are inspected.

## 6.5 Expert Review

**Aggregated verdict:** approve (cycle 2)
**Cycles used:** 2 of 3

| # | Reviewer | Verdict | Findings |
|---|---|---|---|
| R1 | Root-cause linkage (against hypothesized cause + alternatives) | approve | none |
| R2 | Coding conventions | approve | 1 nit (variable name `e` vs `exc` divergence between the two except blocks) |
| R3 | Generic code quality (runtime findings downgraded to `minor` — see Track B deltas) | approve | 1 minor (helper signature uses `BaseException` instead of `Exception`), 3 info (WARNING message context, helper ordering vs `logger`, test reliance on minio constructor signature) |
| R4 | Scope discipline | approve | none (helper vs inline noted as reasonable trade-off, not a violation) |
| R5 | Test adequacy (test is marked UNVERIFIED) | approve in cycle 2 (was `changes_requested` in cycle 1) | cycle-1 major closed: NRL test was missing, now added |
| **R6** | **Evidence honesty (REQUIRED in Track B per honesty rule #6)** | approve | minor wording fix flagged: §3 originally said "intermittent state desync" with too much certainty; report wording softened to "suspected" / "cannot be confirmed" / "hypothesis" |
| R7 | Custom instructions compliance | approve | none (no violations of `--instructions`) |

**Non-blocking notes** (minor / suggestion / nit, preserved from the reviewers that found them):
- `src/nvidia_rag/rag_server/response_generator.py:1012,1161` — except-block variable names diverge (`e` vs `exc`). Suggested fix: standardize to `exc` in both blocks for parallelism. (R2)
- `src/nvidia_rag/rag_server/response_generator.py:52` — helper signature is `exc: BaseException`; narrowing to `Exception` would prevent accidental classification of control-flow exceptions like `KeyboardInterrupt`. Neither current targeted exception type subclasses `BaseException` exclusively, so this is informational only. (R3)
- `src/nvidia_rag/rag_server/response_generator.py:1014-1018, 1163-1167` — WARNING message includes only `source_location` / `stored_image_uri`; consider adding `source_id` or `document_id` for log aggregator correlation. (R3)
- `tests/unit/test_rag_server/test_response_generator.py:1164-1173, 1252-1261` — test constructs `S3Error` via keyword args matching minio 7.2.20; would need updates if minio bumps the constructor signature. (R3)

**Runtime findings downgraded to evidence gaps** (from R3 under Track B leniency — these MUST be verified by the user against the live system):
- The intermittent fire of `NoSuchKey` itself — cannot be observed statically; user must verify the WARNING is emitted (and ERROR is not) when the live race fires.
- Whether the fix's behavior under concurrent failures (multiple citations hit NoSuchKey at the same time in the same `prepare_citations` call) is correct — covered by the loop iteration but not exercised in tests.

## 7. Attempt Timeline

| # | Phase | Action | Outcome |
|---|---|---|---|
| 1 | Phase 1 setup | Confirmed docker NVIDIA-Hosted stack already running; ran `docker compose up -d` idempotently for `vectordb`/`ingestor`/`rag-server` after exporting `NGC_API_KEY=$NVIDIA_API_KEY` | All services healthy: Elasticsearch, SeaweedFS, NIM endpoints (LLM/Embeddings/Ranking/VLM/Summary), Redis, nv-ingest |
| 2 | Phase 1 Track 1B | Infrastructure scout (explore subagent) mapped test/lint/deploy commands and integration test sequences | Returned: pytest with CI ignores, ruff check, docker compose deployment, integration tests under `tests/integration/test_cases/` |
| 3 | Phase 1 Track 1C | NVBug 6191270 content fetch (explore subagent via `mcp__MaaS-NVBugs__nvbugs_get_bug_details`) | Returned bug title/severity/description/comments verbatim, plus 4 SSO-gated attachments (none retrieved) |
| 4 | Phase 1 Track 1A Step 2 | Reproduction Attempt 1: create collection → ingest multimodal_test.pdf → docker compose down keeping volumes → up → re-query | No S3 error; citations had no `source_location` and no S3 fetch attempted (`ENABLE_VLM_INFERENCE=False`) |
| 5 | Phase 1 Step 3 | Gap Analysis: classified `no error observed`; asked user one question (enable VLM / switch to Helm / Track B); user did not answer; defaulted to enable-VLM per `--instructions` | Gap closure: ENABLE_VLM_INFERENCE=True, ENABLE_VLM_RERANKER_IMAGE_INPUT=True, APP_VLM_APIKEY set |
| 6 | Phase 1 Step 4 | Reproduction Attempt 2: recreated rag-server with VLM enabled; ran down/up cycle; re-queried | Still no S3 error; all 5 structured citations returned valid base64 JPEG content; `prepare_citations` → `get_object_from_uri` executed end-to-end successfully |
| 7 | Mode select | Two failed attempts (no error observed despite full repro path) → enter Track B | Track B activated |
| 8 | Phase 2 Track B | Dispatched 4 parallel hypothesis-evidence subagents (H1 prepare_citations resilience, H2 object_store push-down, H3 ingestion desync, H4 sibling sites). Synthesized: H1 primary, H2/H3 secondary, H4 refuted | Ranked H1 as the actionable fix surface |
| 9 | Phase 3 | Planned minimal fix: detect `NoSuchKey` / `FileNotFoundError`, demote `logger.exception` → `logger.warning`, preserve citation-drop behavior | No design change |
| 10 | Phase 4 cycle 1 | Edited `response_generator.py` (helper + 2 except blocks) and `test_response_generator.py` (1 new test for `prepare_citations`) | Workspace edits only, no deploy |
| 11 | Phase 5 cycle 1 | Targeted tests pass; full unit suite 1466 passed + 1 pre-existing failure; lint pre-existing I001 unchanged | Validate green relative to baseline |
| 12 | Phase 6 cycle 1 | 7 reviewers in parallel (R1-R7); R5 flagged a `major`: no test coverage for `prepare_citations_nrl` NoSuchKey path | Re-enter Phase 4 |
| 13 | Phase 4 cycle 2 | Added second test `test_prepare_citations_nrl_nosuchkey_is_warning_not_error` mirroring the first | Done |
| 14 | Phase 5 cycle 2 | 4 prepare_citations tests pass | Done |
| 15 | Phase 6 cycle 2 | Re-ran R5; verdict approve, gap closed | Proceed to Phase 7 |

## 8. Incidental Findings

- **Pre-existing lint warning** `tests/unit/test_rag_server/test_response_generator.py:16:1: I001 Import block is un-sorted or un-formatted` — verified to also fail on develop (`git stash` confirmed). Not introduced by this fix.
- **Pre-existing format issue** `tests/unit/test_rag_server/test_response_generator.py:857` — a multi-line `assert (... == "thinking")` that ruff would collapse to one line; in a test class unrelated to `TestPrepareCitationsErrorHandling`. Not introduced by this fix.
- **Pre-existing unit test failure** `tests/unit/test_ingestor_server/test_ingestor_library.py::TestNvidiaRAGIngestor::test_validate_directory_traversal_attack_success` — fails on develop without any of my changes. Suggest a separate bug.
- **Pre-existing module import failure** `tests/unit/test_rag_perf/conftest.py` cannot load because `ruamel.yaml` is not installed in `.venv`. Suggest declaring this as a test extra or documenting the prerequisite.
- **Note on evidence gaps:** the un-retrieved attachments (especially `rag-server-s3-logs.txt` and `ingestor-server-s3-logs.txt`) might in fact contain the deterministic trigger and discriminator between hypotheses A/B/C. A separate investigation track to read those logs would be valuable for understanding the underlying desync.

## 9. Follow-ups for the Human

- [ ] Review the diff (`git diff src/nvidia_rag/rag_server/response_generator.py tests/unit/test_rag_server/test_response_generator.py`).
- [ ] Verify the fix against a live Helm deployment using the bug's "probable repro" steps (see §6 suggested verification).
- [ ] Decide whether to address the non-blocking notes in §6.5 (variable-name parallelism, helper signature narrowing, WARNING message context). All are stylistic and do not affect correctness.
- [ ] Decide whether to open a separate bug for the underlying ES↔object-store desync (hypothesis C in §3) — this fix only mutes the noisy log, it does not prevent the citation from being dropped.
- [ ] Read the four NVBug attachments and confirm they don't introduce a new hypothesis that should change the fix surface.
- [ ] Commit (skill explicitly does not commit; see "Do not create a git commit" guidance).
- [ ] Set NVBug BugAction / Disposition (intentionally left to human — see §10).

## 10. NVBugs Audit Trail

- **NVBug ID:** 6191270
- **Comment posted:** **no** — `--no-nvbugs-update` was passed at skill invocation; the comment-only update is fully skipped (the prompt is also skipped). Fix is a recommendation only and the bug remains open in NVBugs.
- **Comment type:** n/a (no comment posted)
- **BugAction / Disposition:** **left unchanged — human to set**

</details>
