### PR TITLE
Adding rag-blueprint, rag-eval, rag-perf skill details in top level README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The following is a step-by-step explanation of the workflow from the end-user pe
 
 ## AI Agent Skill
 
-An agent skill is included that enables AI coding assistants (Claude Code, Cursor, etc.) to deploy, configure, troubleshoot, and manage the RAG Blueprint autonomously.
+Agent skills in [`skill-source/`](skill-source/) let coding assistants (Claude Code, Cursor, Codex, etc.) operate this blueprint from natural language.
 
 ### Install
 
@@ -172,17 +172,19 @@ An agent skill is included that enables AI coding assistants (Claude Code, Curso
 npx skills add .
 ```
 
-This installs the `rag-blueprint` skill from `skill-source/`. After installation, the agent handles requests like:
+Installs all skills below from `skill-source/.agents/skills/`.
 
-- *"Deploy RAG on Docker with NVIDIA-hosted models"*
-- *"Enable VLM image captioning and restart the ingestor"*
-- *"Ingestion failed for 3 files, can you check why?"*
-- *"Switch from Docker to library mode"*
-- *"Shut down all RAG services"*
+| Skill | Use for | Example prompts |
+|-------|---------|-----------------|
+| **`rag-blueprint`** | Deploy, configure, troubleshoot, shutdown; REST API usage (`/v1/generate`, ingestor upload) | *"Deploy RAG with self-hosted NIMs"*, *"Enable guardrails"*, *"Wide-net search then high-precision on my collection"* |
+| **`rag-eval`** | RAGAS quality benchmarks with `corpus/` + `train.json` and `scripts/eval/evaluate_rag.py` | *"Run RAGAS eval on my dataset"*, *"Compare reranker on vs off"* |
+| **`rag-perf`** | Latency/throughput benchmarks via `scripts/rag-perf` (profiling + aiperf) | *"Profile retrieval bottlenecks"*, *"Run a concurrency sweep"* |
 
-> **Note:** If the agent doesn't pick up the skill automatically (e.g., for short or ambiguous queries), invoke it explicitly with `/rag-blueprint <your request>`.
+Pick the skill that matches the task: operations → **rag-blueprint**; answer quality → **rag-eval**; performance → **rag-perf**.
 
-For skill architecture details, see [`skill-source/README.md`](skill-source/README.md).
+> **Note:** If routing is unclear, invoke explicitly: `/rag-blueprint`, `/rag-eval`, or `/rag-perf` plus your request.
+
+More detail: [`skill-source/README.md`](skill-source/README.md). OpenClaw plugin: [`.openclaw/README.md`](.openclaw/README.md).
 
 
 ## Get Started With NVIDIA RAG Blueprint


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README with a clearer table of available agent skills, including their use cases and example prompts.
  * Improved guidance on selecting and invoking the appropriate skill for different tasks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-AI-Blueprints/rag/pull/599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->