### PR TITLE
ci: bump GitHub Actions to Node.js 24 runtimes

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -38,10 +38,10 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: 'latest'
 
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: actions/setup-python@v3
       - uses: pre-commit/action@v3.0.1
@@ -79,7 +79,7 @@ jobs:
       image: python:3.12-slim
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install system dependencies
         run: |
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -152,7 +152,7 @@ jobs:
           pnpm test:coverage
 
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: frontend-coverage-${{ steps.sanitize.outputs.ref_name }}-${{ github.sha }}
@@ -166,7 +166,7 @@ jobs:
       image: python:3.12-slim
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install required packages
         run: |
@@ -192,7 +192,7 @@ jobs:
       ENABLE_NRL_INTEGRATION_TESTS: "false"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install NGC CLI
         env:          
@@ -1264,7 +1264,7 @@ jobs:
           echo "ref_name=$SANITIZED_REF" >> $GITHUB_OUTPUT
 
       - name: Upload all integration test logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: integration-tests-logs-${{ steps.sanitize.outputs.ref_name }}-${{ github.sha }}

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -73,7 +73,7 @@ jobs:
       image: python:3.10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set artifactory version
         run: |
@@ -101,7 +101,7 @@ jobs:
           ls -la dist/
 
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: wheel-${{ env.ARTIFACTORY_VERSION }}
           path: dist/*.whl
@@ -156,10 +156,10 @@ jobs:
     if: github.event_name != 'workflow_dispatch' || ((github.event.inputs.JOBS_TO_RUN == 'all' || github.event.inputs.JOBS_TO_RUN == 'containers-only') && github.event.inputs.PUBLISH_RAG_SERVER != 'false')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Determine TAG
         id: tag
@@ -177,7 +177,7 @@ jobs:
           echo "Final TAG value: $TAG"
 
       - name: Login to NGC Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: nvcr.io
           username: '$oauthtoken'
@@ -216,10 +216,10 @@ jobs:
     if: github.event_name != 'workflow_dispatch' || ((github.event.inputs.JOBS_TO_RUN == 'all' || github.event.inputs.JOBS_TO_RUN == 'containers-only') && github.event.inputs.PUBLISH_INGESTOR_SERVER != 'false')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Determine TAG
         id: tag
@@ -237,7 +237,7 @@ jobs:
           echo "Final TAG value: $TAG"
 
       - name: Login to NGC Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: nvcr.io
           username: '$oauthtoken'
@@ -276,10 +276,10 @@ jobs:
     if: github.event_name != 'workflow_dispatch' || ((github.event.inputs.JOBS_TO_RUN == 'all' || github.event.inputs.JOBS_TO_RUN == 'containers-only') && github.event.inputs.PUBLISH_RAG_FRONTEND != 'false')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Determine TAG
         id: tag
@@ -297,7 +297,7 @@ jobs:
           echo "Final TAG value: $TAG"
 
       - name: Login to NGC Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: nvcr.io
           username: '$oauthtoken'
@@ -336,10 +336,10 @@ jobs:
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.JOBS_TO_RUN == 'all' || github.event.inputs.JOBS_TO_RUN == 'helm-chart-only'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: 'v3.17.0'
 

--- a/.github/workflows/run-branch-script.yml
+++ b/.github/workflows/run-branch-script.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout target ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
 
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: branch-script-${{ github.run_id }}
           path: |

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -83,7 +83,7 @@ jobs:
           done
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload results artifact
         if: always() && (github.event_name != 'push' || steps.changes.outputs.relevant == 'true')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: >-
             ${{ github.event_name == 'schedule'

--- a/.github/workflows/skills-nv-base.yml
+++ b/.github/workflows/skills-nv-base.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout mirror head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

- Updates `actions/checkout` and `actions/upload-artifact` from v4 to v5 across CI and publish workflows.
- Updates `azure/setup-helm` from v4 to v5 and Docker actions (`setup-buildx-action`, `login-action`) from v3 to v4 in `publish-artifacts.yml`.
- Resolves GitHub Actions Node.js 20 deprecation warnings on Publish Artifacts jobs (wheel, Helm chart, RAG server/frontend containers) and related CI workflows.

Same changes as #595, targeting `develop` for the mainline branch.

## Test plan

- [ ] Re-run **Publish Artifacts** workflow (or individual jobs via `workflow_dispatch`) and confirm Node.js 20 deprecation annotations are gone.
- [ ] Verify publish jobs still succeed: Python wheel, Helm chart, RAG server, RAG frontend containers.
- [ ] Spot-check CI pipeline jobs that use updated actions (lint, unit tests, helm compliance).