### PR TITLE
ci: refresh CVE tracker Issue body instead of appending comments

### DIFF
--- a/ci/post-cve-report.sh
+++ b/ci/post-cve-report.sh
@@ -2,17 +2,24 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Post agentic-cve-fix findings as a comment on the rolling tracker Issue.
+# Refresh the rolling tracker Issue's body with the latest CVE scan results.
 # Called by the GitLab `cve-post` job after downloading the `cve-scan`
 # artifact. This script has the GitHub PAT; the scan job does not.
 #
+# Design: overwrite the Issue body each night (not append a comment).
+# History lives in the linked GitLab pipeline artifacts (~30-day retention).
+# Keeps Issue #617 a single-source-of-truth view of the latest scan.
+#
 # Required environment:
 #   GITHUB_PAT             Fine-grained PAT, Issues read/write on the target repo.
-#   TRACKER_ISSUE_NUMBER   Issue number of "Nightly CVE Scan Tracker" (e.g. 123).
+#   TRACKER_ISSUE_NUMBER   Issue number of "Nightly CVE Scan Tracker" (e.g. 617).
 #
-# Optional:
+# Optional / GitLab-provided:
 #   GITHUB_REPO            Target repo (default: NVIDIA-AI-Blueprints/rag).
-#   REPORTS_DIR            Directory the skill wrote reports to (default: cve-fix-reports).
+#   REPORTS_DIR            Skill's report output dir (default: cve-fix-reports).
+#   SCANNED_SHA            Commit SHA the skill scanned (from cve-scan dotenv).
+#   CI_PIPELINE_URL        GitLab pipeline URL (auto-set by GitLab).
+#   CI_JOB_URL             cve-scan job URL (auto-set by GitLab).
 
 set -euo pipefail
 
@@ -22,39 +29,68 @@ GITHUB_REPO="${GITHUB_REPO:-NVIDIA-AI-Blueprints/rag}"
 REPORTS_DIR="${REPORTS_DIR:-cve-fix-reports}"
 
 DATE_UTC="$(date -u +%Y-%m-%d)"
+TIMESTAMP_UTC="$(date -u +'%Y-%m-%d %H:%M UTC')"
+SCANNED_SHA="${SCANNED_SHA:-unknown}"
+SCANNED_SHA_SHORT="${SCANNED_SHA:0:8}"
 
