### PR TITLE
agentic-bugfix: NVBug 6191293

### DIFF
--- a/deploy/compose/nvdev.env
+++ b/deploy/compose/nvdev.env
@@ -81,7 +81,15 @@ export APP_VLM_MODELNAME="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
 # export ENABLE_VLM_INFERENCE="true" # Uncomment to use VLM generation
 
 # Image captioning feature
-export APP_NVINGEST_CAPTIONMODELNAME="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
+# NVBug 6191293 (recommendation — root cause not live-verified): the Omni
+# reasoning VLM emits reasoning tokens per request, which is suspected to add
+# per-call latency that can amplify wall time on bulk multimodal ingestion
+# (e.g. the >30 min / 53-pptx report) when image captioning is enabled.
+# nemotron-nano-12b-v2-vl is a non-reasoning captioning VLM. This scope is
+# limited to the NVIDIA-Hosted (nvdev) profile; compose/helm defaults are
+# unchanged. Note: caption calls only run when APP_NVINGEST_EXTRACTIMAGES=True
+# (commented out below) — the original failing-test value is unknown.
+export APP_NVINGEST_CAPTIONMODELNAME="nvidia/nemotron-nano-12b-v2-vl"
 export APP_NVINGEST_CAPTIONENDPOINTURL="https://integrate.api.nvidia.com/v1/chat/completions"
 # export APP_NVINGEST_EXTRACTIMAGES="True" # Uncomment to use image captioning
 

--- a/tests/unit/test_deploy/test_nvdev_caption_model_config.py
+++ b/tests/unit/test_deploy/test_nvdev_caption_model_config.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Config-level assertions for the NVIDIA-Hosted (Cloud) env file.
+
+These tests guard the NVBug 6191293 recommendation — root cause was not
+live-verified. Bulk multimodal pptx ingestion was reported as >30 min for
+53 files when the caption model was a reasoning-mode VLM. A non-reasoning
+captioning VLM is the recommended workaround; tests pin the
+NVIDIA-Hosted (`nvdev.env`) profile only.
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+NVDEV_ENV = REPO_ROOT / "deploy/compose/nvdev.env"
+
+EXPECTED_CAPTION_MODEL = "nvidia/nemotron-nano-12b-v2-vl"
+
+REASONING_MARKERS = ("-reasoning", "_reasoning")
+
+
+def _parse_exports(path: Path) -> dict[str, str]:
+    """Parse simple `export KEY=VALUE` lines from a shell env file.
+
+    Ignores commented lines, blank lines, and non-export statements. Strips
+    surrounding single or double quotes from values. Last assignment wins on
+    duplicates. Intentionally does NOT resolve `${VAR}` interpolation,
+    escaped quotes, inline trailing comments, or line continuations — the
+    nvdev.env subset under test does not require those.
+    """
+    pattern = re.compile(r"^\s*export\s+([A-Z0-9_]+)=(.*)$")
+    result: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        stripped = raw_line.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        match = pattern.match(raw_line)
+        if not match:
+            continue
+        key, value = match.group(1), match.group(2).strip()
+        if value.startswith('"') and value.endswith('"'):
+            value = value[1:-1]
+        elif value.startswith("'") and value.endswith("'"):
+            value = value[1:-1]
+        result[key] = value
+    return result
+
+
+# UNVERIFIED: could not run live; recommended fix only.
+# Reproduction of NVBug 6191293 (>30 min for 53 pptx files) was not possible —
+# the originating dataset lives on internal NVIDIA QA storage. This test
+# encodes the static contract from the recommended fix.
+def test_nvdev_env_caption_model_is_not_reasoning_mode():
+    """The NVIDIA-Hosted caption model must not be a `-reasoning` VLM.
+
+    NVBug 6191293 recommendation (UNVERIFIED): reasoning-mode VLMs emit
+    reasoning tokens per request, which is suspected to add per-call latency
+    on bulk multimodal ingestion when image captioning is enabled. This test
+    encodes the durable invariant of the recommendation regardless of which
+    specific non-reasoning VLM is selected.
+    """
+    env = _parse_exports(NVDEV_ENV)
+    caption_model = env.get("APP_NVINGEST_CAPTIONMODELNAME")
+    assert (
+        caption_model is not None
+    ), "APP_NVINGEST_CAPTIONMODELNAME is not exported in deploy/compose/nvdev.env"
+    caption_model_lower = caption_model.lower()
+    for marker in REASONING_MARKERS:
+        assert marker not in caption_model_lower, (
+            f"NVBug 6191293: NVIDIA-Hosted caption model must not be reasoning-mode; "
+            f"got '{caption_model}'. Use a non-reasoning VLM such as "
+            f"'{EXPECTED_CAPTION_MODEL}' for ingestion-time captioning."
+        )
+
+
+# UNVERIFIED: could not run live; recommended fix only.
+def test_nvdev_env_caption_model_matches_recommended_fix():
+    """The NVIDIA-Hosted caption model should match the recommended VLM.
+
+    If engineering selects a different non-reasoning captioning VLM, update
+    EXPECTED_CAPTION_MODEL accordingly — the durable invariant lives in
+    test_nvdev_env_caption_model_is_not_reasoning_mode.
+    """
+    env = _parse_exports(NVDEV_ENV)
+    assert env.get("APP_NVINGEST_CAPTIONMODELNAME") == EXPECTED_CAPTION_MODEL


