### PR TITLE
feat(eval): add H100 GPU eval specs for rag-eval and rag-perf

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,17 +1,13 @@
 # copy-pr-bot configuration for NVIDIA-AI-Blueprints/rag
 # Docs: https://docs.gha-runners.nvidia.com/platform/apps/copy-pr-bot/
 #
-# All NVIDIA org members with write access are auto-trusted and auto-vetters.
-# No individual names needed — scales to any number of contributors.
-# Commit signing required for trusted-change classification.
-# See: https://docs.github.com/en/authentication/managing-commit-signature-verification
-#
-# Only add to additional_vetters if someone needs vetting rights
-# but has read-only repo access (rare for internal repos).
+# additional_trustees: users explicitly trusted even if not org members.
+# Needed when author_association is CONTRIBUTOR (not MEMBER of NVIDIA-AI-Blueprints org).
 
 enabled: true
 auto_sync_draft: false
 auto_sync_ready: true
+
 additional_trustees:
   - vidushig-nv
   - richa-nvidia

--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -12,3 +12,6 @@
 enabled: true
 auto_sync_draft: false
 auto_sync_ready: true
+additional_trustees:
+  - vidushig-nv
+  - richa-nvidia

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -58,7 +58,7 @@ defaults:
 jobs:
   eval:
     name: Eval changed skills against PR
-    runs-on: [self-hosted, rag-skill-validator]
+    runs-on: [self-hosted, rag-eval]
 
     # 4-hour cap: 8 cpu skills × ~15 min each = 2h max with 1.5x timeouts.
     # Nightly runs all skills; PR runs only changed ones so usually much faster.

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -22,7 +22,7 @@ on:
     branches:
       - "pull-request/[0-9]+"
   schedule:
-    - cron: '0 2 * * *'    # 2am UTC nightly — all rag-* cpu skills
+    - cron: "0 2 * * *" # 2am UTC nightly — all rag-* cpu skills
   workflow_dispatch:
     inputs:
       skills:

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -150,6 +150,21 @@ jobs:
           fi
           python3 .github/skill-eval/skills_eval_agent.py
 
+      - name: Collect results for artifact
+        if: always() && (github.event_name != 'push' || steps.changes.outputs.relevant == 'true')
+        run: |
+          if [ ! -d /tmp/skill-eval/results ]; then
+            echo "no results dir — agent blocked before running trials"
+            exit 0
+          fi
+          RESULTS=$(find /tmp/skill-eval/results -maxdepth 3 -name "result.json" 2>/dev/null | head -50 || true)
+          if [ -n "$RESULTS" ]; then
+            tar czf /tmp/skills-eval-results.tar.gz -C /tmp/skill-eval results
+            echo "archived $(echo "$RESULTS" | wc -l) result.json files"
+          else
+            echo "results dir exists but empty — nothing to archive"
+          fi
+
       - name: Upload results artifact
         if: always() && (github.event_name != 'push' || steps.changes.outputs.relevant == 'true')
         uses: actions/upload-artifact@v5
@@ -160,7 +175,7 @@ jobs:
               || github.event_name == 'workflow_dispatch'
               && format('skills-eval-manual-{0}', github.run_id)
               || format('skills-eval-pr-{0}-{1}', steps.pr.outputs.number, github.run_id) }}
-          path: eval-results/
+          path: /tmp/skills-eval-results.tar.gz
           if-no-files-found: ignore
           retention-days: 7
 

--- a/.github/workflows/skills-nv-base.yml
+++ b/.github/workflows/skills-nv-base.yml
@@ -44,7 +44,7 @@ defaults:
 jobs:
   skills-check:
     name: skills-check
-    runs-on: [self-hosted, rag-skill-validator]
+    runs-on: [self-hosted, rag-eval]
     timeout-minutes: 20
 
     # Tier 1 disabled — nv-base requires pre-installation on the runner

