### PR TITLE
agentic-bugfix: NVBug 6190418

### DIFF
--- a/docs/change-model.md
+++ b/docs/change-model.md
@@ -279,7 +279,7 @@ Use this procedure to change models when you are running self-hosted NVIDIA NIM 
       list-model-profiles
     ```
     
-    If only `vllm` profile is available, you must use the **vLLM engine** and add these specific configurations:
+    If only `vllm` profile is available, you must use the **vLLM engine** with single-GPU (`tensorParallelism: "1"`) configuration. The default values.yaml ships the Nemotron 3 Super profile (`engine: vllm`, `tensorParallelism: "2"`, 2 GPUs); when switching to a Nemotron Nano model, override both the profile and the GPU resources to 1:
     
     ```yaml
     nimOperator:
@@ -287,8 +287,15 @@ Use this procedure to change models when you are running self-hosted NVIDIA NIM 
         image:
           repository: nvcr.io/nim/nvidia/nvidia-nemotron-nano-9b-v2
           tag: "latest"
+        resources:
+          limits:
+            nvidia.com/gpu: 1
+          requests:
+            nvidia.com/gpu: 1
         model:
           engine: vllm  # Required: use vLLM instead of tensorrt_llm
+          precision: "fp8"
+          tensorParallelism: "1"  # Nemotron Nano models run on a single GPU
         env:
           - name: NIM_SERVED_MODEL_NAME
             value: "nvidia/nvidia-nemotron-nano-9b-v2"  # Must match APP_LLM_MODELNAME
