### PR TITLE
Misc updates to Helm docs for RAG 2.6.0, drop rc1 tag

### DIFF
--- a/deploy/helm/nvidia-blueprint-rag/Chart.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v2.6.0-rc1
+appVersion: v2.6.0
 dependencies:
 - condition: nv-ingest.enabled
   name: nv-ingest
@@ -28,4 +28,4 @@ dependencies:
 description: An end to end Helm chart for the NVIDIA RAG Blueprint
 name: nvidia-blueprint-rag
 type: application
-version: v2.6.0-rc1
+version: v2.6.0

--- a/docs/deploy-helm-from-repo.md
+++ b/docs/deploy-helm-from-repo.md
@@ -14,7 +14,6 @@ The following are the core services that you install:
 
 - RAG server
 - Ingestor server
-- NeMo Retriever Library
 
 
 ## Prerequisites

--- a/docs/deploy-helm-openshift.md
+++ b/docs/deploy-helm-openshift.md
@@ -186,7 +186,7 @@ To deploy the RAG Blueprint on OpenShift, use the following procedure.
 
     ```sh
     # Pull and untar the chart from NGC
-    helm pull https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0-rc1.tgz \
+    helm pull https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
       --username '$oauthtoken' --password "$NGC_API_KEY" \
       --untar --untardir /tmp
 

--- a/docs/deploy-helm.md
+++ b/docs/deploy-helm.md
@@ -14,7 +14,6 @@ The following are the core services that you install:
 
 - RAG server
 - Ingestor server
-- NeMo Retriever Library
 
 
 ## Prerequisites
@@ -99,7 +98,7 @@ To deploy End-to-End RAG Server and Ingestor Server, use the following procedure
 2. Install the Helm chart by running the following command.
 
     ```sh
-    helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0-rc1.tgz \
+    helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
     --username '$oauthtoken' \
     --password "${NGC_API_KEY}" \
     --set imagePullSecret.password=$NGC_API_KEY \
@@ -124,7 +123,7 @@ To deploy End-to-End RAG Server and Ingestor Server, use the following procedure
    
    Then install using the modified values.yaml:
    ```sh
-   helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0-rc1.tgz \
+   helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
      --username '$oauthtoken' \
      --password "${NGC_API_KEY}" \
      --set imagePullSecret.password=$NGC_API_KEY \
@@ -261,7 +260,7 @@ Port-forwarding is provided as a quick method to try out the UI. However, large 
 To change an existing deployment, after you modify the [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml) file, run the following code.
 
 ```sh
-helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0-rc1.tgz \
+helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
 --username '$oauthtoken' \
 --password "${NGC_API_KEY}" \
 --set imagePullSecret.password=$NGC_API_KEY \

--- a/docs/mig-deployment.md
+++ b/docs/mig-deployment.md
@@ -197,7 +197,7 @@ You should see output similar to the following.
 Run the following code to install the RAG Blueprint Helm Chart.
 
 ```bash
-helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0-rc1.tgz \
+helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
   --username '$oauthtoken' \
   --password "${NGC_API_KEY}" \
   --set imagePullSecret.password=$NGC_API_KEY \
@@ -211,7 +211,7 @@ helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprin
 If you are deploying on NVIDIA RTX6000 Pro GPUs (instead of H100 GPUs), use [`values-mig-rtx6000.yaml`](../deploy/helm/mig-slicing/values-mig-rtx6000.yaml) and [`mig-config-rtx6000.yaml`](../deploy/helm/mig-slicing/mig-config-rtx6000.yaml) which include the RTX6000-specific MIG profiles and NIM LLM model configuration.
 
 ```sh
-helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0-rc1.tgz \
+helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
   --username '$oauthtoken' \
   --password "${NGC_API_KEY}" \
   --set imagePullSecret.password=$NGC_API_KEY \