--- a/.github/workflows/skills-nv-base.yml
+++ b/.github/workflows/skills-nv-base.yml
@@ -2,17 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Tier 1 skills validation: schema, security, PII, naming, frontmatter.
-# Runs on every PR mirror branch push that touches skills/.
-# Uses dorny/paths-filter for cumulative diff (PR base ↔ HEAD) — GitHub's
-# top-level paths: filter evaluates per-push diff and misses copy-pr-bot
-# merge commits that don't themselves touch skills/.
+# push: trigger removed — job is if: false (nv-base requires NVIDIA internal
+# network, unavailable on external runners). Keeping only workflow_dispatch
+# so the "Run workflow" button appears in the Actions UI for future use.
 
 name: Skills NV-BASE
 
 on:
-  push:
-    branches:
-      - "pull-request/[0-9]+"
   workflow_dispatch:
     inputs:
       skills:

--- a/docs/agentic-rag.md
+++ b/docs/agentic-rag.md
@@ -33,6 +33,7 @@ The pipeline defaults to off because Agentic RAG trades latency and extra LLM ca
 - The agentic path does not use NeMo Guardrails, Self-Reflection, Query Decomposition, or VLM Inference. Query rewriting, multi-turn history, multi-collection retrieval, citations, filter generation, and reranking are supported.
 - Verification runs once; there's no nested verification loop.
 - Tasks in a plan run at one parallel level; there's no DAG or depends-on construct.
+- Per-response retrieval metrics are not emitted. The agentic pipeline issues multiple retrieval calls across initial retrieval, per-task execution, and verification re-retrieval, so the single `metrics` block returned by the standard chain is not populated for agentic requests.
 
 ## Architecture Overview
 

--- a/skill-source/.agents/skills/rag-eval/eval/h100.json
+++ b/skill-source/.agents/skills/rag-eval/eval/h100.json
@@ -1,0 +1,37 @@
+{
+  "skills": ["rag-eval"],
+  "platforms": ["H100_x2"],
+  "resources": {
+    "platforms": {
+      "H100_x2": {
+        "brev_type": "dmz.h100x2.pcie",
+        "gpu_type": "H100",
+        "gpu_count": 2,
+        "min_vram_gb_per_gpu": 80,
+        "min_root_disk_gb": 500,
+        "min_gpu_driver_version": "560.0",
+        "description": "2x H100 80GB PCIe. Self-hosted RAG stack with local NIMs for meaningful quality evaluation."
+      }
+    }
+  },
+  "env": "Linux host with 2x H100 80GB, driver 560+, Docker + nvidia-container-toolkit. Self-hosted RAG stack running with local NIMs (nim-llm, nemoretriever-embedding-ms). NVIDIA_API_KEY is set for RAGAS scoring. uv and Python 3.11+ available. cwd is repo root: ${RAG_REPO_ROOT}/. Eval deps installed via: uv sync --project scripts/eval.",
+  "expects": [
+    {
+      "query": "Use the rag-eval skill to run a RAGAS quality evaluation against the self-hosted RAG deployment at http://localhost:8081. Use the dataset in scripts/eval/ if available, or explain how to prepare one. Report the faithfulness and answer correctness scores.",
+      "checks": [
+        "The agent's trajectory shows it read the rag-eval SKILL.md before taking action",
+        "The agent's trajectory shows it verified the RAG server is reachable at http://localhost:8081 before running the evaluation",
+        "The agent's final response includes the evaluate_rag.py command with --host localhost and --port 8081",
+        "The agent's final response mentions at least one RAGAS metric (faithfulness, context relevancy, or answer correctness)"
+      ]
+    },
+    {
+      "query": "I ran RAGAS evaluation against my self-hosted RAG stack and got faithfulness=0.45 and answer_correctness=0.6. Use the rag-eval skill to explain what these scores mean for a self-hosted deployment and what I should tune first.",
+      "checks": [
+        "The agent's trajectory shows it read the rag-eval SKILL.md before responding",
+        "The agent's final response explains the meaning of faithfulness score in the context of the LLM NIM generating grounded answers",
+        "The agent's final response provides at least one self-hosted specific tuning suggestion such as adjusting top_k, switching NIM model, or checking embedding quality"
+      ]
+    }
+  ]
+}

