### PR TITLE
ci: add post-cve-report.sh for nightly CVE Issue comments

### DIFF
--- a/ci/post-cve-report.sh
+++ b/ci/post-cve-report.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Post agentic-cve-fix findings as a comment on the rolling tracker Issue.
+# Called by the GitLab `cve-post` job after downloading the `cve-scan`
+# artifact. This script has the GitHub PAT; the scan job does not.
+#
+# Required environment:
+#   GITHUB_PAT             Fine-grained PAT, Issues read/write on the target repo.
+#   TRACKER_ISSUE_NUMBER   Issue number of "Nightly CVE Scan Tracker" (e.g. 123).
+#
+# Optional:
+#   GITHUB_REPO            Target repo (default: NVIDIA-AI-Blueprints/rag).
+#   REPORTS_DIR            Directory the skill wrote reports to (default: cve-fix-reports).
+
+set -euo pipefail
+
+: "${GITHUB_PAT:?GITHUB_PAT is required}"
+: "${TRACKER_ISSUE_NUMBER:?TRACKER_ISSUE_NUMBER is required}"
+GITHUB_REPO="${GITHUB_REPO:-NVIDIA-AI-Blueprints/rag}"
+REPORTS_DIR="${REPORTS_DIR:-cve-fix-reports}"
+
+DATE_UTC="$(date -u +%Y-%m-%d)"
+
+if [ ! -d "$REPORTS_DIR" ] || [ -z "$(find "$REPORTS_DIR" -maxdepth 1 -name '*.md' -print -quit 2>/dev/null)" ]; then
+  echo "No CVE reports found in $REPORTS_DIR — posting empty-run comment."
+  BODY=$(cat <<EOF
+## Nightly CVE Scan — $DATE_UTC
+
+No CVEs found in this run.
+
+_Source: agentic-cve-fix (recommend-only) on the latest develop commit._
+EOF
+)
+else
+  REPORT_COUNT="$(find "$REPORTS_DIR" -maxdepth 1 -name '*.md' | wc -l | tr -d ' ')"
+  echo "Found $REPORT_COUNT report file(s) in $REPORTS_DIR."
+  BODY=$(cat <<EOF
+## Nightly CVE Scan — $DATE_UTC
+
+The agentic-cve-fix skill produced $REPORT_COUNT report(s) in
+\`recommend-only\` mode. Findings are workspace-only manifest edits that
+have NOT been installed or merged — review and apply manually if accepted.
+
+EOF
+)
+  for f in "$REPORTS_DIR"/*.md; do
+    BODY+=$'\n---\n\n### `'"$(basename "$f")"$'`\n\n'
+    BODY+="$(cat "$f")"
+    BODY+=$'\n'
+  done
+fi
+
+echo "$BODY" | GH_TOKEN="$GITHUB_PAT" gh issue comment \
+  "$TRACKER_ISSUE_NUMBER" \
+  --repo "$GITHUB_REPO" \
+  --body-file -
+
+echo "Posted comment to $GITHUB_REPO#$TRACKER_ISSUE_NUMBER"


### PR DESCRIPTION
Posts agentic-cve-fix findings as a comment on a rolling tracker Issue. Invoked by the GitLab cve-post job after downloading the cve-scan artifact. Keeps the GitHub PAT out of the scan job — only this script (run from a minimal image) ever sees it.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.