@@ -329,18 +336,34 @@ The text-only embedding NIM (`nemotron-embedding-ms` in [`deploy/compose/nims.ya
 
 ### Helm
 
-In [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml), set the model name in the rag-server and ingestor-server env-var blocks (search for the existing `llama-nemotron-embed-vl-1b-v2` references):
+In [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml), enable the text embedder NIM, disable the VLM embedder NIM, and repoint the embedding env vars (model name and server URL) at the text endpoint in all three places (rag-server `envVars`, `ingestor-server.envVars`, and `nv-ingest.envVars`). Without flipping the `nimOperator` enable flags the text-embedder pod is not deployed, and without updating `APP_EMBEDDINGS_SERVERURL` / `EMBEDDING_NIM_ENDPOINT` traffic still goes to the VLM embedder:
 
 ```yaml
+nimOperator:
+  # Disable VLM embedder, enable text embedder
+  nvidia-nim-llama-nemotron-embed-vl-1b-v2:
+    enabled: false
+  nvidia-nim-llama-nemotron-embed-1b-v2:
+    enabled: true
+
+# rag-server: point at the text embedder
 envVars:
   APP_EMBEDDINGS_MODELNAME: "nvidia/llama-nemotron-embed-1b-v2"
+  APP_EMBEDDINGS_SERVERURL: "nemotron-embedding-ms:8000/v1"
 
 ingestor-server:
   envVars:
     APP_EMBEDDINGS_MODELNAME: "nvidia/llama-nemotron-embed-1b-v2"
+    APP_EMBEDDINGS_SERVERURL: "nemotron-embedding-ms:8000/v1"
+
+nv-ingest:
+  envVars:
+    # Embedding target for the nv-ingest runtime
+    EMBEDDING_NIM_ENDPOINT: "http://nemotron-embedding-ms:8000/v1"
+    EMBEDDING_NIM_MODEL_NAME: "nvidia/llama-nemotron-embed-1b-v2"
 ```
 
-The text-only embedding NIM (`nvidia-nim-llama-nemotron-embed-1b-v2` under `nimOperator`) is already configured in `values.yaml`; no image swap is required. Apply with [Change a Deployment](deploy-helm.md#change-a-deployment).
+Apply with [Change a Deployment](deploy-helm.md#change-a-deployment).
 
 :::{warning}
 **Re-ingest after switching.** Vectors produced by the VLM embedder are not directly comparable to vectors from the text-only embedder; retrieval accuracy will degrade until you re-ingest your corpus.

--- a/docs/deploy-helm-from-repo.md
+++ b/docs/deploy-helm-from-repo.md
@@ -99,34 +99,11 @@ If you are working directly with the source Helm chart, and you want to customiz
     --set ngcApiSecret.password=$NGC_API_KEY
     ```
 
-   :::{important}
-   **For NVIDIA RTX6000 Pro Deployments:**
-   
-    If you are deploying on NVIDIA RTX6000 Pro GPUs (instead of H100 GPUs), you need to configure the NIM LLM model profile. The required configuration is already present but commented out in the [values.yaml](../deploy/helm/nvidia-blueprint-rag/values.yaml) file.
-   
-   Uncomment and modify the following section under `nimOperator.nim-llm.model` in the values.yaml:
-   ```yaml
-   model:
-     engine: tensorrt_llm
-     precision: "fp8"
-     qosProfile: "throughput"
-     tensorParallelism: "1"
-     gpus:
-       - product: "rtx6000_blackwell_sv"
-   ```
-   
-   Then install using the modified values.yaml:
-   ```sh
-   helm upgrade --install rag -n rag nvidia-blueprint-rag/ \
-     --set imagePullSecret.password=$NGC_API_KEY \
-     --set ngcApiSecret.password=$NGC_API_KEY \
-     -f nvidia-blueprint-rag/values.yaml
-   ```
-   :::
-
    :::{note}
    Refer to [NIM Model Profile Configuration](model-profiles.md) for using non-default NIM LLM profile.
    :::
+
+   For **RTX PRO 6000** hardware, see the [RTX PRO 6000 setup prerequisites](nemotron3-super-deployment.md#rtx-pro-6000-setup) in the Nemotron 3 Super deployment guide.
 
 
 6. Follow the remaining instructions in [Deploy on Kubernetes with Helm](./deploy-helm.md) (including verification examples that reflect the default Elasticsearch vector database; optional Milvus adds different pods and services—refer to [Vector database configuration](change-vectordb.md)) for more information.

--- a/docs/deploy-helm.md
+++ b/docs/deploy-helm.md
@@ -105,33 +105,6 @@ To deploy End-to-End RAG Server and Ingestor Server, use the following procedure
     --set ngcApiSecret.password=$NGC_API_KEY
     ```
 
-   :::{important}
-   **For NVIDIA RTX6000 Pro Deployments:**
-   
-    If you are deploying on NVIDIA RTX6000 Pro GPUs (instead of H100 GPUs), you need to configure the NIM LLM model profile. The required configuration is already present but commented out in the [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml) file.
-
-    Uncomment and modify the following section under `nimOperator.nim-llm.model`:
-    ```yaml
-    model:
-      engine: tensorrt_llm
-      precision: "fp8"
-      qosProfile: "throughput"
-      tensorParallelism: "1"
-      gpus:
-        - product: "rtx6000_blackwell_sv"
-    ```
-   
-   Then install using the modified values.yaml:
-   ```sh
-   helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
-     --username '$oauthtoken' \
-     --password "${NGC_API_KEY}" \
-     --set imagePullSecret.password=$NGC_API_KEY \
-     --set ngcApiSecret.password=$NGC_API_KEY \
-     -f deploy/helm/nvidia-blueprint-rag/values.yaml
-   ```
-   :::
-
    :::{note}
    Refer to [NIM Model Profile Configuration](model-profiles.md) for using non-default NIM LLM profile.
    :::

--- a/docs/image_captioning.md
+++ b/docs/image_captioning.md
@@ -72,12 +72,13 @@ export APP_NVINGEST_CAPTIONMODELNAME="<model_name>"
 
 To enable image captioning in Helm-based deployments by using an on-prem VLM model, use the following procedure.
 
-1. Modify [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml) to enable image captioning:
+1. Modify [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml) to enable image captioning. The captioning model is served by a dedicated `nim-vlm-captioning` NIM (`nvidia/nemotron-nano-12b-v2-vl`), which is independent of the `nim-vlm` generation NIM:
 
    ```yaml
-   # Enable VLM NIM for image captioning
-   nim-vlm:
-     enabled: true
+   # Enable the dedicated VLM captioning NIM for image captioning at ingestion
+   nimOperator:
+     nim-vlm-captioning:
+       enabled: true
 
    # Configure ingestor-server for image captioning
    ingestor-server:
@@ -86,8 +87,8 @@ To enable image captioning in Helm-based deployments by using an on-prem VLM mod
        
        # === Image Captioning ===
        APP_NVINGEST_EXTRACTIMAGES: "True"
-       APP_NVINGEST_CAPTIONENDPOINTURL: "http://nim-vlm:8000/v1/chat/completions"
-       APP_NVINGEST_CAPTIONMODELNAME: "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
+       APP_NVINGEST_CAPTIONENDPOINTURL: "http://nim-vlm-captioning:8000/v1/chat/completions"
+       APP_NVINGEST_CAPTIONMODELNAME: "nvidia/nemotron-nano-12b-v2-vl"
    ```
 
 2. Apply the updated Helm chart:

--- a/docs/text_only_ingest.md
+++ b/docs/text_only_ingest.md
@@ -8,13 +8,14 @@ You can enable text-only ingestion for the [NVIDIA RAG Blueprint](readme.md). Fo
 
 1. Follow the [deployment guide](deploy-docker-self-hosted.md) up to and including the step labelled "Start all required NIMs."
 
-2. Set the environment variables to enable text-only extraction mode:
+2. Set the environment variables to enable text-only extraction mode. `COMPONENTS_TO_READY_CHECK` must be set to an empty string so the nv-ingest readiness probe does not wait for the disabled extraction NIMs (the compose default in [docker-compose-ingestor-server.yaml](../deploy/compose/docker-compose-ingestor-server.yaml) is `ALL`):
 
    ```bash
    export APP_NVINGEST_EXTRACTTEXT=True
    export APP_NVINGEST_EXTRACTINFOGRAPHICS=False
    export APP_NVINGEST_EXTRACTTABLES=False
    export APP_NVINGEST_EXTRACTCHARTS=False
+   export COMPONENTS_TO_READY_CHECK=""
    ```
 
    Then deploy the ingestor-server:
@@ -120,6 +121,12 @@ Additionally, disable **table extraction**, **chart extraction**, and **image ex
        APP_NVINGEST_EXTRACTINFOGRAPHICS: "False"
        APP_NVINGEST_EXTRACTTABLES: "False"
        APP_NVINGEST_EXTRACTCHARTS: "False"
+
+       # Health check: skip readiness on disabled extraction NIMs.
+       # The chart default in values.yaml is "ALL"; with table / chart / image
+       # extraction turned off, nv-ingest readiness would otherwise wait
+       # indefinitely for NIMs that are not deployed.
+       COMPONENTS_TO_READY_CHECK: ""
    ```
 
 2. Apply the chart with the modified values, disabling the nv-ingest CV NIMs you no longer need:

--- a/docs/vlm.md
+++ b/docs/vlm.md
@@ -143,15 +143,19 @@ Continue with [Deploy with Docker (NVIDIA-Hosted Models)](deploy-docker-nvidia-h
    APP_VLM_SERVERURL: "http://nim-vlm:8000/v1"
    ```
 
-2. Enable image extraction (and the captioning that runs alongside it) for ingestion. Under `ingestor-server.envVars`, set:
+2. Enable image extraction and captioning for ingestion. Image captioning is recommended when running VLM generation so that ingested images are indexed with their captions and surface as citations at query time. The captioning model is served by a dedicated `nim-vlm-captioning` NIM (see [Separate VLMs for Generation and Captioning](#separate-vlms-for-generation-and-captioning)). Under `nimOperator` and `ingestor-server.envVars`, set:
 
    ```yaml
+   nimOperator:
+     nim-vlm-captioning:
+       enabled: true
+
    ingestor-server:
      envVars:
        APP_NVINGEST_EXTRACTIMAGES: "True"
+       APP_NVINGEST_CAPTIONENDPOINTURL: "http://nim-vlm-captioning:8000/v1/chat/completions"
+       APP_NVINGEST_CAPTIONMODELNAME: "nvidia/nemotron-nano-12b-v2-vl"
    ```
-
-   Image captioning is recommended when running VLM generation so that ingested images are indexed with their captions and surface as citations at query time.
 
 3. Enable `nim-vlm` and disable `nim-llm` (VLM replaces LLM for generation):
 


### PR DESCRIPTION
Auto-generated by **agentic-bugfix** for NVBug `6190418`.

- Source branch: `bugfix/nvbug-6190418-20260526-062749`
- Target branch: `develop`
- Bug ID: `6190418`
- Commit author: `agentic-bug-fix`

<details><summary><strong>Full agent report</strong></summary>

# Bug Fix Report — NVBug 6190418

**Status:** VERIFIED (Track A — Verified Fix)
**Bug:** `[RAG BP][v2.6.0][RC1][docs] Helm side documentation changes`
**Severity:** 3-Functionality
**Priority:** Unprioritized
**Branch:** `bugfix/nvbug-6190418-20260526-062749` (off `origin/develop`, repo at `v2.6.0.rc1-88-g8468f04`)
**Generated:** 2026-05-26 12:11 UTC
**Skill:** `/agentic-bug-fix.bak-1778585527 6190418 --no-nvbugs-update --skills-path skill-source/.agents/skills --instructions 'Use NVIDIA-Hosted (Cloud) docker deployment and for deploy skills check the skill-source folder for skills path'`

---

## 1. Summary

NVBug 6190418 is a documentation-only defect filed against the Helm-side docs in the v2.6.0 release branch. PR #591 (commit `3dac790`, merged 2026-05-21) applied partial fixes and marked the bug VTC, but the reporter **re-opened** the bug on 2026-05-25 stating that comments #2 and #5 and description point #1 were not fixed, the COMPONENTS_TO_READY_CHECK note from comment #3 had been removed and needed to be restored, and (per comment #8 on 2026-05-25) the image-captioning Helm guidance still referenced the wrong NIM and model.

This run applied 8 targeted edits across 6 documentation files in `docs/` to address every reopen-comment item.

### 1.5 User instructions

- `--no-nvbugs-update` — NVBug comment update will be skipped (honored).
- `--skills-path skill-source/.agents/skills` — used the project-local `skill-source/.agents/skills/rag-blueprint` for deploy/reference discovery (honored).
- `--instructions 'Use NVIDIA-Hosted (Cloud) docker deployment and for deploy skills check the skill-source folder for skills path'` — the docs change is mode-independent; the existing NVIDIA-Hosted Docker stack (rag-server, ingestor-server, elasticsearch, seaweedfs) was already running, so no redeploy was necessary. No deployment files were touched.

---

## 2. Reproduction

**Track A — confirmed by direct documentation inspection.** For a docs-only bug, "reproduction" means reading the documented configuration and verifying it diverges from the actual config in `deploy/helm/nvidia-blueprint-rag/values.yaml` and `deploy/compose/*`.

**Reproduction Attempt 1 (successful):** I read each doc file listed in the bug and confirmed all 8 unfixed items as described in §3 below. No Gap Analysis was needed — Attempt 1 produced a definitive set of failing signals.

### 2.5 NVBug content retrieved

| Field | Value |
|---|---|
| Description | Verbatim — two observations: (1) RTX section removal from `deploy-helm.md` / `deploy-helm-from-repo.md`; (2) set `APP_NVINGEST_EXTRACTIMAGES: "True"` in vlm.md Helm section. |
| Comments | 9 comments retrieved; reopen on 2026-05-25T03:16 explicitly listed: comments #2, #3 (carryover for `COMPONENTS_TO_READY_CHECK`), #5 unfixed; description point #1 unfixed. Comment #8 (2026-05-25T04:01) added image-captioning NIM/endpoint/model correction. |
| Attachments | 0 (none returned by `nvbugs_get_bug_details`; bug references inline images via `[image: <guid>]` markers but those are NVBugs-internal). |
| Inline logs | None — this is a docs-correctness bug, no stack traces involved. |

### 2.7 CI Pipeline Context

Not applicable — input is an NVBug ID, not a GitLab URL. Track 1D not triggered.

---

## 3. Analysis

PR #591 (`3dac790`, "Misc updates to Helm docs for RAG 2.6.0, drop rc1 tag") applied surface-level fixes (release tag bump, removed "NeMo Retriever Library" from core-services list) but missed every item the reporter then called out on reopen:

| # | Doc file | Issue confirmed by reading the file |
|---|---|---|
| 1 | `docs/deploy-helm.md` lines 108–133 | Inline RTX6000 Pro `:::{important}` block duplicates content already covered in `nemotron3-super-deployment.md` (already linked from line 139). Reporter says it's "not needed anymore with new RAG release." |
| 2 | `docs/deploy-helm-from-repo.md` lines 102–125 | Same inline RTX6000 Pro `:::{important}` block. |
| 3 | `docs/vlm.md` "Enable VLM with Helm" step 2 (lines 146–154) | Only sets `APP_NVINGEST_EXTRACTIMAGES`; missing `nimOperator.nim-vlm-captioning.enabled: true`, `APP_NVINGEST_CAPTIONENDPOINTURL`, `APP_NVINGEST_CAPTIONMODELNAME`. Comment #8 explicitly lists these as required. |
| 4 | `docs/image_captioning.md` "Using Helm chart deployment" (lines 71–101) | Wrong: uses `nim-vlm: enabled: true`, endpoint `http://nim-vlm:8000/...`, model `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`. Comment #8: should use `nimOperator.nim-vlm-captioning.enabled`, endpoint `http://nim-vlm-captioning:8000/...`, model `nvidia/nemotron-nano-12b-v2-vl`. Cross-checked against `deploy/helm/nvidia-blueprint-rag/values.yaml` (line 427: `APP_NVINGEST_CAPTIONMODELNAME: "nvidia/nemotron-nano-12b-v2-vl"`) and `deploy/compose/nims.yaml` (vlm-captioning-ms service uses `nvidia/nemotron-nano-12b-v2-vl`). |
| 5 | `docs/change-model.md` "Switch from the VLM Embedder to the Text-Only Embedder" Helm section (lines 330–343) | Comment #2 enumerates four required changes; only one (model name in `envVars` + `ingestor-server.envVars`) was present. Missing: `nimOperator` enable/disable flip for the two embedder NIMs (#3), `APP_EMBEDDINGS_SERVERURL` in both `envVars` blocks (#2), `nv-ingest.envVars.EMBEDDING_NIM_ENDPOINT` + `EMBEDDING_NIM_MODEL_NAME` (#4). |
| 6 | `docs/change-model.md` "Nemotron Nano Models … vLLM profile" snippet (lines 285–296) | Lacks `tensorParallelism: "1"`, `precision: "fp8"`, and `resources: {limits/requests: nvidia.com/gpu: 1}`. Comment #5: "we require vllm profile with tp1 configuration … gpu-resources required for llm will be changed to 1." Cross-checked against `values.yaml` line 818–820 (the default Nemotron 3 Super profile uses `engine: vllm, tensorParallelism: "2"`, 2 GPUs) — the docs need to show what to override when switching to a Nemotron Nano model. |
| 7 | `docs/text_only_ingest.md` Docker section (lines 13–18) | Missing `export COMPONENTS_TO_READY_CHECK=""`. PR #591 removed this line (see commit `3dac790` diff for `docs/text_only_ingest.md`). Without it, nv-ingest health-check waits indefinitely on disabled extraction NIMs because `deploy/compose/docker-compose-ingestor-server.yaml:267` hardcodes `COMPONENTS_TO_READY_CHECK=ALL`. |
| 8 | `docs/text_only_ingest.md` Helm section (lines 112–123) | Missing `nv-ingest.envVars.COMPONENTS_TO_READY_CHECK: ""`. Same root cause; chart default in `values.yaml:1149` is `COMPONENTS_TO_READY_CHECK: "ALL"`. |

**Design-change guardrail:** All 8 items are documentation-only corrections of mis-documented configuration that already exists in the actual `values.yaml` / compose files. No code path changes, no architectural changes, no runtime behavior changes.

---

## 4. Fix

8 edits across 6 files. Diff stat:

```
 docs/change-model.md          | 29 ++++++++++++++++++++++++++---
 docs/deploy-helm-from-repo.md | 27 ++-------------------------
 docs/deploy-helm.md           | 27 ---------------------------
 docs/image_captioning.md      | 13 +++++++------
 docs/text_only_ingest.md      |  9 ++++++++-
 docs/vlm.md                   | 10 +++++++---
 6 files changed, 50 insertions(+), 65 deletions(-)
```

Per-item mapping:

1. `docs/deploy-helm.md` — Removed inline `:::{important}` "For NVIDIA RTX6000 Pro Deployments" block (27 lines). Kept the cross-reference at the bottom of the step pointing to `nemotron3-super-deployment.md#rtx-pro-6000-setup`.
2. `docs/deploy-helm-from-repo.md` — Removed the same inline block (24 lines). Added the same cross-reference to `nemotron3-super-deployment.md`.
3. `docs/vlm.md` — In "Enable VLM with Helm" step 2, replaced the single-key `APP_NVINGEST_EXTRACTIMAGES` snippet with a snippet that also enables `nimOperator.nim-vlm-captioning` and sets `APP_NVINGEST_CAPTIONENDPOINTURL` + `APP_NVINGEST_CAPTIONMODELNAME`. Linked to the "Separate VLMs for Generation and Captioning" section already in the file for context.
4. `docs/image_captioning.md` — In "Using Helm chart deployment", changed the YAML snippet: removed `nim-vlm: enabled: true`; added `nimOperator.nim-vlm-captioning.enabled: true`; changed endpoint URL from `http://nim-vlm:8000/...` to `http://nim-vlm-captioning:8000/...`; changed model name from `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` to `nvidia/nemotron-nano-12b-v2-vl`.
5. `docs/change-model.md` — Expanded the "Switch from the VLM Embedder to the Text-Only Embedder" Helm snippet to include: `nimOperator` block flipping the two embedder NIMs, `APP_EMBEDDINGS_SERVERURL` in both `envVars` and `ingestor-server.envVars`, and a new `nv-ingest.envVars` block with `EMBEDDING_NIM_ENDPOINT` + `EMBEDDING_NIM_MODEL_NAME`. Prose rewritten to explain why each is necessary.
6. `docs/change-model.md` — Updated the Nemotron Nano vLLM snippet to include `resources.limits/requests.nvidia.com/gpu: 1`, `model.precision: "fp8"`, and `model.tensorParallelism: "1"`. Added a sentence explaining that the default values.yaml ships the Nemotron 3 Super 2-GPU profile and must be overridden to 1 GPU / tp1 when switching to a Nemotron Nano model.
7. `docs/text_only_ingest.md` Docker section — Added `export COMPONENTS_TO_READY_CHECK=""` to the env-var block. Inlined a sentence explaining why (compose default is `ALL`, otherwise nv-ingest readiness waits forever for disabled NIMs).
8. `docs/text_only_ingest.md` Helm section — Added `COMPONENTS_TO_READY_CHECK: ""` to the `nv-ingest.envVars` block in the values.yaml snippet, with a short comment explaining the same.

---

## 5. Validation

**E2E (Track A):** Not applicable — docs changes have no runtime; the live RAG stack (already running on this host) does not consume markdown files. The doc fixes apply to the next reader, not to a service instance.

**Unit tests:** Not applicable — the repo's `tests/unit/` covers `src/nvidia_rag/*`, not `docs/*`.

**Lint:** Per the Phase 1 infrastructure scout, there is **no markdown linter, no doc-build CI job, no MyST validator** configured for this repo (`pre-commit run --all-files` checks ruff/eslint/typescript only). The docs are built with Sphinx + MyST but no validation runs in CI. Validation was therefore done by:

- **Git diff visual review** — confirmed all 8 changes are minimal and confined to the targeted sections.
- **MyST `:::` block balance** — compared open/close counts before and after the fix. Both `deploy-helm.md` (-1 block) and `deploy-helm-from-repo.md` (-1 block) show correct deltas. The residual `:::` imbalance in `deploy-helm.md` (open=7, close=6) is pre-existing from a nested `:::{note}` inside another directive and is not affected by this fix.
- **YAML validity** — every YAML block I added/changed was inspected against the actual `values.yaml` keys (`nim-vlm-captioning`, `nvidia-nim-llama-nemotron-embed-1b-v2`, `nvidia-nim-llama-nemotron-embed-vl-1b-v2`, `nim-llm`, etc.) and confirmed to be syntactically and semantically correct.
- **Cross-reference integrity** — the new pointer to `nemotron3-super-deployment.md#rtx-pro-6000-setup` was verified by R3 to match the existing heading "## RTX PRO 6000 Setup" at line 28 of that file.

---

## 6. Risk

**Low.** Documentation-only changes; no code path, runtime behavior, deployment artifact, or test was touched. The worst-case downside is a reader following the docs and getting a slightly clearer description of an existing configuration; the upside is fixing a re-opened release-blocker docs bug.

### 6.5 Expert Review notes

Five reviewer subagents ran in parallel (R1 root-cause, R3 doc quality, R4 scope, R7 user-instructions compliance; R2 was skipped — no Python/JS coding conventions apply to a docs change; R5 not applicable — no test changes; R6 not applicable — Track A).

| Reviewer | Verdict | Summary |
|---|---|---|
| R1 (root-cause linkage) | `none` | "Fix accurately resolves all reported unfixed items. Cross-referencing against actual config sources confirms full alignment." Verified config keys against `values.yaml`, `nims.yaml`, `docker-compose-ingestor-server.yaml`. |
| R3 (doc quality) | `none` | "YAML syntax valid, MyST directives balanced, cross-references intact, no typos." |
| R4 (scope discipline) | **`blocker`** | Argued that `text_only_ingest.md` and `vlm.md` were "not mentioned in the bug" and that `change-model.md` expansion exceeded the reopen-comment scope. |
| R7 (user-instructions compliance) | `none` | "Docs-only fix, no `deploy/*` modifications, `--no-nvbugs-update` honored, `--skills-path skill-source/.agents/skills` honored." |

**Orchestrator decision on R4's blocker:** override and proceed. R4 reviewed the diff against only the reopen-comment text, not the full NVBug comment timeline. Cross-checking against the verbatim bug content (Track 1C fetch):

- `text_only_ingest.md` **is** in scope — the reopen comment explicitly says "for comment no #3 COMPONENTS_TO_READY_CHECK must be set to empty string. That note is removed." Comment #3 (chronological) is the 2026-05-19 comment about `text_only_ingest.md`.
- `vlm.md` **is** in scope — comment #8 (2026-05-25) explicitly enumerates the required captioning-config variables for both `image-captioning.md` AND `vlm.md` (its second half discusses "For vlm-generation section: … we should also set below variables …" listing `nim-vlm-captioning.enabled`, `APP_NVINGEST_CAPTIONENDPOINTURL`, `APP_NVINGEST_CAPTIONMODELNAME`).
- The `change-model.md` expansion exactly matches comment #2's enumerated four required changes and comment #5's tp1 + GPU=1 requirement — nothing was added beyond what the reporter listed.

R4's blocker was therefore based on incomplete bug context. Re-entering Phase 3 would not improve the fix; the more productive action is to record R4's concern transparently here so a human reviewer can re-check it against the verbatim bug content if they wish.

---

## 7. Audit

- **Branch:** `bugfix/nvbug-6190418-20260526-062749`
- **Files changed:** `docs/change-model.md`, `docs/deploy-helm-from-repo.md`, `docs/deploy-helm.md`, `docs/image_captioning.md`, `docs/text_only_ingest.md`, `docs/vlm.md`
- **Commit status:** Uncommitted — per skill convention, the user creates the commit.
- **NVBug comment posted?** No (`--no-nvbugs-update`).
- **Incidental findings:** Pre-existing `:::` imbalance in `docs/deploy-helm.md` from nested MyST directives (open=8/close=7 before fix, open=7/close=6 after). Not introduced by this fix; flagging in case a separate cleanup is desired.

---

## 8. Suggested NVBug comment (if the user later wants to post one)

> Repro: read `docs/deploy-helm.md`, `docs/deploy-helm-from-repo.md`, `docs/vlm.md`, `docs/image_captioning.md`, `docs/change-model.md`, `docs/text_only_ingest.md` on branch `bugfix/nvbug-6190418-20260526-062749` and confirm the 8 items the reopen comment called out are present.
>
> Fix applied (8 edits across 6 files, all in `docs/`):
> 1. Removed inline RTX6000 Pro `:::{important}` block from `deploy-helm.md` and `deploy-helm-from-repo.md`; kept the cross-reference to `nemotron3-super-deployment.md#rtx-pro-6000-setup`.
> 2. `vlm.md` "Enable VLM with Helm" step 2 — added `nim-vlm-captioning.enabled`, `APP_NVINGEST_CAPTIONENDPOINTURL`, `APP_NVINGEST_CAPTIONMODELNAME` to the snippet.
> 3. `image_captioning.md` "Using Helm chart deployment" — switched from `nim-vlm` to `nim-vlm-captioning`; endpoint `http://nim-vlm-captioning:8000/v1/chat/completions`; model `nvidia/nemotron-nano-12b-v2-vl`.
> 4. `change-model.md` "Switch from VLM Embedder to Text-Only Embedder" Helm section — added `nimOperator` flip for the two embedder NIMs, `APP_EMBEDDINGS_SERVERURL` in both env-var blocks, and `nv-ingest.envVars.EMBEDDING_NIM_ENDPOINT` + `EMBEDDING_NIM_MODEL_NAME`.
> 5. `change-model.md` Nemotron Nano vLLM snippet — added `tensorParallelism: "1"`, `precision: "fp8"`, `resources: {nvidia.com/gpu: 1}`.
> 6. `text_only_ingest.md` Docker section — added `export COMPONENTS_TO_READY_CHECK=""`.
> 7. `text_only_ingest.md` Helm section — added `nv-ingest.envVars.COMPONENTS_TO_READY_CHECK: ""`.
>
> Verified by reading each section back against the actual config in `deploy/helm/nvidia-blueprint-rag/values.yaml`, `deploy/compose/nims.yaml`, and `deploy/compose/docker-compose-ingestor-server.yaml`. No code or deployment artifacts touched.

(Not posted — `--no-nvbugs-update` was set.)

</details>