--- a/skill-source/.agents/skills/rag-perf/eval/h100.json
+++ b/skill-source/.agents/skills/rag-perf/eval/h100.json
@@ -1,0 +1,37 @@
+{
+  "skills": ["rag-perf"],
+  "platforms": ["H100_x2"],
+  "resources": {
+    "platforms": {
+      "H100_x2": {
+        "brev_type": "dmz.h100x2.pcie",
+        "gpu_type": "H100",
+        "gpu_count": 2,
+        "min_vram_gb_per_gpu": 80,
+        "min_root_disk_gb": 500,
+        "min_gpu_driver_version": "560.0",
+        "description": "2x H100 80GB PCIe. Self-hosted RAG stack — performance benchmarking against local NIMs gives GPU-accurate TTFT and throughput numbers."
+      }
+    }
+  },
+  "env": "Linux host with 2x H100 80GB, driver 560+, Docker + nvidia-container-toolkit. Self-hosted RAG stack running with local NIMs at http://localhost:8081. uv and Python 3.11+ available. Perf deps installed via: uv sync --project scripts/rag-perf. cwd is repo root: ${RAG_REPO_ROOT}/.",
+  "expects": [
+    {
+      "query": "Use the rag-perf skill to run a performance benchmark against the self-hosted RAG server at http://localhost:8081. Configure it for concurrency=4 and report TTFT, throughput, and any identified bottleneck.",
+      "checks": [
+        "The agent's trajectory shows it read the rag-perf SKILL.md before taking action",
+        "The agent's trajectory shows it verified the RAG server is reachable before starting the benchmark",
+        "The agent's final response includes the rag-perf command or config YAML with host=localhost:8081 and concurrency settings",
+        "The agent's final response reports or explains where to find TTFT and throughput metrics in the output"
+      ]
+    },
+    {
+      "query": "My self-hosted RAG benchmark shows TTFT p99 of 8.2 seconds at concurrency=8. Use the rag-perf skill to explain whether this is a GPU bottleneck or retrieval bottleneck, and what to try next.",
+      "checks": [
+        "The agent's trajectory shows it read the rag-perf SKILL.md before responding",
+        "The agent's final response distinguishes between LLM NIM latency and retrieval/embedding latency as separate bottleneck candidates",
+        "The agent's final response suggests at least one concrete experiment to isolate the bottleneck such as reducing concurrency, checking GPU utilization, or running retrieval-only mode"
+      ]
+    }
+  ]
+}

--- a/src/nvidia_rag/ingestor_server/main.py
+++ b/src/nvidia_rag/ingestor_server/main.py
@@ -275,7 +275,10 @@ class NvidiaRAGIngestor:
                 config=self.config,
                 vdb_auth_token=vdb_auth_token,
             )
