### PR TITLE
chore(ci): add vidushig-nv and richa-nvidia as additional_trustees

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,14 +1,13 @@
 # copy-pr-bot configuration for NVIDIA-AI-Blueprints/rag
 # Docs: https://docs.gha-runners.nvidia.com/platform/apps/copy-pr-bot/
 #
-# All NVIDIA org members with write access are auto-trusted and auto-vetters.
-# No individual names needed — scales to any number of contributors.
-# Commit signing required for trusted-change classification.
-# See: https://docs.github.com/en/authentication/managing-commit-signature-verification
-#
-# Only add to additional_vetters if someone needs vetting rights
-# but has read-only repo access (rare for internal repos).
+# additional_trustees: users explicitly trusted even if not org members.
+# Needed when author_association is CONTRIBUTOR (not MEMBER of NVIDIA-AI-Blueprints org).
 
 enabled: true
 auto_sync_draft: false
 auto_sync_ready: true
+
+additional_trustees:
+  - vidushig-nv
+  - richa-nvidia


### PR DESCRIPTION
Needed because author_association is CONTRIBUTOR not MEMBER for users who are not direct members of NVIDIA-AI-Blueprints org. This ensures their signed commits auto-mirror without needing /ok to test.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.