### PR DESCRIPTION
Auto-generated by **agentic-bugfix** for NVBug `6191293`.

- Source branch: `bugfix/nvbug-6191293-20260520-174354`
- Target branch: `develop`
- Bug ID: `6191293`
- Commit author: `smasurekar`

<details><summary><strong>Full agent report</strong></summary>

> **RECOMMENDATION ONLY — reproduction was not possible.**
> Fix applied to workspace but **NOT live-verified**. The user must verify this change against the live system (the original QA dataset on internal NVIDIA storage) when the environment is available. See §2.5 for why reproduction could not be completed.

# Bug Fix Report — NVBug 6191293

- **Report generated:** 2026-05-20T18:00:00Z
- **Bug source:** NVBugs #6191293
- **Reporter / requester:** Atharva Kulkarni (atkulkarni@nvidia.com); Engineer: Sumit Bhattacharya
- **Repository:** NVIDIA-AI-Blueprints/rag @ `e0f57777e6ca9f8cf48ce41c5ab940493967cca0`
- **Branch:** `bugfix/nvbug-6191293-20260520-174354`
- **Fix status:** RECOMMENDATION (UNVERIFIED) — reproduction was not possible; fix applied to workspace only

## 1. Reported Symptom

> *[RAG BP][v2.6.0][RC1] Bulk ingestion of 53 pptx files is taking more than 30mins*
>
> Repo: https://github.com/NVIDIA-AI-Blueprints/rag/blob/v2.6.0.rc1
>
> Observations:
> 1. Tried bulk ingestion of pptx files. Dataset used: `https://qvsfilestore/qvs_contents/foundational_rag/TCID-104061-Ingestion/` (53 files from this).
>
> ingestor-server logs: `http://httpstorage-vm-01/qvslogs/QVSLogs/main/linux-none/desktop_ubuntu_x86_64/20260515-large_/SanityTestLogs/Log_sanity_all_20260515-large_smc-522ga-0073_2026_05_18_592267_1775964/Testcase_Logs/104061/iter1/server_logs/ingestor-server-5df5b78747-zgb4b/ingestor-server.log`

- Severity: 3-Functionality / Priority: P0-Must have / BugAction: Dev - Open - To fix
- Module: NIM BP - Foundational RAG
- Keywords: RAG_BP, RAG_BP_Stretch
- Linked DevTest tasks: T104061 "Bulk Upload Multimodal PPTX", T104062 "Bulk Upload combination"
- Comments: 0 / Attachments: 0

## 1.5 Custom Instructions

**Source:** inline
**Content:**
```
Use NVIDIA-Hosted (Cloud) docker deployment and for deploy skills check the skill-source folder for skills path
```

