### PR TITLE
Add Agentic RAG observability metrics and Grafana dashboard

### DIFF
--- a/deploy/config/agentic-rag-metrics-dashboard.json
+++ b/deploy/config/agentic-rag-metrics-dashboard.json
@@ -1,0 +1,577 @@
+{
+  "title": "Agentic RAG Metrics",
+  "uid": "agentic-rag-metrics",
+  "version": 1,
+  "schemaVersion": 40,
+  "editable": false,
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "refresh": "30s",
+  "panels": [
+    {
+      "type": "row",
+      "title": "Overview",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "Agentic Reqs/sec",
+      "description": "",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(agentic_requests_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Error rate (%)",
+      "description": "",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "100 * sum(rate(agentic_requests_total{job=~\"$job\", instance=~\"$instance\", status=\"error\"}[$__rate_interval])) / sum(rate(agentic_requests_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Avg Request Duration (ms)",
+      "description": "",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(increase(agentic_request_duration_ms_sum{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) / sum(increase(agentic_request_duration_ms_count{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "P95 Request Duration (ms)",
+      "description": "",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(agentic_request_duration_ms_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "type": "row",
+      "title": "Stage Latency",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Avg stage duration (ms)",
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (stage) (increase(agentic_stage_duration_ms_sum{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) / sum by (stage) (increase(agentic_stage_duration_ms_count{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{stage}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "P95 stage duration (ms)",
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (stage, le) (rate(agentic_stage_duration_ms_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "{{stage}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "type": "row",
+      "title": "LLM Cost",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "Avg. LLM calls / request",
+      "description": "",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 15
+      },
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(increase(agentic_llm_calls_total{job=~\"$job\", instance=~\"$instance\"}[$__range])) / sum(increase(agentic_requests_total{job=~\"$job\", instance=~\"$instance\"}[$__range]))"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Total Input token usage",
+      "description": "",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 15
+      },
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(increase(agentic_llm_tokens_total{type=\"input\", job=~\"$job\", instance=~\"$instance\"}[$__range]))"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Total output token usage",
+      "description": "",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 15
+      },
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(increase(agentic_llm_tokens_total{type=\"output\", job=~\"$job\", instance=~\"$instance\"}[$__range]))"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "LLM calls/min by role",
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 19
+      },
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "60 * sum by (role) (rate(agentic_llm_calls_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{role}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Token rate by role/type",
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 19
+      },
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (role, type) (rate(agentic_llm_tokens_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{role}} {{type}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Avg LLM call duration (ms)",
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 19
+      },
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (role) (increase(agentic_llm_call_duration_ms_sum{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) / sum by (role) (increase(agentic_llm_call_duration_ms_count{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{role}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "type": "row",
+      "title": "Retrieval",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Retrieval calls/min by stage",
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "60 * sum by (stage) (rate(agentic_retrieval_calls_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{stage}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Avg retrieved chunks by stage",
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (stage) (increase(agentic_retrieved_chunks_sum{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) / sum by (stage) (increase(agentic_retrieved_chunks_count{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{stage}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "label": "Data source",
+        "query": "prometheus",
+        "refresh": 1,
+        "current": {
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "options": []
+      },
+      {
+        "name": "job",
+        "type": "query",
+        "label": "Job",
+        "datasource": "$datasource",
+        "refresh": 2,
+        "hide": 0,
+        "includeAll": true,
+        "allValue": ".+",
+        "multi": true,
+        "definition": "label_values(up, job)",
+        "query": {
+          "query": "label_values(up, job)",
+          "refId": "StandardVariableQuery"
+        }
+      },
+      {
+        "name": "instance",
+        "type": "query",
+        "label": "Instance",
+        "datasource": "$datasource",
+        "refresh": 2,
+        "hide": 0,
+        "includeAll": true,
+        "allValue": ".+",
+        "multi": true,
+        "definition": "label_values(up{job=~\"$job\"}, instance)",
+        "query": {
+          "query": "label_values(up{job=~\"$job\"}, instance)",
+          "refId": "StandardVariableQuery"
+        }
+      }
+    ]
+  },
+  "annotations": {
+    "list": []
+  },
+  "links": []
+}

--- a/docs/agentic-rag.md
+++ b/docs/agentic-rag.md
@@ -33,7 +33,13 @@ The pipeline defaults to off because Agentic RAG trades latency and extra LLM ca
 - The agentic path does not use NeMo Guardrails, Self-Reflection, Query Decomposition, or VLM Inference. Query rewriting, multi-turn history, multi-collection retrieval, citations, filter generation, and reranking are supported.
 - Verification runs once; there's no nested verification loop.
 - Tasks in a plan run at one parallel level; there's no DAG or depends-on construct.
-- Per-response retrieval metrics are not emitted. The agentic pipeline issues multiple retrieval calls across initial retrieval, per-task execution, and verification re-retrieval, so the single `metrics` block returned by the standard chain is not populated for agentic requests.
+- Response metadata that is specific to the Standard RAG single-pass pipeline can be omitted or returned empty for Agentic RAG when it does not map cleanly to the multi-step agentic flow.
+
+## Observability
+
+When observability is enabled, Agentic RAG exports aggregate `agentic_` Prometheus metrics for retrieval calls, task outcomes, stage latency, LLM usage, and verification behavior. These metrics are separate from the Standard RAG dashboard because Agentic RAG can issue multiple retrieval and LLM calls across initial retrieval, task execution, retries, synthesis, and verification.
+
+Use `deploy/config/agentic-rag-metrics-dashboard.json` to view these metrics in Grafana. See [Observability Setup](observability.md#view-metrics-in-grafana) for dashboard import steps.
 
 ## Architecture Overview
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -54,33 +54,18 @@ Open the Zipkin UI at: **http://localhost:9411**
 
 ## View Metrics in Grafana
 
-As part of the tracing, the RAG service also exports metrics like API request counts, LLM prompt and completion token count and words per chunk.
+Metrics are exposed at **http://localhost:8889/metrics** and can be viewed in Grafana.
 
-These metrics are exposed on the metrics endpoint exposed by Otel collector at **http://localhost:8889/metrics**
-
-You can open Grafana UI and visualize these metrics on a dashboard by selecting data source as Prometheus and putting prometheus URL as **http://prometheus:9090**
-
-Open the Grafana UI at **http://localhost:3000**
-
-
-### Create a Dashboard in Grafana
-
-To create a dashboard in [Grafana](https://grafana.com/) use the following procedure.
-
-1. Navigate to the Grafana UI at `http://localhost:3000`.
-
-2. Log in with the default credentials (`admin`/`admin`).
-
-3. Go to the **Dashboards** section and click **Import**.
-
-4. Upload the JSON file located in the `deploy/config` directory.
-
-5. Select the data source for the dashboard. Ensure that the data source is correctly configured to pull metrics from your Prometheus instance.
-
-6. Save the dashboard.
-
-7. View your metrics and traces.
-
+1. Open Grafana:
+   - Docker Compose: <http://localhost:3000>
+   - Helm: port-forward Grafana and open <http://localhost:3001>.
+2. Log in with `admin` / `admin`, unless you changed the Grafana credentials.
+3. If the Prometheus data source is not configured, add it with URL `http://prometheus:9090`.
+4. Go to **Dashboards** > **Import**.
+5. Upload the dashboard JSON file:
+   - Standard RAG: `deploy/config/rag-metrics-dashboard.json`
+   - Agentic RAG: `deploy/config/agentic-rag-metrics-dashboard.json`
+6. Select the `Prometheus` data source, then select **Import**.
 
 ## Query-to-Answer Pipeline and Studying Time Spent
 

--- a/src/nvidia_rag/rag_server/agentic_rag/agentic_rag.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/agentic_rag.py
@@ -55,6 +55,7 @@ from opentelemetry import trace as otel_trace
 from pydantic import BaseModel, Field
 
 from nvidia_rag.rag_server.agentic_rag.response_parser import parse_json_response
+from nvidia_rag.rag_server.agentic_rag.tracing import get_current_trace
 
 logger = logging.getLogger(__name__)
 
@@ -971,6 +972,8 @@ class AgenticRag:
                 ) as rspan:
                     rspan.set_attribute("openinference.span.kind", "RETRIEVER")
                     rspan.set_attribute("input.value", current_query or "")
+                    retrieval_start = time.perf_counter()
+                    retrieval_error = False
                     try:
                         raw_context = await self.retriever_fn(current_query, stage)
                         if raw_context is None:
@@ -981,10 +984,22 @@ class AgenticRag:
                             "metadata", json.dumps({"error": str(ex)[:200]})
                         )
                         raw_context = []
+                        retrieval_error = True
+                    retrieval_duration_ms = (
+                        time.perf_counter() - retrieval_start
+                    ) * 1000
 
                 chunks = self._extract_chunks(
                     raw_context if isinstance(raw_context, list) else [raw_context]
                 )
+                trace = get_current_trace()
+                if trace:
+                    trace.record_retrieval_call(
+                        stage,
+                        len(chunks),
+                        duration_ms=retrieval_duration_ms,
+                        error=retrieval_error,
+                    )
 
                 if not chunks:
                     logger.debug(
@@ -1153,6 +1168,8 @@ class AgenticRag:
             with self._otel.start_as_current_span("retrieve:original") as rspan:
                 rspan.set_attribute("openinference.span.kind", "RETRIEVER")
                 rspan.set_attribute("input.value", state.user_query)
+                retrieval_start = time.perf_counter()
+                retrieval_error = False
                 try:
                     raw = await self.retriever_fn(state.user_query, "initial_retrieval")
                     if raw is None:
@@ -1182,6 +1199,8 @@ class AgenticRag:
                         "metadata", json.dumps({"error": str(ex)[:200]})
                     )
                     chunks = []
+                    retrieval_error = True
+                retrieval_duration_ms = (time.perf_counter() - retrieval_start) * 1000
 
             logger.info("%s Retrieval complete: %d chunks", _P, len(chunks))
 
@@ -1193,6 +1212,12 @@ class AgenticRag:
             trace = get_current_trace()
             if trace:
                 trace.retrieval_stats = stats
+                trace.record_retrieval_call(
+                    "initial_retrieval",
+                    len(chunks),
+                    duration_ms=retrieval_duration_ms,
+                    error=retrieval_error,
+                )
 
             rebuilt_context = [{"results": [self._rebuild_result(c) for c in chunks]}]
 

--- a/src/nvidia_rag/rag_server/agentic_rag/runner.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/runner.py
@@ -105,6 +105,23 @@ def _collate_citations(
     )
 
 
+def _record_agentic_query_metrics(
+    metrics: Any | None,
+    trace: QueryTrace,
+    *,
+    status: str,
+    verification_enabled: bool,
+) -> None:
+    if metrics is None:
+        return
+    try:
+        metrics.record_agentic_query_trace(
+            trace, status=status, verification_enabled=verification_enabled
+        )
+    except Exception as mex:  # noqa: BLE001
+        logger.debug("Agentic RAG metrics update failed: %s", mex)
+
+
 def _log_final_response(answer: str) -> None:
     """Emit the LLM GENERATION COMPLETE / Final LLM Response block.
 
@@ -176,6 +193,9 @@ async def run_agentic_pipeline(
 
     initial_state = AgenticRAGGraphState(user_query=query)
     collection_name = collection_names[0] if collection_names else ""
+    verification_enabled = bool(
+        getattr(getattr(agent, "verification_cfg", None), "enabled", False)
+    )
 
     if enable_streaming:
         # ContextVars are bound *inside* the streaming generator (see
@@ -254,6 +274,12 @@ async def run_agentic_pipeline(
             trace.final_answer = answer
             trace.finalize()
             agent.metrics.update(trace)
+            _record_agentic_query_metrics(
+                metrics,
+                trace,
+                status="success",
+                verification_enabled=verification_enabled,
+            )
 
             root_span.set_attribute("output.value", answer)
             logger.info("[AGENTIC_RAG] Query done: %s", trace.one_line_summary())
@@ -282,6 +308,12 @@ async def run_agentic_pipeline(
         trace.error = str(ex)[:500]
         trace.finalize()
         agent.metrics.update(trace)
+        _record_agentic_query_metrics(
+            metrics,
+            trace,
+            status="error",
+            verification_enabled=verification_enabled,
+        )
         logger.info("[AGENTIC_RAG] Query failed: %s", trace.one_line_summary())
         agent.metrics.log_summary()
 
@@ -341,7 +373,10 @@ async def _run_streaming(
     created in a different Context".
     """
     debug_stream = bool(getattr(cfg, "enable_debug_stream", False))
-    verification_enabled = bool(getattr(agent.verification_cfg, "enabled", False))
+    verification_enabled = bool(
+        getattr(getattr(agent, "verification_cfg", None), "enabled", False)
+    )
+    metrics_recorded = False
 
     def _build_citations_now() -> Citations | None:
         if not enable_citations:
@@ -349,14 +384,23 @@ async def _run_streaming(
         return _collate_citations(citations_acc)
 
     async def _on_complete(final_answer: str) -> None:
+        nonlocal metrics_recorded
         trace.final_answer = final_answer
         trace.finalize()
         agent.metrics.update(trace)
+        _record_agentic_query_metrics(
+            metrics,
+            trace,
+            status="success",
+            verification_enabled=verification_enabled,
+        )
+        metrics_recorded = True
         logger.info("[AGENTIC_RAG] Query done: %s", trace.one_line_summary())
         _log_final_response(final_answer)
         agent.metrics.log_summary()
 
     async def _stream() -> AsyncIterator[str]:
+        nonlocal metrics_recorded
         trace_token = _current_trace.set(trace)
         params_token = _agentic_search_params.set(search_params)
         citations_token = _agentic_all_citations.set(citations_acc)
@@ -401,6 +445,13 @@ async def _run_streaming(
             trace.error = str(ex)[:500]
             trace.finalize()
             agent.metrics.update(trace)
+            _record_agentic_query_metrics(
+                metrics,
+            trace,
+            status="error",
+            verification_enabled=verification_enabled,
+            )
+            metrics_recorded = True
             logger.info("[AGENTIC_RAG] Query failed: %s", trace.one_line_summary())
             agent.metrics.log_summary()
             raise
@@ -416,20 +467,15 @@ async def _run_streaming(
                 # keep a defensive guard so a stray context mismatch never
                 # masks the stream's real outcome.
                 logger.debug("Streaming cleanup failed: %s", cex)
-            # ``metrics`` is passed in for parity with the non-streaming path;
-            # the translator already records TTFT/generation time on the
-            # finishing chunk, but we still want OTel histogram updates.
-            if metrics is not None:
-                try:
-                    payload = {
-                        "rag_ttft_ms": getattr(trace, "rag_ttft_ms", None),
-                        "llm_ttft_ms": getattr(trace, "llm_ttft_ms", None),
-                    }
-                    payload = {k: v for k, v in payload.items() if v is not None}
-                    if payload:
-                        metrics.update_latency_metrics(payload)
-                except Exception as mex:  # noqa: BLE001
-                    logger.debug("OTel latency update failed: %s", mex)
+            if not metrics_recorded and trace.end_time is not None:
+                agent.metrics.update(trace)
+                _record_agentic_query_metrics(
+                    metrics,
+                    trace,
+                    status="error" if trace.error else "success",
+                    verification_enabled=verification_enabled,
+                )
+                agent.metrics.log_summary()
 
     # collection_name not currently surfaced in streaming chunks, but kept in
     # signature for parity with the non-streaming branch.

--- a/src/nvidia_rag/rag_server/agentic_rag/streaming.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/streaming.py
@@ -68,6 +68,7 @@ from enum import StrEnum
 from typing import Any
 from uuid import uuid4
 
+from nvidia_rag.rag_server.agentic_rag.tracing import get_current_trace
 from nvidia_rag.rag_server.response_generator import (
     ChainResponse,
     ChainResponseChoices,
@@ -798,6 +799,10 @@ async def translate_graph_stream(
         raise
     except Exception as ex:  # noqa: BLE001
         logger.exception("[stream] graph stream failed: %s", ex)
+        trace = get_current_trace()
+        if trace is not None and trace.end_time is None:
+            trace.error = str(ex)[:500]
+            trace.finalize()
         # Surface the error to the client so it doesn't hang on a half-stream.
         yield _build_chunk(
             resp_id=resp_id,

--- a/src/nvidia_rag/rag_server/agentic_rag/tracing.py
+++ b/src/nvidia_rag/rag_server/agentic_rag/tracing.py
@@ -74,6 +74,16 @@ class NodeTiming:
     duration_ms: float
 
 
+@dataclass
+class RetrievalRecord:
+    """Single retrieval call summary."""
+
+    stage: str
+    chunks: int
+    duration_ms: float | None = None
+    error: bool = False
+
+
 # ---------------------------------------------------------------------------
 # QueryTrace — per-query collector
 # ---------------------------------------------------------------------------
@@ -91,6 +101,7 @@ class QueryTrace:
 
     llm_calls: list[LLMCallRecord] = field(default_factory=list)
     node_timings: list[NodeTiming] = field(default_factory=list)
+    retrieval_calls: list[RetrievalRecord] = field(default_factory=list)
 
     retrieval_stats: dict[str, Any] = field(default_factory=dict)
     plan_summary: dict[str, Any] = field(default_factory=dict)
@@ -132,6 +143,22 @@ class QueryTrace:
 
     # ---- properties -------------------------------------------------------
 
+    def record_retrieval_call(
+        self,
+        stage: str,
+        chunks: int,
+        duration_ms: float | None = None,
+        error: bool = False,
+    ) -> None:
+        self.retrieval_calls.append(
+            RetrievalRecord(
+                stage=stage,
+                chunks=chunks,
+                duration_ms=duration_ms,
+                error=error,
+            )
+        )
+
     @property
     def total_llm_calls(self) -> int:
         return len(self.llm_calls)
@@ -169,6 +196,17 @@ class QueryTrace:
             "node_timings": [
                 {"node": nt.node_name, "duration_ms": round(nt.duration_ms, 1)}
                 for nt in self.node_timings
+            ],
+            "retrieval_calls": [
+                {
+                    "stage": rc.stage,
+                    "chunks": rc.chunks,
+                    "duration_ms": round(rc.duration_ms, 1)
+                    if rc.duration_ms is not None
+                    else None,
+                    "error": rc.error,
+                }
+                for rc in self.retrieval_calls
             ],
             "llm_calls": [
                 {

--- a/src/nvidia_rag/utils/observability/agentic_metrics.py
+++ b/src/nvidia_rag/utils/observability/agentic_metrics.py
@@ -1,0 +1,278 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenTelemetry metrics for the Agentic RAG pipeline."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nvidia_rag.rag_server.agentic_rag.tracing import QueryTrace
+
+logger = logging.getLogger(__name__)
+
+_STAGES = (
+    "initial_retrieval",
+    "plan",
+    "execute",
+    "synthesize",
+    "verify_execute",
+    "verify",
+)
+
+
+class AgenticRAGMetrics:
+    """Encapsulates Agentic RAG aggregate metrics.
+
+    The exporter consumes the per-request ``QueryTrace`` object once the
+    agentic graph finishes. This keeps metric emission centralized and avoids
+    high-cardinality labels from query, task, or document content.
+    """
+
+    def __init__(self, service_name: str, meter: Any):
+        self.service_name = service_name
+        self._instruments = self._create_instruments(meter)
+        self._otlp_instruments = None
+
+    def _create_instruments(self, meter: Any) -> dict[str, Any]:
+        return {
+            "requests": meter.create_counter(
+                "agentic_requests_total",
+                description="Total Agentic RAG requests",
+            ),
+            "request_duration": meter.create_histogram(
+                "agentic_request_duration_ms",
+                description="Agentic RAG request duration in milliseconds",
+            ),
+            "stage_duration": meter.create_histogram(
+                "agentic_stage_duration_ms",
+                description="Agentic RAG graph stage duration in milliseconds",
+            ),
+            "llm_calls": meter.create_counter(
+                "agentic_llm_calls_total",
+                description="Agentic RAG LLM calls",
+            ),
+            "llm_call_duration": meter.create_histogram(
+                "agentic_llm_call_duration_ms",
+                description="Agentic RAG LLM call duration in milliseconds",
+            ),
+            "llm_tokens": meter.create_counter(
+                "agentic_llm_tokens_total",
+                description="Agentic RAG LLM token usage",
+            ),
+            "plan_tasks": meter.create_histogram(
+                "agentic_plan_tasks",
+                description="Agentic RAG planned task count per request",
+            ),
+            "scope_rounds": meter.create_histogram(
+                "agentic_scope_rounds",
+                description="Agentic RAG scope discovery rounds per request",
+            ),
+            "retrieval_calls": meter.create_counter(
+                "agentic_retrieval_calls_total",
+                description="Agentic RAG retrieval calls",
+            ),
+            "retrieved_chunks": meter.create_histogram(
+                "agentic_retrieved_chunks",
+                description="Agentic RAG retrieved chunks per retrieval call",
+            ),
+            "task_results": meter.create_counter(
+                "agentic_task_results_total",
+                description="Agentic RAG task outcomes",
+            ),
+            "task_attempts": meter.create_histogram(
+                "agentic_task_attempts",
+                description="Agentic RAG task attempts",
+            ),
+            "verification": meter.create_counter(
+                "agentic_verification_total",
+                description="Agentic RAG verification outcomes",
+            ),
+            "verification_followup_tasks": meter.create_histogram(
+                "agentic_verification_followup_tasks",
+                description="Agentic RAG verification follow-up task count",
+            ),
+            "errors": meter.create_counter(
+                "agentic_errors_total",
+                description="Agentic RAG errors",
+            ),
+        }
+
+    def setup_otlp_meter(self, otlp_meter: Any) -> None:
+        """Set up an OTLP meter for dual export."""
+        try:
+            self._otlp_instruments = self._create_instruments(otlp_meter)
+        except Exception as e:  # noqa: BLE001
+            logger.error("Failed to setup Agentic RAG OTLP metrics: %s", e)
+            self._otlp_instruments = None
+
+    def record_query_trace(
+        self,
+        trace: QueryTrace,
+        *,
+        status: str,
+        verification_enabled: bool,
+    ) -> None:
+        """Record aggregate metrics for one completed Agentic RAG query."""
+        try:
+            status_label = _normalize_status(status)
+            verification_label = _bool_label(verification_enabled)
+            for instruments in self._instrument_sets():
+                self._record_with_instruments(
+                    instruments,
+                    trace,
+                    status=status_label,
+                    verification_enabled=verification_label,
+                )
+        except Exception as e:  # noqa: BLE001
+            logger.debug("Failed to record Agentic RAG metrics: %s", e)
+
+    def _instrument_sets(self) -> list[dict[str, Any]]:
+        instrument_sets = [self._instruments]
+        if self._otlp_instruments is not None:
+            instrument_sets.append(self._otlp_instruments)
+        return instrument_sets
+
+    def _record_with_instruments(
+        self,
+        instruments: dict[str, Any],
+        trace: QueryTrace,
+        *,
+        status: str,
+        verification_enabled: str,
+    ) -> None:
+        request_attrs = {
+            "status": status,
+            "verification_enabled": verification_enabled,
+        }
+        instruments["requests"].add(1, request_attrs)
+        instruments["request_duration"].record(trace.total_duration_ms, request_attrs)
+
+        if status == "error":
+            instruments["errors"].add(1, {"stage": "request"})
+
+        for timing in getattr(trace, "node_timings", []):
+            stage = _normalize_stage(getattr(timing, "node_name", "unknown"))
+            instruments["stage_duration"].record(
+                getattr(timing, "duration_ms", 0.0),
+                {"stage": stage, "status": status},
+            )
+
+        for call in getattr(trace, "llm_calls", []):
+            role = _normalize_role(getattr(call, "step_name", "unknown"))
+            attrs = {"role": role, "status": status}
+            instruments["llm_calls"].add(1, attrs)
+            instruments["llm_call_duration"].record(
+                getattr(call, "duration_ms", 0.0),
+                attrs,
+            )
+            input_tokens = int(getattr(call, "input_tokens", 0) or 0)
+            output_tokens = int(getattr(call, "output_tokens", 0) or 0)
+            if input_tokens:
+                instruments["llm_tokens"].add(
+                    input_tokens, {"role": role, "type": "input", "status": status}
+                )
+            if output_tokens:
+                instruments["llm_tokens"].add(
+                    output_tokens, {"role": role, "type": "output", "status": status}
+                )
+
+        plan_summary = getattr(trace, "plan_summary", {}) or {}
+        if plan_summary:
+            plan_type = "scope" if plan_summary.get("scope_only") else "answer"
+            instruments["plan_tasks"].record(
+                int(plan_summary.get("task_count") or 0),
+                {"plan_type": plan_type, "status": status},
+            )
+            instruments["scope_rounds"].record(
+                int(plan_summary.get("scope_rounds") or 0),
+                {"status": status},
+            )
+
+        for retrieval in getattr(trace, "retrieval_calls", []):
+            stage = _normalize_stage(getattr(retrieval, "stage", "unknown"))
+            attrs = {"stage": stage, "status": status}
+            instruments["retrieval_calls"].add(1, attrs)
+            instruments["retrieved_chunks"].record(
+                int(getattr(retrieval, "chunks", 0) or 0),
+                attrs,
+            )
+            if getattr(retrieval, "error", False):
+                instruments["errors"].add(1, {"stage": stage})
+
+        task_results = getattr(trace, "task_results_summary", {}) or {}
+        for task in task_results.values():
+            result = _normalize_result(task.get("status", "unknown"))
+            attrs = {"result": result, "status": status}
+            instruments["task_results"].add(1, attrs)
+            instruments["task_attempts"].record(
+                int(task.get("attempts") or 0),
+                attrs,
+            )
+
+        verification = getattr(trace, "verification_outcome", {}) or {}
+        if verification:
+            result = "passed" if verification.get("passed") else "failed"
+        elif verification_enabled == "true":
+            result = "skipped"
+        else:
+            result = "disabled"
+        instruments["verification"].add(1, {"result": result, "status": status})
+        instruments["verification_followup_tasks"].record(
+            int(verification.get("follow_up_tasks") or 0),
+            {"status": status},
+        )
+
+
+def _bool_label(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _normalize_status(status: str) -> str:
+    return "error" if status == "error" else "success"
+
+
+def _normalize_result(result: str) -> str:
+    normalized = (result or "unknown").lower()
+    if normalized in {"answered", "no_data", "error"}:
+        return normalized
+    return "unknown"
+
+
+def _normalize_role(step_name: str) -> str:
+    normalized = (step_name or "").lower()
+    if "seed gen" in normalized or "seed" in normalized:
+        return "seed_generator"
+    if "task" in normalized and "answer" in normalized:
+        return "task"
+    if "planner" in normalized:
+        return "planner"
+    if "verification" in normalized or "verify" in normalized:
+        return "verifier"
+    if "synth" in normalized or "answer synthesis" in normalized:
+        return "synthesis"
+    return "unknown"
+
+
+def _normalize_stage(stage_name: str) -> str:
+    normalized = (stage_name or "").lower().strip()
+    for stage in _STAGES:
+        if normalized.startswith(stage):
+            return stage
+    if normalized.startswith("execute_scope"):
+        return "execute"
+    return "unknown"

--- a/src/nvidia_rag/utils/observability/otel_metrics.py
+++ b/src/nvidia_rag/utils/observability/otel_metrics.py
@@ -19,6 +19,8 @@ import logging
 
 from opentelemetry import metrics
 
+from nvidia_rag.utils.observability.agentic_metrics import AgenticRAGMetrics
+
 
 class OtelMetrics:
     """Encapsulates OpenTelemetry Metrics for API tracking."""
@@ -99,6 +101,9 @@ class OtelMetrics:
         self.avg_words_per_chunk_gauge = instruments["avg_words_per_chunk_gauge"]
         self.token_usage_histogram = instruments["token_usage_histogram"]
         self.latency_hists = instruments["latency_hists"]
+        self.agentic = AgenticRAGMetrics(
+            service_name=self.service_name, meter=self.meter
+        )
 
         logging.info("OpenTelemetry Metrics Initialized")
 
@@ -124,6 +129,7 @@ class OtelMetrics:
                 "avg_words_per_chunk_gauge"
             ]
             self._otlp_latency_hists = otlp_instruments["latency_hists"]
+            self.agentic.setup_otlp_meter(self._otlp_meter)
 
             logging.info(
                 "OTLP meter configured for dual export with cached instruments"
@@ -188,6 +194,18 @@ class OtelMetrics:
                     and name in self._otlp_latency_hists
                 ):
                     self._otlp_latency_hists[name].record(value)
+
+    def record_agentic_query_trace(
+        self,
+        trace,
+        *,
+        status: str,
+        verification_enabled: bool,
+    ) -> None:
+        """Record aggregate metrics for one Agentic RAG query."""
+        self.agentic.record_query_trace(
+            trace, status=status, verification_enabled=verification_enabled
+        )
 
 
 # Singleton factory to reuse a single OtelMetrics instance per process

--- a/tests/unit/test_observability/test_agentic_metrics.py
+++ b/tests/unit/test_observability/test_agentic_metrics.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from pathlib import Path
+
+from nvidia_rag.rag_server.agentic_rag.tracing import (
+    LLMCallRecord,
+    NodeTiming,
+    QueryTrace,
+    RetrievalRecord,
+)
+from nvidia_rag.utils.observability.agentic_metrics import AgenticRAGMetrics
+
+
+class FakeHistogram:
+    def __init__(self, name: str):
+        self.name = name
+        self.records: list[tuple[float, dict]] = []
+
+    def record(self, value: float, attrs: dict | None = None):
+        self.records.append((value, attrs or {}))
+
+
+class FakeCounter:
+    def __init__(self, name: str):
+        self.name = name
+        self.add_calls: list[tuple[int, dict]] = []
+
+    def add(self, amount: int, attrs: dict | None = None):
+        self.add_calls.append((amount, attrs or {}))
+
+
+class FakeMeter:
+    def __init__(self):
+        self.histograms: dict[str, FakeHistogram] = {}
+        self.counters: dict[str, FakeCounter] = {}
+
+    def create_histogram(self, name: str, description: str = ""):
+        hist = self.histograms.get(name)
+        if hist is None:
+            hist = FakeHistogram(name)
+            self.histograms[name] = hist
+        return hist
+
+    def create_counter(self, name: str, description: str = ""):
+        counter = self.counters.get(name)
+        if counter is None:
+            counter = FakeCounter(name)
+            self.counters[name] = counter
+        return counter
+
+
+def _build_trace() -> QueryTrace:
+    trace = QueryTrace(query_text="what changed?")
+    trace.llm_calls.extend(
+        [
+            LLMCallRecord("Planner (phase 1)", 10, 20, 30.0),
+            LLMCallRecord("Task t1 answer (attempt 1)", 5, 15, 25.0),
+            LLMCallRecord("Task t1 seed gen (attempt 2)", 3, 4, 5.0),
+            LLMCallRecord("Verification", 7, 8, 9.0),
+            LLMCallRecord("Answer synthesis", 11, 12, 13.0),
+        ]
+    )
+    trace.node_timings.extend(
+        [
+            NodeTiming("initial_retrieval", 12.0),
+            NodeTiming("plan (phase 1)", 34.0),
+            NodeTiming("execute (answer)", 56.0),
+            NodeTiming("verify_execute", 78.0),
+        ]
+    )
+    trace.retrieval_calls.extend(
+        [
+            RetrievalRecord("initial_retrieval", chunks=3, duration_ms=10.0),
+            RetrievalRecord("execute", chunks=2, duration_ms=20.0),
+            RetrievalRecord("verify_execute", chunks=0, duration_ms=5.0, error=True),
+        ]
+    )
+    trace.plan_summary = {"scope_only": False, "task_count": 2, "scope_rounds": 1}
+    trace.task_results_summary = {
+        "t1": {"status": "answered", "attempts": 1},
+        "t2": {"status": "no_data", "attempts": 2},
+    }
+    trace.verification_outcome = {
+        "passed": False,
+        "issues": ["missing figure"],
+        "follow_up_tasks": 1,
+    }
+    trace.finalize()
+    return trace
+
+
+def test_agentic_metrics_records_query_trace():
+    meter = FakeMeter()
+    metrics = AgenticRAGMetrics("rag", meter)
+
+    metrics.record_query_trace(
+        _build_trace(), status="success", verification_enabled=True
+    )
+
+    assert "agentic_requests_total" in meter.counters
+    assert meter.counters["agentic_requests_total"].add_calls[-1] == (
+        1,
+        {"status": "success", "verification_enabled": "true"},
+    )
+    assert meter.histograms["agentic_request_duration_ms"].records
+    assert any(
+        attrs == {"stage": "plan", "status": "success"}
+        for _, attrs in meter.histograms["agentic_stage_duration_ms"].records
+    )
+    assert (1, {"role": "planner", "status": "success"}) in meter.counters[
+        "agentic_llm_calls_total"
+    ].add_calls
+    assert (10, {"role": "planner", "type": "input", "status": "success"}) in meter.counters[
+        "agentic_llm_tokens_total"
+    ].add_calls
+    assert any(
+        attrs == {"plan_type": "answer", "status": "success"}
+        for _, attrs in meter.histograms["agentic_plan_tasks"].records
+    )
+    assert (1, {"stage": "verify_execute"}) in meter.counters[
+        "agentic_errors_total"
+    ].add_calls
+    assert (1, {"result": "failed", "status": "success"}) in meter.counters[
+        "agentic_verification_total"
+    ].add_calls
+
+
+def test_agentic_metrics_records_otlp_meter():
+    meter = FakeMeter()
+    otlp_meter = FakeMeter()
+    metrics = AgenticRAGMetrics("rag", meter)
+    metrics.setup_otlp_meter(otlp_meter)
+
+    metrics.record_query_trace(_build_trace(), status="error", verification_enabled=False)
+
+    assert meter.counters["agentic_requests_total"].add_calls[-1][1]["status"] == "error"
+    assert otlp_meter.counters["agentic_requests_total"].add_calls[-1][1]["status"] == "error"
+
+
+def test_agentic_metrics_handles_sparse_trace():
+    meter = FakeMeter()
+    metrics = AgenticRAGMetrics("rag", meter)
+    trace = QueryTrace(query_text="empty")
+    trace.finalize()
+
+    metrics.record_query_trace(trace, status="unknown", verification_enabled=False)
+
+    assert meter.counters["agentic_requests_total"].add_calls[-1][1] == {
+        "status": "success",
+        "verification_enabled": "false",
+    }
+    assert meter.counters["agentic_verification_total"].add_calls[-1] == (
+        1,
+        {"result": "disabled", "status": "success"},
+    )
+
+
+def test_agentic_dashboard_json_uses_agentic_metrics():
+    dashboard = json.loads(
+        Path("deploy/config/agentic-rag-metrics-dashboard.json").read_text()
+    )
+    expressions = []
+
+    def collect_exprs(value):
+        if isinstance(value, dict):
+            expr = value.get("expr")
+            if expr:
+                expressions.append(expr)
+            for child in value.values():
+                collect_exprs(child)
+        elif isinstance(value, list):
+            for child in value:
+                collect_exprs(child)
+
+    collect_exprs(dashboard["panels"])
+
+    assert expressions
+    assert all("agentic_" in expr for expr in expressions)

--- a/tests/unit/test_rag_server/test_agentic_rag.py
+++ b/tests/unit/test_rag_server/test_agentic_rag.py
@@ -46,6 +46,7 @@ from nvidia_rag.rag_server.agentic_rag.tracing import (
     AgentMetrics,
     LLMCallRecord,
     QueryTrace,
+    RetrievalRecord,
     get_current_trace,
 )
 from nvidia_rag.rag_server.response_generator import (
@@ -336,6 +337,46 @@ class TestTracing:
     def test_get_current_trace_default_none(self) -> None:
         assert get_current_trace() is None
 
+    def test_query_trace_serializes_retrieval_calls(self) -> None:
+        tr = QueryTrace(query_text="z")
+        tr.retrieval_calls.append(
+            RetrievalRecord(
+                stage="initial_retrieval",
+                chunks=3,
+                duration_ms=12.34,
+                error=False,
+            )
+        )
+        data = tr.to_dict()
+        assert data["retrieval_calls"] == [
+            {
+                "stage": "initial_retrieval",
+                "chunks": 3,
+                "duration_ms": 12.3,
+                "error": False,
+            }
+        ]
+
+
+class _DummyOtelMetrics:
+    def __init__(self) -> None:
+        self.agentic_calls = []
+        self.latency_updates = []
+
+    def record_agentic_query_trace(
+        self, trace, *, status: str, verification_enabled: bool
+    ) -> None:
+        self.agentic_calls.append(
+            {
+                "trace": trace,
+                "status": status,
+                "verification_enabled": verification_enabled,
+            }
+        )
+
+    def update_latency_metrics(self, payload: dict) -> None:
+        self.latency_updates.append(payload)
+
 
 class TestRunAgenticPipeline:
     @pytest.mark.asyncio
@@ -383,6 +424,101 @@ class TestRunAgenticPipeline:
         assert resp.status_code == ErrorCodeMapping.INTERNAL_SERVER_ERROR
         text = "".join([c async for c in resp.generator])
         assert "error" in text.lower() or "encountered" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_records_agentic_metrics(self) -> None:
+        graph = MagicMock()
+        graph.ainvoke = AsyncMock(return_value={"final_answer": "synthesized"})
+        metrics = _DummyOtelMetrics()
+
+        class _Agent:
+            def __init__(self) -> None:
+                self.metrics = AgentMetrics()
+                self.verification_cfg = SimpleNamespace(enabled=True)
+
+        cfg = AgenticRAGConfig()
+        resp = await run_agentic_pipeline(
+            agent=_Agent(),
+            graph=graph,
+            query="user q",
+            cfg=cfg,
+            search_params=AgenticSearchParams(),
+            enable_streaming=False,
+            metrics=metrics,
+        )
+
+        assert resp.status_code == ErrorCodeMapping.SUCCESS
+        assert len(metrics.agentic_calls) == 1
+        assert metrics.agentic_calls[0]["status"] == "success"
+        assert metrics.agentic_calls[0]["verification_enabled"] is True
+
+    @pytest.mark.asyncio
+    async def test_streaming_records_agentic_metrics(self) -> None:
+        class _FakeChunk:
+            def __init__(self, content: str = "") -> None:
+                self.content = content
+                self.additional_kwargs = {}
+
+        async def _fake_astream(_state, *, config, stream_mode):  # noqa: ARG001
+            yield (
+                "messages",
+                (_FakeChunk(content="done"), {"langgraph_node": "synthesize"}),
+            )
+
+        graph = MagicMock()
+        graph.astream = _fake_astream
+        metrics = _DummyOtelMetrics()
+
+        class _Agent:
+            def __init__(self) -> None:
+                self.metrics = AgentMetrics()
+                self.verification_cfg = SimpleNamespace(enabled=False)
+
+        resp = await run_agentic_pipeline(
+            agent=_Agent(),
+            graph=graph,
+            query="q",
+            cfg=AgenticRAGConfig(),
+            search_params=AgenticSearchParams(),
+            enable_streaming=True,
+            metrics=metrics,
+        )
+        chunks = [c async for c in resp.generator]
+
+        assert chunks
+        assert len(metrics.agentic_calls) == 1
+        assert metrics.agentic_calls[0]["status"] == "success"
+        assert metrics.agentic_calls[0]["verification_enabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_streaming_error_records_agentic_metrics(self) -> None:
+        async def _fake_astream(_state, *, config, stream_mode):  # noqa: ARG001
+            raise RuntimeError("boom")
+            yield  # pragma: no cover
+
+        graph = MagicMock()
+        graph.astream = _fake_astream
+        metrics = _DummyOtelMetrics()
+
+        class _Agent:
+            def __init__(self) -> None:
+                self.metrics = AgentMetrics()
+                self.verification_cfg = SimpleNamespace(enabled=False)
+
+        resp = await run_agentic_pipeline(
+            agent=_Agent(),
+            graph=graph,
+            query="q",
+            cfg=AgenticRAGConfig(),
+            search_params=AgenticSearchParams(),
+            enable_streaming=True,
+            metrics=metrics,
+        )
+        chunks = [json.loads(c.removeprefix("data: ")) async for c in resp.generator]
+
+        assert chunks[-1]["event_type"] == "error"
+        assert len(metrics.agentic_calls) == 1
+        assert metrics.agentic_calls[0]["status"] == "error"
 
     @pytest.mark.asyncio
     async def test_streaming_emits_stage_and_final_chunks(self) -> None:

--- a/tests/unit/test_rag_server/test_response_parser.py
+++ b/tests/unit/test_rag_server/test_response_parser.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the LLM response JSON parser / recovery module."""
+
+from __future__ import annotations
+
+import json
+
+from nvidia_rag.rag_server.agentic_rag.response_parser import (
+    _sanitize_json_string,
+    parse_json_response,
+)
+
+
+class TestSanitizeJsonString:
+    def test_escapes_newlines_in_strings(self) -> None:
+        dirty = '{"x": "line1\nline2"}'
+        clean = _sanitize_json_string(dirty)
+        assert "\n" not in clean.split('"x":')[1]
+        assert json.loads(clean)["x"] == "line1\nline2"
+
+    def test_repairs_missing_colon_before_array(self) -> None:
+        # '"tasks[' should become '"tasks": ['
+        broken = '{"tasks[{"id": "t1"}]}'
+        repaired = _sanitize_json_string(broken)
+        assert json.loads(repaired) == {"tasks": [{"id": "t1"}]}
+
+
+class TestParseJsonResponse:
+    def test_direct_and_embedded(self) -> None:
+        assert parse_json_response('{"k": 1}') == {"k": 1}
+        assert parse_json_response('prefix {"k": 2} suffix') == {"k": 2}
+
+    def test_invalid_returns_error_dict(self) -> None:
+        out = parse_json_response("not json at all")
+        assert out.get("error") == "Failed to parse JSON"
+
+    def test_sibling_restart_picks_last_complete_object(self) -> None:
+        # Reasoning model "draft + restart" pattern: pick the final object.
+        sibling = '{"completeness": "none", "answer": ""} {"completeness": "complete", "answer": "X"}'
+        assert parse_json_response(sibling) == {
+            "completeness": "complete",
+            "answer": "X",
+        }
+
+    def test_nested_objects_parse_intact(self) -> None:
+        assert parse_json_response('{"a": {"b": 1}, "c": 2}') == {
+            "a": {"b": 1},
+            "c": 2,
+        }


### PR DESCRIPTION
# Add Agentic RAG observability metrics

- Added Agentic RAG Prometheus metrics for request status, stage latency, LLM usage, retrieval, task results, and verification.
- Added an Agentic RAG Grafana dashboard and wired metrics emission from agentic query traces.
- Updated observability docs with concise dashboard import steps.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [X] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [X] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.