### PR TITLE
fix(ingestor): return backend-canonicalized collection name to align summary keys

### DIFF
--- a/src/nvidia_rag/ingestor_server/main.py
+++ b/src/nvidia_rag/ingestor_server/main.py
@@ -275,7 +275,10 @@ class NvidiaRAGIngestor:
                 config=self.config,
                 vdb_auth_token=vdb_auth_token,
             )
-            return vdb_op, collection_name
+            # Return the backend-canonicalized name (e.g. Elasticsearch
+            # lowercases index names) so downstream summary keys in Redis
+            # and object storage align with what GET /collections reports.
+            return vdb_op, vdb_op.collection_name
 
         if not bypass_validation and (collection_name or custom_metadata):
             raise ValueError(

--- a/tests/unit/test_ingestor_server/test_ingestor_main_core_components.py
+++ b/tests/unit/test_ingestor_server/test_ingestor_main_core_components.py
@@ -303,6 +303,7 @@ class TestNvidiaRAGIngestorPrepareVDBOp:
     def test_prepare_vdb_op_without_vdb_op_with_collection_name(self, mock_get_vdb):
         """Test __prepare_vdb_op without vdb_op but with collection_name."""
         mock_vdb_op = Mock(spec=VDBRag)
+        mock_vdb_op.collection_name = "test_collection"
         mock_get_vdb.return_value = mock_vdb_op
 
         ingestor = NvidiaRAGIngestor()
@@ -315,9 +316,29 @@ class TestNvidiaRAGIngestorPrepareVDBOp:
         mock_get_vdb.assert_called_once()
 
     @patch("nvidia_rag.ingestor_server.main._get_vdb_op")
+    def test_prepare_vdb_op_returns_backend_canonicalized_name(self, mock_get_vdb):
+        """Backends that normalize (e.g. Elasticsearch lowercases index names) must
+        have their canonical name flow back to the caller so downstream summary
+        keys in Redis and object storage align with what GET /collections reports.
+        Regression guard for bug 6206269.
+        """
+        mock_vdb_op = Mock(spec=VDBRag)
+        mock_vdb_op.collection_name = "mycollection"
+        mock_get_vdb.return_value = mock_vdb_op
+
+        ingestor = NvidiaRAGIngestor()
+
+        result = ingestor._NvidiaRAGIngestor__prepare_vdb_op_and_collection_name(
+            collection_name="MyCollection"
+        )
+
+        assert result == (mock_vdb_op, "mycollection")
+
+    @patch("nvidia_rag.ingestor_server.main._get_vdb_op")
     def test_prepare_vdb_op_bypass_validation(self, mock_get_vdb):
         """Test __prepare_vdb_op with bypass_validation=True."""
         mock_vdb_op = Mock(spec=VDBRag)
+        mock_vdb_op.collection_name = None
         mock_get_vdb.return_value = mock_vdb_op
 
         ingestor = NvidiaRAGIngestor()

--- a/tests/unit/test_ingestor_server/test_ingestor_main_document_operations.py
+++ b/tests/unit/test_ingestor_server/test_ingestor_main_document_operations.py
@@ -550,6 +550,7 @@ class TestNvidiaRAGIngestorCoverageImprovement:
         # Test __prepare_vdb_op_and_collection_name
         with patch("nvidia_rag.ingestor_server.main._get_vdb_op") as mock_get_vdb:
             mock_vdb_instance = Mock(spec=VDBRag)
+            mock_vdb_instance.collection_name = "test_collection"
             mock_get_vdb.return_value = mock_vdb_instance
 
             vdb_op, collection_name = (


### PR DESCRIPTION
## Description
Return backend-canonicalized collection name to align summary keys

## Checklist
- [X] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [X] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [X] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.