-if [ ! -d "$REPORTS_DIR" ] || [ -z "$(find "$REPORTS_DIR" -maxdepth 1 -name '*.md' -print -quit 2>/dev/null)" ]; then
-  echo "No CVE reports found in $REPORTS_DIR — posting empty-run comment."
-  BODY=$(cat <<EOF
-## Nightly CVE Scan — $DATE_UTC
+# Metadata header — shown at the top of every refresh.
+HEADER=$(cat <<EOF
+# Nightly CVE Scan — $DATE_UTC
 
-No CVEs found in this run.
+| | |
+|---|---|
+| Updated | $TIMESTAMP_UTC |
+| Commit scanned | \`$SCANNED_SHA_SHORT\` (\`$SCANNED_SHA\`) |
+| GitLab pipeline | ${CI_PIPELINE_URL:-_(local run)_} |
+| cve-scan job | ${CI_JOB_URL:-_(local run)_} |
 
-_Source: agentic-cve-fix (recommend-only) on the latest develop commit._
+## About this Issue
+
+This Issue is auto-updated each night by the GitLab \`agentic-cve-fix\`
+pipeline. The body shows the **latest** scan only. **Do not close** —
+the pipeline writes back to this Issue number.
+
+Per-CVE detail (separate \`.md\` files, reviewer verdicts, validation
+results) lives in the linked GitLab pipeline artifact (30-day retention).
+
+---
 EOF
 )
-else
-  REPORT_COUNT="$(find "$REPORTS_DIR" -maxdepth 1 -name '*.md' | wc -l | tr -d ' ')"
-  echo "Found $REPORT_COUNT report file(s) in $REPORTS_DIR."
-  BODY=$(cat <<EOF
-## Nightly CVE Scan — $DATE_UTC
 
-The agentic-cve-fix skill produced $REPORT_COUNT report(s) in
-\`recommend-only\` mode. Findings are workspace-only manifest edits that
-have NOT been installed or merged — review and apply manually if accepted.
-
-EOF
-)
-  for f in "$REPORTS_DIR"/*.md; do
-    BODY+=$'\n---\n\n### `'"$(basename "$f")"$'`\n\n'
-    BODY+="$(cat "$f")"
-    BODY+=$'\n'
-  done
+# Find the program-level summary first; fall back to walking all .md files.
+# The skill writes _summary.md alongside per-CVE files under a timestamped
+# subdirectory like cve-fix-reports/NSPECT-<id>-<timestamp>/_summary.md.
+SUMMARY_FILE=""
+if [ -d "$REPORTS_DIR" ]; then
+  SUMMARY_FILE="$(find "$REPORTS_DIR" -name '_summary.md' -print -quit 2>/dev/null || true)"
 fi
 
-echo "$BODY" | GH_TOKEN="$GITHUB_PAT" gh issue comment \
+if [ -n "$SUMMARY_FILE" ] && [ -s "$SUMMARY_FILE" ]; then
+  echo "Found program summary: $SUMMARY_FILE"
+  BODY=$(printf '%s\n\n%s\n' "$HEADER" "$(cat "$SUMMARY_FILE")")
+elif [ -d "$REPORTS_DIR" ] && [ -n "$(find "$REPORTS_DIR" -name '*.md' -print -quit 2>/dev/null)" ]; then
+  # No _summary.md but per-CVE files exist — concatenate them all.
+  REPORT_COUNT="$(find "$REPORTS_DIR" -name '*.md' | wc -l | tr -d ' ')"
+  echo "Found $REPORT_COUNT report file(s); no _summary.md — concatenating per-CVE files."
+  BODY_PARTS="$HEADER
+
+## Findings ($REPORT_COUNT report(s))
+
+The skill ran in \`--recommend-only\` mode. No \`_summary.md\` was
+produced; per-CVE detail below."
+  while IFS= read -r f; do
+    BODY_PARTS+=$'\n\n---\n\n### `'"$(basename "$f")"$'`\n\n'
+    BODY_PARTS+="$(cat "$f")"
+  done < <(find "$REPORTS_DIR" -name '*.md' | sort)
+  BODY="$BODY_PARTS"
+else
+  echo "No CVE reports found under $REPORTS_DIR — posting empty-run body."
+  BODY=$(printf '%s\n\n## Result\n\nNo findings in this run.\n\n_Source: agentic-cve-fix (recommend-only) on the latest develop commit._\n' "$HEADER")
+fi
+
+echo "$BODY" | GH_TOKEN="$GITHUB_PAT" gh issue edit \
   "$TRACKER_ISSUE_NUMBER" \
   --repo "$GITHUB_REPO" \
   --body-file -
 
-echo "Posted comment to $GITHUB_REPO#$TRACKER_ISSUE_NUMBER"
+echo "Refreshed body of $GITHUB_REPO#$TRACKER_ISSUE_NUMBER"


### PR DESCRIPTION
Two changes in one rewrite of ci/post-cve-report.sh:

1. Switch gh issue comment → gh issue edit. The Issue body is now overwritten each night with the latest scan, not a new comment appended. Prevents unbounded comment thread growth on #617. Per-CVE history continues to live in the GitLab pipeline artifact (~30-day retention), linked from the body.

2. Drop `-maxdepth 1` from the find calls. The skill writes reports to a timestamped subdirectory (NSPECT-<id>-<ts>/_summary.md), so the previous top-level-only find missed every report. Verified against the real artifact from pipeline 52643357.

The new body has a metadata header (date, scanned SHA, GitLab pipeline + job links) above the skill's _summary.md content, followed by an 'About this Issue' boilerplate. Falls back to concatenating per-CVE files if no _summary.md is present, and to a 'No findings' body if the reports directory is empty.

Verified locally with mocked gh against both code paths.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.