### PR TITLE
chore(ci): sync copy-pr-bot.yaml + run-branch-script.yml from main to…

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,0 +1,14 @@
+# copy-pr-bot configuration for NVIDIA-AI-Blueprints/rag
+# Docs: https://docs.gha-runners.nvidia.com/platform/apps/copy-pr-bot/
+#
+# All NVIDIA org members with write access are auto-trusted and auto-vetters.
+# No individual names needed — scales to any number of contributors.
+# Commit signing required for trusted-change classification.
+# See: https://docs.github.com/en/authentication/managing-commit-signature-verification
+#
+# Only add to additional_vetters if someone needs vetting rights
+# but has read-only repo access (rare for internal repos).
+
+enabled: true
+auto_sync_draft: false
+auto_sync_ready: true

--- a/.github/workflows/run-branch-script.yml
+++ b/.github/workflows/run-branch-script.yml
@@ -16,6 +16,16 @@ on:
         description: 'Script path relative to repo root'
         required: true
         default: 'ci/run_nvbase_eval.sh'
+      runner:
+        description: 'Runner label to use'
+        required: true
+        default: 'blueprints-skills-eval-runner'
+        type: choice
+        options:
+          - blueprints-skills-eval-runner
+          - sonarqube-workflows-bp-sre
+          - arc-runners-org-nvidia-ai-bp-2-gpu
+          - rag-eval
 
 permissions:
   contents: read
@@ -27,7 +37,7 @@ concurrency:
 jobs:
   run:
     name: Run ${{ inputs.script }} on ${{ inputs.ref }}
-    runs-on: arc-runners-org-nvidia-ai-bp-2-gpu
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 120
 
     steps:


### PR DESCRIPTION
… develop

Brings two CI files from main into develop to prevent merge conflicts on the upcoming v2.6.0 release (develop → main):

- .github/copy-pr-bot.yaml: enables automated PR mirroring for skill eval CI pipeline
- .github/workflows/run-branch-script.yml: adds rag-eval runner option and makes runner configurable for skill eval dispatches

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.