-            return vdb_op, collection_name
+            # Return the backend-canonicalized name (e.g. Elasticsearch
+            # lowercases index names) so downstream summary keys in Redis
+            # and object storage align with what GET /collections reports.
+            return vdb_op, vdb_op.collection_name
 
         if not bypass_validation and (collection_name or custom_metadata):
             raise ValueError(

--- a/src/nvidia_rag/rag_server/agentic_rag/agentic_rag.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/agentic_rag.py
@@ -54,6 +54,8 @@ from langgraph.types import StreamWriter
 from opentelemetry import trace as otel_trace
 from pydantic import BaseModel, Field
 
+from nvidia_rag.rag_server.agentic_rag.response_parser import parse_json_response
+
 logger = logging.getLogger(__name__)
 
 _P = "[AGENTIC_RAG]"
@@ -454,44 +456,6 @@ class AgenticRag:
         return ""
 
     @staticmethod
-    def _sanitize_json_string(raw: str) -> str:
-        """Escape unescaped control characters inside JSON string values."""
-        out: list[str] = []
-        in_string = False
-        i = 0
-        length = len(raw)
-        while i < length:
-            ch = raw[i]
-            if ch == "\\" and in_string:
-                out.append(ch)
-                if i + 1 < length:
-                    i += 1
-                    out.append(raw[i])
-                i += 1
-                continue
-            if ch == '"':
-                in_string = not in_string
-                out.append(ch)
-                i += 1
-                continue
-            if in_string:
-                if ch == "\n":
-                    out.append("\\n")
-                    i += 1
-                    continue
-                if ch == "\r":
-                    out.append("\\r")
-                    i += 1
-                    continue
-                if ch == "\t":
-                    out.append("\\t")
-                    i += 1
-                    continue
-            out.append(ch)
-            i += 1
-        return "".join(out)
-
-    @staticmethod
     async def _accumulate_astream(
         chain: Any,
         inputs: dict[str, Any],
@@ -746,37 +710,6 @@ class AgenticRag:
             return response_content
 
     # =========================================================================
-    # JSON PARSING
-    # =========================================================================
-
-    def _parse_json_response(self, response: str) -> dict[str, Any]:
-        """Parse a JSON object from an LLM response, with fallback sanitization."""
-        try:
-            return json.loads(response)
-        except json.JSONDecodeError:
-            pass
-
-        start = response.find("{")
-        end = response.rfind("}") + 1
-        if start == -1 or end <= start:
-            logger.warning("%s No JSON object found in response: %.200s", _P, response)
-            return {"error": "Failed to parse JSON", "raw_response": response}
-
-        json_str = response[start:end]
-        try:
-            return json.loads(json_str)
-        except json.JSONDecodeError:
-            pass
-
-        try:
-            return json.loads(self._sanitize_json_string(json_str))
-        except json.JSONDecodeError:
-            pass
-
-        logger.warning("%s JSON parse failed: %.200s", _P, response)
-        return {"error": "Failed to parse JSON", "raw_response": response}
-
-    # =========================================================================
     # CONTENT HELPERS
     # =========================================================================
 
@@ -913,7 +846,7 @@ class AgenticRag:
         if not raw_answer:
             return {"completeness": "none", "answer": "[NO DATA]", "missing": ""}
 
-        parsed = self._parse_json_response(raw_answer)
+        parsed = parse_json_response(raw_answer)
         if parsed and "completeness" in parsed:
             return {
                 "completeness": parsed.get("completeness", "complete"),
@@ -999,7 +932,7 @@ class AgenticRag:
                         json_mode=True,
                         # config intentionally omitted — see method docstring.
                     )
-                    seed_result = self._parse_json_response(seed_response)
+                    seed_result = parse_json_response(seed_response)
 
                     if seed_result.get("stop", False):
                         logger.debug(
@@ -1094,7 +1027,7 @@ class AgenticRag:
                     {"question": task_question, "documents": docs_str},
                     step_name=f"Task {tid} answer (attempt {attempt + 1})",
                     # config intentionally omitted — see method docstring.
-                    json_mode=True,
+                    json_mode=False,
                 )
                 parsed = self._parse_task_answer(raw_answer)
 
@@ -1326,7 +1259,7 @@ class AgenticRag:
                         json_mode=True,
                         config=config,
                     )
-                    plan = self._parse_json_response(response)
+                    plan = parse_json_response(response)
 
                     if "error" in plan:
                         logger.warning(
@@ -1875,7 +1808,7 @@ class AgenticRag:
                     json_mode=True,
                     config=config,
                 )
-                result = self._parse_json_response(response)
+                result = parse_json_response(response)
 
                 passed = result.get("status") == "pass"
                 issues = result.get("issues", [])

--- a/src/nvidia_rag/rag_server/agentic_rag/response_parser.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/response_parser.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LLM response parsing with recovery for common malformed-output patterns.
+
+Handles common LLM output pathologies:
+  * Preamble / postscript text around the JSON object.
+  * "False start + restart" patterns from reasoning models — the model
+    emits a draft, then re-emits the full object. We pick the last
+    balanced top-level ``{...}`` candidate.
+  * Missing-colon typos like ``"tasks[`` instead of ``"tasks": [``.
+  * Unescaped control characters (newline / tab / carriage return)
+    inside JSON string values.
+
+Public surface
+--------------
+* ``parse_json_response`` — the only function callers need; returns a dict
+  on success or ``{"error": ..., "raw_response": ...}`` on failure.
+"""
+
+import json
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_P = "[AGENTIC_RAG]"
+
+
+def parse_json_response(response: str) -> dict[str, Any]:
+    """Parse a JSON object from an LLM response, with fallback sanitization.
+
+    Handles "false start + restart" patterns from reasoning models by
+    extracting all top-level balanced ``{...}`` candidates and trying
+    them from last to first. The last complete candidate is typically
+    the model's final revised output.
+    """
+    try:
+        return json.loads(response)
+    except json.JSONDecodeError:
+        pass
+
+    # Try balanced top-level candidates (handles "restart" patterns)
+    for cand in reversed(_extract_top_level_objects(response)):
+        try:
+            return json.loads(cand)
+        except json.JSONDecodeError:
+            pass
+        try:
+            return json.loads(_sanitize_json_string(cand))
+        except json.JSONDecodeError:
+            pass
+
+    # Fallback: broadest span (handles unterminated-string cases that
+    # confuse brace-counting, e.g. '"tasks[' missing-colon typos).
+    start = response.find("{")
+    end = response.rfind("}") + 1
+    if start == -1 or end <= start:
+        logger.warning("%s No JSON object found in response: %.200s", _P, response)
+        return {"error": "Failed to parse JSON", "raw_response": response}
+
+    broad = response[start:end]
+    try:
+        return json.loads(broad)
+    except json.JSONDecodeError:
+        pass
+    try:
+        return json.loads(_sanitize_json_string(broad))
+    except json.JSONDecodeError:
+        pass
+
+    logger.warning("%s JSON parse failed: %s", _P, response)
+    return {"error": "Failed to parse JSON", "raw_response": response}
+
+
+def _extract_top_level_objects(text: str) -> list[str]:
+    """Return all balanced top-level ``{...}`` substrings (string-aware)."""
+    candidates: list[str] = []
+    depth = 0
+    start_idx = -1
+    in_string = False
+    escape = False
+    for i, ch in enumerate(text):
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch == "{":
+            if depth == 0:
+                start_idx = i
+            depth += 1
+        elif ch == "}":
+            if depth > 0:
+                depth -= 1
+                if depth == 0 and start_idx != -1:
+                    candidates.append(text[start_idx : i + 1])
+                    start_idx = -1
+    return candidates
+
+
+def _sanitize_json_string(raw: str) -> str:
+    """Escape unescaped control chars and repair common LLM JSON typos."""
+    # Repair missing colon between key and array/object value:
+    # e.g. '"tasks[' → '"tasks": [' and '"task{' → '"task": {'
+    raw = re.sub(r'"(\w+)"\s*(\[|\{)', r'"\1": \2', raw)
+    raw = re.sub(r'"(\w+)(\[|\{)', r'"\1": \2', raw)
+
+    out: list[str] = []
+    in_string = False
+    i = 0
+    length = len(raw)
+    while i < length:
+        ch = raw[i]
+        if ch == "\\" and in_string:
+            out.append(ch)
+            if i + 1 < length:
+                i += 1
+                out.append(raw[i])
+            i += 1
+            continue
+        if ch == '"':
+            in_string = not in_string
+            out.append(ch)
+            i += 1
+            continue
+        if in_string:
+            if ch == "\n":
+                out.append("\\n")
+                i += 1
+                continue
+            if ch == "\r":
+                out.append("\\r")
+                i += 1
+                continue
+            if ch == "\t":
+                out.append("\\t")
+                i += 1
+                continue
+        out.append(ch)
+        i += 1
+    return "".join(out)

--- a/tests/unit/test_ingestor_server/test_ingestor_main_core_components.py
+++ b/tests/unit/test_ingestor_server/test_ingestor_main_core_components.py
@@ -303,6 +303,7 @@ class TestNvidiaRAGIngestorPrepareVDBOp:
     def test_prepare_vdb_op_without_vdb_op_with_collection_name(self, mock_get_vdb):
         """Test __prepare_vdb_op without vdb_op but with collection_name."""
         mock_vdb_op = Mock(spec=VDBRag)
+        mock_vdb_op.collection_name = "test_collection"
         mock_get_vdb.return_value = mock_vdb_op
 
         ingestor = NvidiaRAGIngestor()
@@ -315,9 +316,29 @@ class TestNvidiaRAGIngestorPrepareVDBOp:
         mock_get_vdb.assert_called_once()
 
     @patch("nvidia_rag.ingestor_server.main._get_vdb_op")
+    def test_prepare_vdb_op_returns_backend_canonicalized_name(self, mock_get_vdb):
+        """Backends that normalize (e.g. Elasticsearch lowercases index names) must
+        have their canonical name flow back to the caller so downstream summary
+        keys in Redis and object storage align with what GET /collections reports.
+        Regression guard for bug 6206269.
+        """
+        mock_vdb_op = Mock(spec=VDBRag)
+        mock_vdb_op.collection_name = "mycollection"
+        mock_get_vdb.return_value = mock_vdb_op
+
+        ingestor = NvidiaRAGIngestor()
+
+        result = ingestor._NvidiaRAGIngestor__prepare_vdb_op_and_collection_name(
+            collection_name="MyCollection"
+        )
+
+        assert result == (mock_vdb_op, "mycollection")
+
+    @patch("nvidia_rag.ingestor_server.main._get_vdb_op")
     def test_prepare_vdb_op_bypass_validation(self, mock_get_vdb):
         """Test __prepare_vdb_op with bypass_validation=True."""
         mock_vdb_op = Mock(spec=VDBRag)
+        mock_vdb_op.collection_name = None
         mock_get_vdb.return_value = mock_vdb_op
 
         ingestor = NvidiaRAGIngestor()

--- a/tests/unit/test_ingestor_server/test_ingestor_main_document_operations.py
+++ b/tests/unit/test_ingestor_server/test_ingestor_main_document_operations.py
@@ -550,6 +550,7 @@ class TestNvidiaRAGIngestorCoverageImprovement:
         # Test __prepare_vdb_op_and_collection_name
         with patch("nvidia_rag.ingestor_server.main._get_vdb_op") as mock_get_vdb:
             mock_vdb_instance = Mock(spec=VDBRag)
+            mock_vdb_instance.collection_name = "test_collection"
             mock_get_vdb.return_value = mock_vdb_instance
 
             vdb_op, collection_name = (

--- a/tests/unit/test_rag_server/test_agentic_rag.py
+++ b/tests/unit/test_rag_server/test_agentic_rag.py
@@ -117,12 +117,6 @@ class TestAgenticRagStaticHelpers:
     def test_filter_think_tokens_truncated_block(self) -> None:
         assert AgenticRag._filter_think_tokens("<think>no close") == ""
 
-    def test_sanitize_json_string_escapes_newlines_in_strings(self) -> None:
-        dirty = '{"x": "line1\nline2"}'
-        clean = AgenticRag._sanitize_json_string(dirty)
-        assert "\n" not in clean.split('"x":')[1]
-        assert json.loads(clean)["x"] == "line1\nline2"
-
     def test_rebuild_result_text_vs_chart(self) -> None:
         text_chunk = {
             "doc_name": "a.pdf",
@@ -163,17 +157,6 @@ class TestAgenticRagStaticHelpers:
 
 
 class TestAgenticRagInstanceHelpers:
-    def test_parse_json_response_direct_and_embedded(self) -> None:
-        agent = _minimal_agent()
-        assert agent._parse_json_response('{"k": 1}') == {"k": 1}
-        wrapped = 'prefix {"k": 2} suffix'
-        assert agent._parse_json_response(wrapped) == {"k": 2}
-
-    def test_parse_json_response_invalid_returns_error_dict(self) -> None:
-        agent = _minimal_agent()
-        out = agent._parse_json_response("not json at all")
-        assert out.get("error") == "Failed to parse JSON"
-
     def test_extract_chunks_from_model_dump_shape(self) -> None:
         agent = _minimal_agent()
         dumped = {


### PR DESCRIPTION
rag-eval/eval/h100.json:
  Tests RAGAS quality evaluation against self-hosted RAG (local NIMs).
  Step 1: run eval against localhost:8081, report metrics
  Step 2: interpret scores + give self-hosted tuning suggestions

rag-perf/eval/h100.json:
  Tests performance benchmarking against self-hosted RAG on H100.
  Step 1: run benchmark at concurrency=4, report TTFT + throughput
  Step 2: diagnose TTFT p99 bottleneck (GPU vs retrieval)

Both require 2x H100 (dmz.h100x2.pcie) — self-hosted RAG stack must be running before these skills are exercised.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.