### PR TITLE
fix(ingestor): prevent 409 ConflictError on concurrent collection creation by passing conflicts=proceed to Elasticsearch delete_by_query

### DIFF
--- a/src/nvidia_rag/utils/vdb/elasticsearch/elastic_vdb.py
+++ b/src/nvidia_rag/utils/vdb/elasticsearch/elastic_vdb.py
@@ -795,11 +795,22 @@ class ElasticVDB(VDBRagIngest):
         Add metadata schema to a elasticsearch index.
         """
         collection_name = self._normalize_index_name(collection_name)
-        # Delete the metadata schema from the index
-        _ = self._es_connection.delete_by_query(
-            index=DEFAULT_METADATA_SCHEMA_COLLECTION,
-            body=get_delete_metadata_schema_query(collection_name),
-        )
+        # Delete the metadata schema from the index.
+        # conflicts="proceed" skips docs whose seq_no/primary_term changed between the
+        # search and delete phases of delete_by_query, which races when two
+        # create_collection calls for the same collection run concurrently. Any stale
+        # doc left behind is harmless because get_metadata_schema reads the most
+        # recent write via _seq_no desc sort.
+        try:
+            _ = self._es_connection.delete_by_query(
+                index=DEFAULT_METADATA_SCHEMA_COLLECTION,
+                body=get_delete_metadata_schema_query(collection_name),
+                conflicts="proceed",
+            )
+        except ConflictError:
+            logger.info(
+                f"Metadata schema delete_by_query saw a version conflict for collection: {collection_name}; proceeding to re-index."
+            )
         # Add the metadata schema to the index
         data = {
             "collection_name": collection_name,
@@ -912,7 +923,9 @@ class ElasticVDB(VDBRagIngest):
                 info_value=info_value,
             )
 
-        # Delete the document info from the index
+        # Delete the document info from the index.
+        # conflicts="proceed" prevents the same delete_by_query race seen in
+        # add_metadata_schema from surfacing as a 409 to callers.
         try:
             _ = self._es_connection.delete_by_query(
                 index=DEFAULT_DOCUMENT_INFO_COLLECTION,
@@ -921,9 +934,10 @@ class ElasticVDB(VDBRagIngest):
                     document_name=document_name,
                     info_type=info_type,
                 ),
+                conflicts="proceed",
             )
         except ConflictError:
-            logger.info(f"Document info not found for collection: {collection_name}, document: {document_name}, info type: {info_type}")
+            logger.info(f"Document info delete_by_query saw a version conflict for collection: {collection_name}, document: {document_name}, info type: {info_type}; proceeding to re-index.")
         # Add the document info to the index
         data = {
             "collection_name": collection_name,

--- a/tests/unit/test_utils/test_vdb/test_elastic_vdb.py
+++ b/tests/unit/test_utils/test_vdb/test_elastic_vdb.py
@@ -842,7 +842,9 @@ class TestElasticVDB(unittest.TestCase):
         }
 
         mock_es_connection.delete_by_query.assert_called_once_with(
-            index="metadata_schema", body={"query": "delete_query"}
+            index="metadata_schema",
+            body={"query": "delete_query"},
+            conflicts="proceed",
         )
         mock_es_connection.index.assert_called_once_with(
             index="metadata_schema", body=expected_data


### PR DESCRIPTION
# Fix occasional 500 on collection creation

## Problem
`POST /v1/collection` occasionally failed with HTTP 500 in nightly pipelines on RTX6000 and H100:
```
ConflictError(409, version_conflict_engine_exception ... index: metadata_schema)
```
Rerunning usually fixed it. This seems like an Race condition issue.

## Root cause
When two requests created the **same collection concurrently**, both ran `delete_by_query` on the `metadata_schema` index. Request A deleted the row at version 170; Request B's delete (still targeting version 170) then failed with 409, which surfaced as a 500 to the caller.

## Fix
Added `conflicts="proceed"` to the `delete_by_query` calls in `add_metadata_schema` and `add_document_info` (`src/nvidia_rag/utils/vdb/elasticsearch/elastic_vdb.py`). Tells Elasticsearch to skip racing rows instead of erroring. The read path already returns the newest row by `_seq_no`, so any leftover stale row is harmless.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [X] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [X] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.