### PR TITLE
v2.6.0.rc2: frontend base 4.0.7 and release notes updates

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,23 +10,26 @@ This documentation contains the release notes for [NVIDIA RAG Blueprint](readme.
 
 ## Release 2.6.0 (TBD)
 
-This release updates the default deployment stack to Elasticsearch and SeaweedFS, moves the default model stack to Nemotron 3 Super with VLM embeddings, and adds agentic, filtering, and evaluation capabilities to the RAG pipeline.
+This release adds [Agentic RAG](./agentic-rag.md) support with plan-and-execute pipelines, streaming responses, and UI integration; changes the default vector database to Elasticsearch and the default object store to SeaweedFS; and introduces new [agent skills](../skill-source/README.md) for deployment, evaluation, and performance tooling.
 
 ### Highlights
 
 This release includes the following key updates:
 
 - [Added Agentic RAG support](./agentic-rag.md), including the plan-and-execute pipeline, streaming responses, and RAG UI integration.
-- Changed the default vector database to Elasticsearch. Milvus remains available as an optional vector database backend.
+- Changed the default vector database to Elasticsearch. 
+  - [GPU accelerated support needs enterprise access](./elasticsearch-configuration.md) and is disabled by default.
+  - [Milvus](./change-vectordb.md) remains available as an optional vector database backend.
 - Changed the default object store to SeaweedFS from MinIO.
 - Updated the default LLM to `nvidia/nemotron-3-super-120b-a12b` and enabled Nemotron reasoning by default in deployment configurations.
-- Promoted `nvidia/llama-nemotron-embed-vl-1b-v2` as the default embedding model. The text embedding model `nvidia/llama-nemotron-embed-1b-v2` remains available as an optional configuration.
-- Added VLM reranker support as an opt-in.
+- Promoted `nvidia/llama-nemotron-embed-vl-1b-v2` as the default embedding model. The text embedding model `nvidia/llama-nemotron-embed-1b-v2` remains available as [an optional configuration](./change-model.md#switch-from-the-vlm-embedder-to-the-text-only-embedder).
+- Added [VLM reranker support](./change-model.md#switch-to-the-vlm-reranker) as an opt-in.
 - Added dynamic filter expression generation for Elasticsearch.
-- Published RAG performance tooling on GitHub.
-- Published the RAG evaluation framework on GitHub.
+- Published [RAG performance tooling](../scripts/rag-perf/) and [skills](../skill-source/README.md) to use it easily.
+- Published the [RAG evaluation framework](../scripts/eval/README.md) and [skills](../skill-source/README.md) to use it easily.
 - Updated NV-Ingest to version 26.3.0.
 - Updated OCR NIM naming from `nemoretriever-ocr-v1` to `nemotron-ocr-v1`.
+- Added OpenClaw plugin for agent-driven deploy/configure/eval workflows.
 
 ### Fixed Known Issues
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-# Build stage - OSRB approved Ubuntu base (Bug 3840915)
+# Build stage
 FROM nvcr.io/nvidia/base/ubuntu:jammy-20260217 AS builder
 
 ARG DOWNLOAD_LEGAL_COMPLIANCE=false
@@ -92,8 +92,7 @@ RUN if [ "$DOWNLOAD_LEGAL_COMPLIANCE" = "true" ] && [ -d /legal ]; then \
     fi
 
 # Production stage - NVIDIA distroless (pre-approved)
-# Updated to latest version to address CVE-2025-9230 (libssl3)
-FROM nvcr.io/nvidia/distroless/node:24-v4.0.6
+FROM nvcr.io/nvidia/distroless/node:24-v4.0.7
 
 # Copy built application and config for production preview
 WORKDIR /app/frontend


### PR DESCRIPTION
## Summary

Finalizes **v2.6.0.rc2** release prep on top of `develop` with two focused changes:

1. **Frontend base image** — Bump production distroless Node base from `24-v4.0.6` to `24-v4.0.7` in `frontend/Dockerfile` (addresses updated NVIDIA base image / prior CVE-related base refresh).
2. **Release notes** — Update `docs/release-notes.md` for the 2.6.0 release: revised intro emphasizing Agentic RAG, default Elasticsearch/SeaweedFS stack, and new agent skills; expanded highlights (ES GPU note, doc links for Milvus/embedder/reranker/skills/eval); OpenClaw plugin bullet.

## Commits

| Commit | Description |
|--------|-------------|
| `791dc83` | Update frontend base version to 4.0.7 |
| `4f807d0` | Update release notes for v2.6.0 release |

## Release notes changes (detail)

- **Intro**: Leads with Agentic RAG, default VDB (Elasticsearch) + object store (SeaweedFS), and agent skills for deploy/eval/perf.
- **Highlights**: ES enterprise GPU note; links to `change-vectordb.md`, `change-model.md`, `scripts/rag-perf/`, `scripts/eval/`, and `skill-source/`; OpenClaw plugin entry.

## Test plan

- [x] `frontend/Dockerfile` builds successfully with `nvcr.io/nvidia/distroless/node:24-v4.0.7`
- [ ] Release notes render correctly in docs (links resolve)
- [x] No other files changed beyond `frontend/Dockerfile` and `docs/release-notes.md`