Propagated constraints applied across phases:
- Phase 1 setup invoked the rag-blueprint skill at `skill-source/.agents/skills/rag-blueprint/references/deploy/docker-nvidia-hosted.md` (idempotent — stack was already healthy on the NVIDIA-Hosted profile).
- The fix scope is intentionally limited to the NVIDIA-Hosted profile (`deploy/compose/nvdev.env`). Helm and self-hosted-compose defaults are NOT modified.
- Track 1B Infrastructure Scout enumerated `skill-source/.agents/skills/` (per the `--skills-path` flag) before falling back to `.claude/skills/` (none present).

## 2. Reproduction Attempts

**Trigger used:** POST `http://localhost:8082/v1/documents` with `documents=@<file>...` + `data='{"collection_name":"...","blocking":false,...}'`, then poll `/v1/status?task_id=...` every 10–15 s.

**Environment:** Docker Compose, NVIDIA-Hosted profile (nvdev.env sourced); rag-frontend, rag-server, ingestor-server, nv-ingest-ms-runtime, redis, elasticsearch, seaweedfs — all healthy. NIM endpoints routed to `integrate.api.nvidia.com` / `ai.api.nvidia.com`.

**Attempts log:**
| # | Inputs / gap closure applied | Observed outcome | Failure mode |
|---|---|---|---|
| 1 | 5 synthetic text-only pptx (~30 KB each, generated via `python-pptx`) into a fresh collection `repro_6191293`. `generate_summary=false`. | Ingested in **10 s** (2 s/file). `doc_type_counts: {text: 3}` per file. No slow path observed. | `no error observed` |
| 2 | Gap closure: my synthetic pptx was text-only → did not exercise the multimodal extraction path. Re-ran with 10 multimodal pptx (~44 KB each: 6 slides with title + bullets + embedded PNG image + native column chart + 11-row table) into `repro_6191293_mm`. | Ingested in **15 s** (1.5 s/file). `doc_type_counts: {text: 6, table: 1, chart: 1}` per file. No slow path observed. Projection: 53 files ≈ 80 s, not >30 min. | `no error observed` |

## 2.5 Why reproduction was not possible

The originating 53-pptx dataset (`qvsfilestore/qvs_contents/foundational_rag/TCID-104061-Ingestion/`) lives on internal NVIDIA QA storage that is not reachable from this checkout. The bug's `ingestor-server.log` URL (`http://httpstorage-vm-01/qvslogs/...`) is also internal-only. Both reproduction attempts used locally-generated synthetic pptx (text-only, then multimodal with embedded images + charts + tables); neither matched the volume, file size, or content density of the original deck and neither reproduced the >30 min wall-clock signal.

Compounding factors:
1. The bug is a perf/throughput regression — without comparable input, throughput cannot be benchmarked meaningfully.
2. The NVIDIA-Hosted deployment profile (per `--instructions`) explicitly carries a rate-limit caveat (`docs/deploy-docker-nvidia-hosted.md:15`: "you might encounter rate limiting with larger file ingestions (>10 files)"), so any local 53-file run would be confounded by 429s. The original test was almost certainly on helm with self-hosted NIMs (the QA log path `Log_sanity_all_20260515-large_*` is consistent with on-prem QA infrastructure).
3. Image captioning is gated by `APP_NVINGEST_EXTRACTIMAGES` — commented out by default in `nvdev.env:91`. Whether the original QA run had it enabled is unknown.

**User was asked:** *(Two structured `AskUserQuestion` prompts were issued — for upfront path choice and Gap Analysis — and both were declined by the user, who instructed the skill to proceed autonomously per the `--instructions` flag.)*
**User's response:** *(no answer; proceed-autonomously stance honored)*

**NVBug attachments (from Phase 1 Track 1C):** none. Bug has 0 comments and 0 attachments — the description-only fetch is the complete authoritative content.

## 3. Hypothesized Root Cause (not live-verified)

The NVIDIA-Hosted (`nvdev.env`) profile sets the **image-captioning** VLM to `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` — a **reasoning-mode** model that emits reasoning tokens per request (`LLM_ENABLE_THINKING=true` is the global default in nvdev.env). When the ingestion pipeline calls the caption model once per extracted image/chart/table on bulk multimodal pptx workloads (when `APP_NVINGEST_EXTRACTIMAGES=True`), per-call latency from reasoning generation is suspected to amplify total wall-clock time. **This hypothesis is supported by static config inspection and an inferential parallel to the sibling correctness bug 6130091 — it has NOT been live-verified against the failing 53-pptx test.**