--- a/docs/retrieval-only-deployment.md
+++ b/docs/retrieval-only-deployment.md
@@ -229,32 +229,73 @@ python scripts/retriever_api_usage.py \
 
 Use the same cluster prerequisites as a full Helm deployment, including the ECK operator for the default Elasticsearch vector database—refer to [Deploy on Kubernetes with Helm](deploy-helm.md#prerequisites).
 
-For Kubernetes deployments, configure the Helm chart to disable the LLM NIM:
+In the v2.6.0 chart, the embedding and reranking NIMs are enabled by default; the LLM NIM (`nim-llm`) is also enabled by default and must be disabled for retrieval-only mode. The VLM generation (`nim-vlm`) and VLM captioning (`nim-vlm-captioning`) services are disabled by default and require no action.
+
+| Component | v2.6.0 default | Retrieval-only |
+|-----------|----------------|----------------|
+| `nim-llm` (LLM) | enabled | **set to `false`** |
+| `nvidia-nim-llama-nemotron-embed-vl-1b-v2` (VLM embedder) | enabled | leave enabled |
+| `nvidia-nim-llama-nemotron-rerank-1b-v2` (text reranker) | enabled | leave enabled |
+| `nim-vlm`, `nim-vlm-captioning` | disabled | leave disabled |
+
+### Option A: --set flag
 
 ```bash
-helm upgrade --install rag nvidia-blueprint-rag \
-  --namespace rag \
+helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
+  --username '$oauthtoken' \
+  --password "${NGC_API_KEY}" \
   --set nimOperator.nim-llm.enabled=false \
-  --set nimOperator.nvidia-nim-llama-nemotron-embed-1b-v2.enabled=true \
-  --set nimOperator.nvidia-nim-llama-nemotron-rerank-1b-v2.enabled=true \
   --set imagePullSecret.password=$NGC_API_KEY \
   --set ngcApiSecret.password=$NGC_API_KEY
 ```
 
-Or modify `values.yaml`:
+### Option B: values.yaml override
 
 ```yaml
-# Disable LLM NIM for retrieval-only deployment
+# Disable LLM NIM for retrieval-only deployment.
+# VLM embedder + text reranker stay on chart defaults (enabled).
 nimOperator:
   nim-llm:
     enabled: false
+```
 
-  # Keep embedding and reranking NIMs enabled
+### (Optional) Use the text embedder instead of the VLM embedder
+
+If you don't want to pull the VLM embedding NIM, switch to the text embedder by flipping the two embedder enable flags and pointing the embedding env vars at the text NIM:
+
+```yaml
+nimOperator:
+  nim-llm:
+    enabled: false
+  nvidia-nim-llama-nemotron-embed-vl-1b-v2:
+    enabled: false
   nvidia-nim-llama-nemotron-embed-1b-v2:
     enabled: true
 
-  nvidia-nim-llama-nemotron-rerank-1b-v2:
-    enabled: true
+envVars:
+  APP_EMBEDDINGS_MODELNAME: "nvidia/llama-nemotron-embed-1b-v2"
+  APP_EMBEDDINGS_SERVERURL: "nemotron-embedding-ms:8000/v1"
+
+ingestor-server:
+  envVars:
+    APP_EMBEDDINGS_MODELNAME: "nvidia/llama-nemotron-embed-1b-v2"
+    APP_EMBEDDINGS_SERVERURL: "nemotron-embedding-ms:8000/v1"
+
+nv-ingest:
+  envVars:
+    EMBEDDING_NIM_ENDPOINT: "http://nemotron-embedding-ms:8000/v1"
+    EMBEDDING_NIM_MODEL_NAME: "nvidia/llama-nemotron-embed-1b-v2"
+```
+
+Apply the chart with the values override:
+
+```bash
+helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
+  --username '$oauthtoken' \
+  --password "${NGC_API_KEY}" \
+  --set imagePullSecret.password=$NGC_API_KEY \
+  --set ngcApiSecret.password=$NGC_API_KEY \
+  -f values.yaml
 ```
 
 

--- a/docs/text_only_ingest.md
+++ b/docs/text_only_ingest.md
@@ -15,12 +15,7 @@ You can enable text-only ingestion for the [NVIDIA RAG Blueprint](readme.md). Fo
    export APP_NVINGEST_EXTRACTINFOGRAPHICS=False
    export APP_NVINGEST_EXTRACTTABLES=False
    export APP_NVINGEST_EXTRACTCHARTS=False
-   export COMPONENTS_TO_READY_CHECK=""
    ```
-
-   :::{important}
-   When disabling NeMo Retriever Library dependent services, you must set `COMPONENTS_TO_READY_CHECK=""` to ensure the NeMo Retriever Library container reaches ready state. Without this setting, the NeMo Retriever Library container will wait indefinitely for the disabled components.
-   :::
 
    Then deploy the ingestor-server:
 
@@ -53,7 +48,7 @@ You can enable text-only ingestion for the [NVIDIA RAG Blueprint](readme.md). Fo
 5. Once the ingestion and rag servers are deployed, open the [ingestion notebook](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/notebooks/ingestion_api_usage.ipynb) and follow the steps. While trying out the `Upload Document Endpoint` set the payload to below.
    ```bash
        data = {
-        "vdb_endpoint": "http://milvus:19530",
+        "vdb_endpoint": "http://elasticsearch:9200",
         "collection_name": collection_name,
         "split_options": {
             "chunk_size": 1024,
@@ -81,66 +76,63 @@ In case you are [interacting with cloud hosted models](deploy-docker-nvidia-host
 To ingest text-only files, you do not need to deploy the complete pipeline with all NIMs connected.
 If your scenario requires only text extraction from files, use the following steps to deploy only the necessary components using Helm.
 
-When you install the Helm chart, enable only the following services that are required for text ingestion:
+In the v2.6.0 chart, the **VLM embedder** (`nvidia-nim-llama-nemotron-embed-vl-1b-v2`) is enabled by default and the **text embedder** (`nvidia-nim-llama-nemotron-embed-1b-v2`) is disabled. For text-only ingestion, flip the two flags and repoint the embedding env vars at the text endpoint. Keep the following enabled:
 
 - `rag-server`
 - `ingestor-server`
 - `nv-ingest`
-- `nvidia-nim-llama-nemotron-embed-1b-v2`
-- `text-reranking-nim`
+- `nvidia-nim-llama-nemotron-embed-1b-v2` (text embedder)
+- `nvidia-nim-llama-nemotron-rerank-1b-v2` (text reranker)
 - `nim-llm`
-- `milvus`
+- `eck-elasticsearch`
 - `seaweedfs`
 
-Additionally, ensure that **table extraction**, **chart extraction**, and **image extraction** are disabled.
+Additionally, disable **table extraction**, **chart extraction**, and **image extraction**.
 
-1. First, modify the environment variables in [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml) to enable text-only extraction:
+1. Modify [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml) to (a) swap the embedder NIMs, (b) repoint embedding env vars at the text endpoint, and (c) turn off image/table/chart extraction:
 
-   In the `nv-ingest.envVars` section, set the following values:
-   
    ```yaml
+   nimOperator:
+     # Disable VLM embedder, enable text embedder
+     nvidia-nim-llama-nemotron-embed-vl-1b-v2:
+       enabled: false
+     nvidia-nim-llama-nemotron-embed-1b-v2:
+       enabled: true
+
+   # rag-server: point at the text embedder
+   envVars:
+     APP_EMBEDDINGS_MODELNAME: "nvidia/llama-nemotron-embed-1b-v2"
+     APP_EMBEDDINGS_SERVERURL: "nemotron-embedding-ms:8000/v1"
+
+   ingestor-server:
+     envVars:
+       APP_EMBEDDINGS_MODELNAME: "nvidia/llama-nemotron-embed-1b-v2"
+       APP_EMBEDDINGS_SERVERURL: "nemotron-embedding-ms:8000/v1"
+
    nv-ingest:
      envVars:
-       # ... existing configurations ...
-       
-       # === Text-Only Extraction Mode ===
+       # Embedding target for the nv-ingest runtime
+       EMBEDDING_NIM_ENDPOINT: "http://nemotron-embedding-ms:8000/v1"
+       EMBEDDING_NIM_MODEL_NAME: "nvidia/llama-nemotron-embed-1b-v2"
+
+       # Text-only extraction mode
        APP_NVINGEST_EXTRACTTEXT: "True"
        APP_NVINGEST_EXTRACTINFOGRAPHICS: "False"
        APP_NVINGEST_EXTRACTTABLES: "False"
        APP_NVINGEST_EXTRACTCHARTS: "False"
    ```
 
-2. Then use the modified [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml) file in your Helm upgrade command:
+2. Apply the chart with the modified values, disabling the nv-ingest CV NIMs you no longer need:
 
-```bash
-helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0-rc1.tgz \
-  --username '$oauthtoken' \
-  --password "${NGC_API_KEY}" \
-  --values deploy/helm/nvidia-blueprint-rag/values.yaml \
-  --set nimOperator.nim-llm.enabled=true \
-  --set nimOperator.nvidia-nim-llama-nemotron-embed-1b-v2.enabled=true \
-  --set nimOperator.nvidia-nim-llama-nemotron-rerank-1b-v2.enabled=true \
-  --set ingestor-server.enabled=true \
-  --set nv-ingest.enabled=true \
-  --set nv-ingest.nimOperator.page_elements.enabled=false \
-  --set nv-ingest.nimOperator.graphic_elements.enabled=false \
-  --set nv-ingest.nimOperator.table_structure.enabled=false \
-  --set nv-ingest.nimOperator.ocr.enabled=false \
-  --set imagePullSecret.password=$NGC_API_KEY \
-  --set ngcApiSecret.password=$NGC_API_KEY
-```
-
-:::{important}
-**Disabling NeMo Retriever Library Components for GPU Resource Management:**
-
-If you disable any nv-ingest dependent services (such as `table_structure`, `graphic_elements`, `ocr`, etc.) to free up GPU resources for customization, you must set the `COMPONENTS_TO_READY_CHECK` parameter to an empty string in the `nv-ingest.envVars` section of your [values.yaml](../deploy/helm/nvidia-blueprint-rag/values.yaml) file:
-
-```yaml
-nv-ingest:
-  envVars:
-    COMPONENTS_TO_READY_CHECK: ""
-```
-
-This ensures the NeMo Retriever Library pod reaches ready state even when some dependent components are disabled. Without this setting, the NeMo Retriever Library pod will wait indefinitely for the disabled components to become ready.
-
-:::
+   ```bash
+   helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
+     --username '$oauthtoken' \
+     --password "${NGC_API_KEY}" \
+     --values deploy/helm/nvidia-blueprint-rag/values.yaml \
+     --set nv-ingest.nimOperator.page_elements.enabled=false \
+     --set nv-ingest.nimOperator.graphic_elements.enabled=false \
+     --set nv-ingest.nimOperator.table_structure.enabled=false \
+     --set nv-ingest.nimOperator.ocr.enabled=false \
+     --set imagePullSecret.password=$NGC_API_KEY \
+     --set ngcApiSecret.password=$NGC_API_KEY
+   ```

--- a/docs/vlm.md
+++ b/docs/vlm.md
@@ -143,7 +143,17 @@ Continue with [Deploy with Docker (NVIDIA-Hosted Models)](deploy-docker-nvidia-h
    APP_VLM_SERVERURL: "http://nim-vlm:8000/v1"
    ```
 
-2. Enable `nim-vlm` and disable `nim-llm` (VLM replaces LLM for generation):
+2. Enable image extraction (and the captioning that runs alongside it) for ingestion. Under `ingestor-server.envVars`, set:
+
+   ```yaml
+   ingestor-server:
+     envVars:
+       APP_NVINGEST_EXTRACTIMAGES: "True"
+   ```
+
+   Image captioning is recommended when running VLM generation so that ingested images are indexed with their captions and surface as citations at query time.
+
+3. Enable `nim-vlm` and disable `nim-llm` (VLM replaces LLM for generation):
 
    ```yaml
    nimOperator:
@@ -157,9 +167,9 @@ Continue with [Deploy with Docker (NVIDIA-Hosted Models)](deploy-docker-nvidia-h
    By disabling `nim-llm` and enabling `nim-vlm`, the VLM uses the GPU resources normally allocated to the LLM, so no additional hardware is required.
    :::
 
-3. Apply the changes as described in [Change a Deployment](deploy-helm.md#change-a-deployment). For full steps, see [Deploy with Helm](deploy-helm.md).
+4. Apply the changes as described in [Change a Deployment](deploy-helm.md#change-a-deployment). For full steps, see [Deploy with Helm](deploy-helm.md).
 
-4. Verify the VLM pod is running. A pod with the name `nim-vlm-*` will start (the `nim-llm` pod will not be created when it is disabled). Example status:
+5. Verify the VLM pod is running. A pod with the name `nim-vlm-*` will start (the `nim-llm` pod will not be created when it is disabled). Example status:
 
    ```text
    rag       nim-vlm-f4c446cbf-ffzm7       1/1     Running   0          22m

--- a/tests/integration/test_cases/multimodal_query.py
+++ b/tests/integration/test_cases/multimodal_query.py
@@ -95,7 +95,7 @@ Helm Deployment:
 
     2. Deploy or upgrade the chart:
 
-        helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0-rc1.tgz \\
+        helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \\
           --username '$oauthtoken' \\
           --password "${NGC_API_KEY}" \\
           --set imagePullSecret.password=$NGC_API_KEY \\


### PR DESCRIPTION
- Misc updates to Helm docs for RAG 2.6.0
- Dropping rc1 tag from the chart.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.