### PR TITLE
docs: document OpenShift support in v2.6.0 release notes

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,7 +10,7 @@ This documentation contains the release notes for [NVIDIA RAG Blueprint](readme.
 
 ## Release 2.6.0 (TBD)
 
-This release adds [Agentic RAG](./agentic-rag.md) support with plan-and-execute pipelines, streaming responses, and UI integration; changes the default vector database to Elasticsearch and the default object store to SeaweedFS; and introduces new [agent skills](../skill-source/README.md) for deployment, evaluation, and performance tooling.
+This release adds [Agentic RAG](./agentic-rag.md) support with plan-and-execute pipelines, streaming responses, and UI integration; changes the default vector database to Elasticsearch and the default object store to SeaweedFS; adds [Red Hat OpenShift](./deploy-helm-openshift.md) support for Helm-based deployment; and introduces new [agent skills](../skill-source/README.md) for deployment, evaluation, and performance tooling.
 
 ### Highlights
 
@@ -30,6 +30,7 @@ This release includes the following key updates:
 - Updated NV-Ingest to version 26.3.0.
 - Updated OCR NIM naming from `nemoretriever-ocr-v1` to `nemotron-ocr-v1`.
 - Added OpenClaw plugin for agent-driven deploy/configure/eval workflows.
+- Added [Red Hat OpenShift and OKD support](./deploy-helm-openshift.md) for Helm deployments.
 
 ### Fixed Known Issues
 


### PR DESCRIPTION
## Summary

- Adds Red Hat OpenShift to the Release 2.6.0 summary paragraph.
- Adds a Highlights bullet linking to [deploy-helm-openshift.md](docs/deploy-helm-openshift.md).

## Test plan

- [x] Review rendered release notes for correct links and wording.
- [x] Confirm alignment with existing OpenShift Helm chart and documentation.