**Candidate root causes considered:**
| # | Hypothesis | Evidence | Ranked |
|---|---|---|---|
| **H2** | Reasoning-mode caption VLM (Nemotron Omni) emits reasoning tokens per request → per-call latency on every image caption on bulk multimodal pptx | `deploy/compose/nvdev.env:84` set caption model to reasoning Omni; existing branch `dev/nikkulkarni/vlm-captioning-fix` (commit `818a61f`) addresses the **correctness** sibling (bug 6130091, missing-caption case) by switching to non-reasoning `nemotron-nano-12b-v2-vl`. The perf parallel is inference, not observation. | **primary (medium-high — config-static only; runtime latency not observed)** |
| H4 | NVIDIA-Hosted cloud routes 5 separate CV endpoints per element (page-elements YOLO, graphic-elements YOLO, table-structure YOLO, OCR, caption) and 429 rate limits add backoff on >10-file ingestion | `nvdev.env:50–58` cloud endpoints; `docs/deploy-docker-nvidia-hosted.md:15`, `docs/troubleshooting.md:187–205` (rate-limit mitigation requires `FILES_PER_BATCH=1`, `CONCURRENT_BATCHES=1`, `MAX_INGEST_PROCESS_WORKERS=1`) | secondary — only applies if original test was NVIDIA-Hosted cloud (the QA log path suggests helm with on-prem NIMs, weakening this) |
| H3 | Default `NV_INGEST_FILES_PER_BATCH=16` and `NV_INGEST_CONCURRENT_BATCHES=4` are conservative for bulk multimodal pptx; `pptx` is not in `TEXT_LIKE_EXTENSIONS` and always falls through to defaults; the 1-second polling loop (`__perform_async_nv_ingest_ingestion` in `src/nvidia_rag/ingestor_server/main.py:2849`) adds wall overhead per batch | `src/nvidia_rag/utils/batch_utils.py:31–46` (text-like set), `src/nvidia_rag/utils/configuration.py:432–446`, `src/nvidia_rag/ingestor_server/main.py:2603–2672` parallel-batch loop | secondary — polling overhead per batch is ≤4 s, not 30 min |
| H1 | `NV_INGEST_MAX_UTIL=8` in nvdev.env (vs default 48) throttles the nv-ingest microservice's worker pool 6× | `deploy/compose/nvdev.env:70` (`export NV_INGEST_MAX_UTIL=8`), `deploy/compose/docker-compose-ingestor-server.yaml:234` default 48, `deploy/helm/nvidia-blueprint-rag/values.yaml:1086` value 48 | **does not apply to the original test** — helm uses 48; H1 affects only local nvdev users. Recorded for completeness. |

**Evidence gaps** (per Track B honesty rule #6 — content that could confirm/refute the primary hypothesis but is NOT available):
- `ingestor-server.log` at `http://httpstorage-vm-01/qvslogs/...` — internal-only; the per-call latency breakdown and per-file timing that would prove which layer dominates were not retrieved.
- The 53-pptx test dataset at `qvsfilestore/.../TCID-104061-Ingestion/` — internal-only; file sizes, image counts per slide, and per-deck multimodal density are unknown.
- The value of `APP_NVINGEST_EXTRACTIMAGES` in the original QA configuration — unknown. If it was `False`, the caption path was never invoked and the primary hypothesis does NOT apply.
- The exact deployment mode of the failing test — inferred to be helm with on-prem NIMs from the log path, but not confirmed.

**Call chain (static):**
```
POST /v1/documents
  → NvidiaRAGIngestor.upload_documents
    → calculate_dynamic_batch_parameters (pptx → defaults: 16/4)
    → __run_nvingest_batched_ingestion (parallel-batch path; asyncio.Semaphore(4))
      → __nv_ingest_ingestion_pipeline (per-batch)
        → _perform_file_ext_based_nv_ingest_ingestion
          → get_nv_ingest_ingestor (uses APP_NVINGEST_CAPTIONMODELNAME if EXTRACTIMAGES=True)
            → nv-ingest extract → caption call → reasoning model → reasoning tokens emitted per call
              [hypothesized per-call latency amplification dominates wall time]
```

**Contributing factors:**
- Uncommitted local changes: yes — this run's workspace edits (the recommended fix).
- Secondary hypotheses not addressed by this fix: H1, H3, H4 (out of scope; would each require separate config tuning or design changes).

## 4. Fix Applied (to workspace; uncommitted)

**Files changed:**
| File | Lines | Change |
|---|---|---|
| `deploy/compose/nvdev.env` | 83–92 | Replace caption model `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` with non-reasoning `nvidia/nemotron-nano-12b-v2-vl`; add an 8-line comment block explicitly labeling the change as UNVERIFIED, scope-limited to nvdev, and conditional on `APP_NVINGEST_EXTRACTIMAGES=True`. |
| `tests/unit/test_deploy/test_nvdev_caption_model_config.py` | NEW, 87 lines | 2 regression tests pinning `nvdev.env`'s caption model: (1) durable invariant — model name does not contain `-reasoning`/`_reasoning` (case-insensitive); (2) exact-match pin against `EXPECTED_CAPTION_MODEL`. Both marked `# UNVERIFIED: could not run live; recommended fix only`. Mirrors the existing `test_seaweedfs_deploy_config.py` config-validator pattern. |

**Diff:**
```diff
diff --git a/deploy/compose/nvdev.env b/deploy/compose/nvdev.env
index df394eb..ed3bd19 100644
--- a/deploy/compose/nvdev.env
+++ b/deploy/compose/nvdev.env
@@ -81,7 +81,15 @@ export APP_VLM_MODELNAME="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
 # export ENABLE_VLM_INFERENCE="true" # Uncomment to use VLM generation
 
 # Image captioning feature
-export APP_NVINGEST_CAPTIONMODELNAME="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
+# NVBug 6191293 (recommendation — root cause not live-verified): the Omni
+# reasoning VLM emits reasoning tokens per request, which is suspected to add
+# per-call latency that can amplify wall time on bulk multimodal ingestion
+# (e.g. the >30 min / 53-pptx report) when image captioning is enabled.
+# nemotron-nano-12b-v2-vl is a non-reasoning captioning VLM. This scope is
+# limited to the NVIDIA-Hosted (nvdev) profile; compose/helm defaults are
+# unchanged. Note: caption calls only run when APP_NVINGEST_EXTRACTIMAGES=True
+# (commented out below) — the original failing-test value is unknown.
+export APP_NVINGEST_CAPTIONMODELNAME="nvidia/nemotron-nano-12b-v2-vl"
 export APP_NVINGEST_CAPTIONENDPOINTURL="https://integrate.api.nvidia.com/v1/chat/completions"
 # export APP_NVINGEST_EXTRACTIMAGES="True" # Uncomment to use image captioning
```

**Why this is minimal and safe:** Single-line config value change (plus comment) and one new test file. No new services, no API changes, no schema changes — scope-limited to nvdev's caption model. Honors the `--instructions` constraint ("NVIDIA-Hosted Cloud docker deployment"). Both models (old and new) are served at the same `integrate.api.nvidia.com/v1/chat/completions` endpoint, so no infrastructure or networking impact.

**Failure modes this fix addresses:**
- Reasoning-token amplification on per-image caption calls in the NVIDIA-Hosted profile, **conditional on** `APP_NVINGEST_EXTRACTIMAGES=True`.

**Failure modes this fix does NOT address:**
- The same reasoning-mode caption model default in `deploy/compose/docker-compose-ingestor-server.yaml:113` (self-hosted compose without nvdev.env sourced) — out of scope per `--instructions`.
- The same reasoning-mode caption model default in `deploy/helm/nvidia-blueprint-rag/values.yaml:427` (helm deployments) — out of scope per `--instructions`. **This is the likely deployment mode of the failing QA test**, so the user should consider extending the fix there before closing the bug. The in-flight engineering branch `dev/nikkulkarni/vlm-captioning-fix` (commit `818a61f`) addresses this for helm by introducing a separate captioning VLM service.
- Default batch sizes (H3) and `NV_INGEST_MAX_UTIL` throttle (H1) — separate config tuning, not changed.
- Cloud rate limits (H4) — inherent to the NVIDIA-Hosted profile; mitigation in `docs/troubleshooting.md:187–205`.

## 5. Tests

- **New test:** `tests/unit/test_deploy/test_nvdev_caption_model_config.py::test_nvdev_env_caption_model_is_not_reasoning_mode` — asserts `APP_NVINGEST_CAPTIONMODELNAME` in nvdev.env does NOT contain `-reasoning`/`_reasoning` (case-insensitive). Marked `# UNVERIFIED: could not run live; recommended fix only`.
- **New test:** `tests/unit/test_deploy/test_nvdev_caption_model_config.py::test_nvdev_env_caption_model_matches_recommended_fix` — asserts exact match against `EXPECTED_CAPTION_MODEL = "nvidia/nemotron-nano-12b-v2-vl"`. Marked `# UNVERIFIED`.
- **Unit test run:** `15 passed` — `uv run pytest tests/unit/test_deploy/ -v` (2 new + 13 pre-existing in the directory).
- **Compose/helm parity test (sanity):** `4 passed` — `uv run pytest tests/unit/test_compose_helm_parity/`. The parity test compares compose YAML to helm values.yaml (NOT nvdev.env), so it still passes — our `nvdev.env` change does not violate any parity contract.
- **Lint:** clean on touched files — `uv run ruff check tests/unit/test_deploy/test_nvdev_caption_model_config.py` and `uv run ruff format --check tests/unit/test_deploy/test_nvdev_caption_model_config.py` both pass. Pre-existing 27 errors elsewhere in `src/` are unchanged (verified with `git stash` baseline comparison) and unrelated to this fix.

## 6. Live E2E Validation

**SKIPPED** — see §2.5. User must verify this recommendation against the live system when the QA dataset and environment are available.

**Suggested verification steps for the user:**
1. Re-run the original failing test (Bulk Upload Multimodal PPTX, TCID-104061) on the same QA helm deployment, with `APP_NVINGEST_CAPTIONMODELNAME` overridden to `nvidia/nemotron-nano-12b-v2-vl` and `APP_NVINGEST_EXTRACTIMAGES=True` (whatever the original was). Measure wall-clock end-to-end.
2. Compare against the original >30 min baseline. **Success** = order-of-magnitude reduction (e.g., < 10 min) attributable to caption-call latency drop.
3. Confirm in the ingestor-server.log that caption requests now hit `nvidia/nemotron-nano-12b-v2-vl` and that per-image caption latency drops significantly.
4. **If perf still bad:** the primary hypothesis is wrong (or only partial). Re-evaluate H4 (cloud rate limits — if the test was on nvdev cloud), H3 (batch sizes), or open a follow-up bug for the in-pipeline serialization in `__perform_async_nv_ingest_ingestion` (the 1 s poll loop).
5. **If the test was on helm:** consider extending this fix to `deploy/helm/nvidia-blueprint-rag/values.yaml:427`, or land the in-flight engineering branch `dev/nikkulkarni/vlm-captioning-fix` instead.

## 6.5 Expert Review

**Aggregated verdict:** approve (after Cycle 2 re-iteration)
**Cycles used:** 2 of 3

| # | Reviewer | Verdict | Findings |
|---|---|---|---|
| R1 | Root-cause linkage | approve w/ caveat | 2 major (Helm/compose YAML defaults still reasoning-mode — **intentionally out of scope** per `--instructions`, downgraded to minor + recorded as §4 "failure modes not addressed") + 1 minor + 1 nit |
| R2 | Coding conventions | approve | minor only (module docstring; matches sibling style closely) |
| R3 | Generic code quality | approve | 1 major same as R1 (parity) — same scope rationale, downgraded; 4 minor + 2 nit; Cycle-2 edits addressed `_parse_exports` docstring honesty and added `.lower()` normalization |
| R4 | Scope discipline | approve | both hunks in scope |
| R5 | Test adequacy | approve | clean; UNVERIFIED markers placed correctly |
| **R6** | **Evidence honesty (Track B)** | approve (after Cycle 2) | **Cycle 1: 1 blocker + 2 major + 1 minor — all resolved in Cycle 2.** Cycle 2: 1 minor (unverified hypothesis enforced as CI gate — acknowledged) + 1 nit. |
| R7 | Custom instructions compliance | approve | 1 suggestion (could explicitly invoke deploy skill restart procedure — non-blocking) |

**Non-blocking notes** (minor / suggestion / nit, preserved from reviewers):
- `deploy/compose/nvdev.env:84-91` — comment block adheres to surrounding style.
- `tests/unit/test_deploy/test_nvdev_caption_model_config.py:5–9` — module docstring is present where some siblings omit one; minor stylistic divergence, acceptable for bug-specific test files.
- `_parse_exports` does not resolve `${VAR}` interpolation, escaped quotes, or inline comments — limitation now documented in the docstring (R3 F2 Cycle 1 → addressed Cycle 2).
- `EXPECTED_CAPTION_MODEL` is a single hard-coded pin — durable invariant lives in the sibling test; this one is the recommendation pin. Docstring guides maintainers (R3 F3).
- Reasoning marker tuple now applies `.lower()` normalization for case-insensitive matching (R3 F4 Cycle 1 → addressed Cycle 2).
- File reads in each test are independent — fixture extraction would be cleaner but not material (R3 F7 — nit, not actioned).
- R7 suggestion: could explicitly invoke the rag-blueprint deploy skill's `source nvdev.env` + recreate procedure to close the verification gap.

**Runtime findings downgraded to evidence gaps** (R3 leniency under Track B — to be verified by user):
- "Reasoning tokens dominate caption-call wall time" — text-asserted in Cycle 1 artifacts, softened in Cycle 2; user must measure per-call latency in the live QA env.
- The relative contribution of H2 vs H3/H4 to the original 30-min wall time is unknown; if the user observes < 10× speedup after applying this fix, H3 or H4 (or both) are non-trivial contributors.

## 7. Attempt Timeline

| # | Phase | Action | Outcome |
|---|---|---|---|
| 1 | Phase 1 — Setup | Verified rag-blueprint stack already healthy on NVIDIA-Hosted profile (rag-frontend, rag-server, ingestor-server, nv-ingest-ms-runtime, redis, elasticsearch, seaweedfs); ingestor /health returned healthy with all NIMs at `integrate.api.nvidia.com`. | OK (idempotent) |
| 2 | Phase 1 — Track 1B | Infrastructure scout enumerated `skill-source/.agents/skills/` (rag-blueprint, rag-eval, rag-perf); test runner = `uv run pytest`; lint = `ruff`; deploy = `docker compose -f deploy/compose/...` | OK |
| 3 | Phase 1 — Track 1C | NVBug 6191293 fetched via `scripts/maas/nvbugs_mcp.py`: synopsis, description, 0 comments, 0 attachments | OK |
| 4 | Phase 1 — Reproduction Attempt 1 | 5 synthetic text-only pptx → 10 s ingest (2 s/file) | `no error observed` |
| 5 | Phase 1 — Gap analysis + Attempt 2 | 10 synthetic multimodal pptx (images + chart + table) → 15 s ingest (1.5 s/file) | `no error observed` → enter Track B |
| 6 | Phase 2 — Analyze (Track B) | Dispatched 4 hypothesis-evidence subagents in parallel. Ranked H2 primary, H4/H3 secondary, H1 not applicable. Discovered `818a61f` (in-flight engineering fix for sibling correctness bug 6130091). | H2 primary |
| 7 | Phase 3 — Plan fix | Minimal nvdev.env config change + UNVERIFIED test. Track B STOP-condition (runtime dependence) acknowledged in report. | Planned |
| 8 | Phase 4 — Apply fix | Edited `nvdev.env`, created `tests/unit/test_deploy/test_nvdev_caption_model_config.py`. | Applied |
| 9 | Phase 5 — Validate (Cycle 1) | 15 unit tests passed; lint clean on touched files | OK |
| 10 | Phase 6 — Expert Review (Cycle 1) | Dispatched R1–R5 + R6 + R7 in parallel. R6 returned BLOCKER (commit citation conflates perf vs correctness), 2 MAJOR (overstated wall-time claim; EXTRACTIMAGES gap). | changes_requested → Cycle 2 |
| 11 | Phase 3-4 — Re-plan + Re-edit (Cycle 2) | Softened comment in `nvdev.env`; removed commit `818a61f` citation from test docstring; added `.lower()` normalization to `REASONING_MARKERS`; tightened `_parse_exports` docstring re actual capabilities; added scope/EXTRACTIMAGES note | Re-applied |
| 12 | Phase 5 — Validate (Cycle 2) | 15 unit tests passed; lint clean | OK |
| 13 | Phase 6 — Re-Review (Cycle 2) | R6 re-dispatched. All 4 Cycle-1 findings RESOLVED. 1 new minor + 1 nit, no new blockers. | approve |
| 14 | Phase 7 — Report & Audit | This report. NVBug update skipped per `--no-nvbugs-update`. | done |

## 8. Incidental Findings

- **`deploy/helm/nvidia-blueprint-rag/values.yaml:427`** — Helm default caption model is `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` (same reasoning-mode VLM). If the original failing test was on helm (likely per log path inference), the bug will reproduce there until this default is also flipped. **Suggested severity: major (for the human triager).** The in-flight branch `dev/nikkulkarni/vlm-captioning-fix` addresses this comprehensively by introducing a separate captioning VLM service — recommend reviewing/merging that PR.
- **`deploy/compose/docker-compose-ingestor-server.yaml:113`** — Compose YAML default for `APP_NVINGEST_CAPTIONMODELNAME` is also the reasoning Omni model. Self-hosted compose deployments without `source nvdev.env` would still hit the bug. **Suggested severity: minor** (self-hosted is documented to need nvdev sourcing).
- **`deploy/workbench/compose.yaml:280`** — workbench compose also hardcodes the reasoning caption model. **Suggested severity: minor.**
- **`notebooks/launchable.ipynb:1117`** — user-facing notebook hardcodes the reasoning caption model in an export. **Suggested severity: minor.**
- **`docs/image_captioning.md:52, 90`** — docs reference the reasoning caption model. **Suggested severity: nit.**
- **`deploy/compose/nvdev.env:80`** — `APP_VLM_MODELNAME` (generation/chat VLM, distinct from captioning) is still the reasoning Omni. This is **intentional** per the in-flight engineering split (Omni for generation, nano-12b for captioning) and is NOT a defect. Recorded for clarity.

**Note on evidence gaps:** The H1 finding (`NV_INGEST_MAX_UTIL=8` override in nvdev.env) is a separate config divergence from helm's 48 and may itself be a misconfiguration warranting its own NVBug if it surprises users on nvdev. Suggested severity: minor / triage-only.

## 9. Follow-ups for the Human

- [ ] Review the diff (`git diff` + `git status` to see the untracked test file).
- [ ] Verify the recommended fix against the live system: re-run TCID-104061 with the new caption model and `APP_NVINGEST_EXTRACTIMAGES` set to whatever the original failing test used. Measure wall-clock before/after.
- [ ] If the failing QA test was on **helm** (likely), apply the same caption-model change in `deploy/helm/nvidia-blueprint-rag/values.yaml:427`, or land `dev/nikkulkarni/vlm-captioning-fix` (PR-ready engineering fix).
- [ ] Consider follow-up triage for the §8 incidental findings (workbench compose, notebook, docs) for full deployment-surface consistency.
- [ ] Commit or revert based on verification outcome.
- [ ] Set NVBug 6191293 BugAction / Disposition (intentionally left to human — see §10).

## 10. NVBugs Audit Trail

- **NVBug ID:** 6191293
- **Comment posted:** no — `--no-nvbugs-update` flag was passed.
- **Comment type:** *(n/a — no comment posted)*
- **BugAction / Disposition:** **left unchanged — human to set**
- **NVBug update skipped** per `--no-nvbugs-update` flag (both Track A and Track B respect this flag).

</details>
