### PR TITLE
agentic-bugfix: NVBug 6191270

### DIFF
--- a/src/nvidia_rag/rag_server/response_generator.py
+++ b/src/nvidia_rag/rag_server/response_generator.py
@@ -37,6 +37,7 @@ from uuid import uuid4
 
 import bleach
 from langchain_core.documents import Document
+from minio.error import S3Error
 from pydantic import BaseModel, Field, validator
 from pymilvus.exceptions import MilvusException, MilvusUnavailableException
 
@@ -992,6 +993,35 @@ def prepare_citations(
                             description=doc.page_content,
                             content_metadata=doc.metadata.get("content_metadata"),
                         )
+                except S3Error as e:
+                    # Missing-object errors are an expected condition when the
+                    # vector store retains a citation reference whose backing
+                    # object has been removed from object storage (e.g. after a
+                    # helm uninstall that retained the vector-store PVC but
+                    # cleared the object-store bucket). The request itself is
+                    # not failing — the citation is gracefully skipped by the
+                    # downstream `if content and document_type in [...]` filter
+                    # — so log at WARNING without a traceback to avoid polluting
+                    # rag-server logs with spurious ERROR-level noise.
+                    if e.code in ("NoSuchKey", "NoSuchBucket"):
+                        logger.warning(
+                            "Skipping citation: object missing in object storage "
+                            "(code=%s, resource=%s). The citation will be omitted "
+                            "from the response.",
+                            e.code,
+                            getattr(e, "resource", "<unknown>"),
+                        )
+                    else:
+                        logger.exception(
+                            "Error pulling content from object storage for "
+                            "image/table/chart for citations: %s",
+                            e,
+                        )
+                    content = ""
+                    source_metadata = SourceMetadata(
+                        description=doc.page_content,
+                        content_metadata=doc.metadata.get("content_metadata", {}),
+                    )
                 except Exception as e:
                     logger.exception(
                         f"Error pulling content from object storage for image/table/chart for citations: {e}"
@@ -1134,6 +1164,31 @@ def prepare_citations_nrl(
                         )
                     )
                     content = base64.b64encode(raw_bytes).decode("ascii")
+                except S3Error as exc:
+                    # Mirror the prepare_citations() behavior: missing-object
+                    # errors are an expected condition (vector store retains a
+                    # citation reference whose backing object has been removed
+                    # from object storage). Log at WARNING without a traceback
+                    # so rag-server logs stay clean; downstream guard drops the
+                    # citation via the empty-content check. Other S3Error codes
+                    # still surface at ERROR level so real backend problems are
+                    # not silently downgraded. (NVBug 6191270.)
+                    if exc.code in ("NoSuchKey", "NoSuchBucket"):
+                        logger.warning(
+                            "[Prepare Citations NRL] Skipping citation: object"
+                            " missing in object storage (code=%s, uri=%s)."
+                            " The citation will be omitted from the response.",
+                            exc.code,
+                            stored_image_uri,
+                        )
+                    else:
+                        logger.exception(
+                            "[Prepare Citations NRL] Failed to fetch asset"
+                            " from object storage (uri=%s): %s",
+                            stored_image_uri,
+                            exc,
+                        )
+                    content = ""
                 except Exception as exc:
                     logger.exception(
                         "[Prepare Citations NRL] Failed to fetch asset from object storage"

--- a/tests/unit/test_rag_server/test_response_generator.py
+++ b/tests/unit/test_rag_server/test_response_generator.py
@@ -20,6 +20,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from langchain_core.messages import AIMessageChunk
+from minio.error import S3Error
 from pydantic import ValidationError
 from pymilvus.exceptions import MilvusException, MilvusUnavailableException
 
@@ -46,6 +47,7 @@ from nvidia_rag.rag_server.response_generator import (
     generate_answer,
     generate_answer_async,
     prepare_citations,
+    prepare_citations_nrl,
     prepare_llm_request,
     retrieve_summary,
 )
@@ -856,10 +858,7 @@ class TestGenerateAnswerAsync:
             item for item in result if item["choices"][0].get("finish_reason") is None
         ]
         assert token_chunks[0]["choices"][0]["delta"]["content"] == ""
-        assert (
-            token_chunks[0]["choices"][0]["delta"]["reasoning_content"]
-            == "thinking"
-        )
+        assert token_chunks[0]["choices"][0]["delta"]["reasoning_content"] == "thinking"
         assert token_chunks[1]["choices"][0]["delta"]["content"] == "answer"
         assert token_chunks[1]["choices"][0]["delta"]["reasoning_content"] is None
 
@@ -1152,6 +1151,217 @@ class TestPrepareCitationsErrorHandling:
         assert isinstance(result, Citations)
         assert result.total_results == 1
         assert result.results[0].document_type == "audio"
+
+    @pytest.mark.parametrize("missing_code", ["NoSuchKey", "NoSuchBucket"])
+    def test_prepare_citations_object_store_missing_object_logged_as_warning(
+        self, missing_code, caplog
+    ):
+        """Regression for NVBug 6191270 — when the object-store key/bucket is missing
+        (a routine condition when the vector store retains citation references whose
+        backing object has been cleared, e.g. helm uninstall without deleting only the
+        object-store PVC), the citation must be gracefully skipped AND the rag-server
+        log must NOT contain an ERROR-level traceback. The QA expectation in the bug
+        report is explicit: "answer should come without any s3 error in rag-server
+        logs"."""
+        mock_doc = Mock()
+        mock_doc.page_content = "Test content"
+        mock_doc.metadata = {
+            "source": {
+                "source_id": "test.pdf",
+                "source_location": "s3://default-bucket/test_collection/test.pdf/1.png",
+            },
+            "content_metadata": {
+                "type": "image",
+                "subtype": "image",
+                "page_number": 1,
+                "location": [],
+            },
+            "collection_name": "test_collection",
+        }
+
+        s3_error = S3Error(
+            code=missing_code,
+            message="The specified key does not exist.",
+            resource="/default-bucket/test_collection/test.pdf/1.png",
+            request_id="test-request-id",
+            host_id=None,
+            response=None,
+            bucket_name="default-bucket",
+            object_name="test_collection/test.pdf/1.png",
+        )
+
+        with patch(
+            "nvidia_rag.rag_server.response_generator.get_object_store_operator_instance"
+        ) as mock_object_store_getter:
+            mock_object_store = Mock()
+            mock_object_store.get_object_from_uri.side_effect = s3_error
+            mock_object_store_getter.return_value = mock_object_store
+
+            with caplog.at_level(
+                "WARNING", logger="nvidia_rag.rag_server.response_generator"
+            ):
+                result = prepare_citations([mock_doc], enable_citations=True)
+
+        # Behavior preserved: missing object → content empty → citation dropped.
+        assert isinstance(result, Citations)
+        assert result.total_results == 0
+
+        # Log discipline: the handler must emit exactly one WARNING for this code
+        # path, and must NOT emit any ERROR-level record.
+        records = [
+            r
+            for r in caplog.records
+            if r.name == "nvidia_rag.rag_server.response_generator"
+        ]
+        warnings = [r for r in records if r.levelname == "WARNING"]
+        errors = [r for r in records if r.levelname == "ERROR"]
+
+        assert errors == [], (
+            "Missing-object S3Error must NOT be logged at ERROR level: "
+            f"got {[r.getMessage() for r in errors]}"
+        )
+        assert len(warnings) == 1, (
+            "Expected exactly one WARNING-level log for the missing object, "
+            f"got {len(warnings)}: {[r.getMessage() for r in warnings]}"
+        )
+        assert missing_code in warnings[0].getMessage()
+        # Per logger.warning() contract — no exception info should be attached
+        # to the record, so there's no traceback rendered for the expected case.
+        assert warnings[0].exc_info is None
+
+    def test_prepare_citations_object_store_other_s3_error_still_logged_as_error(
+        self, caplog
+    ):
+        """Regression guard for NVBug 6191270 fix — non-missing-object S3Error subclasses
+        (e.g. AccessDenied, InternalError) MUST continue to log at ERROR with traceback
+        so real backend problems are not silently downgraded."""
+        mock_doc = Mock()
+        mock_doc.page_content = "Test content"
+        mock_doc.metadata = {
+            "source": {
+                "source_id": "test.pdf",
+                "source_location": "s3://default-bucket/test_collection/test.pdf/1.png",
+            },
+            "content_metadata": {
+                "type": "image",
+                "subtype": "image",
+                "page_number": 1,
+                "location": [],
+            },
+            "collection_name": "test_collection",
+        }
+
+        s3_error = S3Error(
+            code="AccessDenied",
+            message="Access denied.",
+            resource="/default-bucket/test_collection/test.pdf/1.png",
+            request_id="test-request-id",
+            host_id=None,
+            response=None,
+            bucket_name="default-bucket",
+            object_name="test_collection/test.pdf/1.png",
+        )
+
+        with patch(
+            "nvidia_rag.rag_server.response_generator.get_object_store_operator_instance"
+        ) as mock_object_store_getter:
+            mock_object_store = Mock()
+            mock_object_store.get_object_from_uri.side_effect = s3_error
+            mock_object_store_getter.return_value = mock_object_store
+
+            with caplog.at_level(
+                "ERROR", logger="nvidia_rag.rag_server.response_generator"
+            ):
+                result = prepare_citations([mock_doc], enable_citations=True)
+
+        assert isinstance(result, Citations)
+        assert result.total_results == 0
+
+        errors = [
+            r
+            for r in caplog.records
+            if r.name == "nvidia_rag.rag_server.response_generator"
+            and r.levelname == "ERROR"
+        ]
+        assert len(errors) == 1, (
+            "Unexpected S3Error (AccessDenied) MUST still log at ERROR. Got "
+            f"{[r.getMessage() for r in errors]}"
+        )
+        # logger.exception() must attach exc_info so operators see the
+        # traceback for real backend problems — this is the contract the
+        # WARNING path explicitly does NOT honor for missing-object errors.
+        assert errors[0].exc_info is not None, (
+            "logger.exception() must attach exc_info for non-missing S3Errors"
+        )
+
+    @pytest.mark.parametrize("missing_code", ["NoSuchKey", "NoSuchBucket"])
+    def test_prepare_citations_nrl_object_store_missing_object_logged_as_warning(
+        self, missing_code, caplog
+    ):
+        """Regression for NVBug 6191270 (NRL/LanceDB code path) — the same
+        missing-object S3 condition must be demoted from ERROR+traceback to a
+        single WARNING in the NRL citation builder, mirroring prepare_citations.
+        Both code paths fetch from object storage via the same operator and
+        therefore share the same QA expectation: "answer should come without
+        any s3 error in rag-server logs"."""
+        mock_doc = Mock()
+        mock_doc.page_content = "Test NRL chart content"
+        mock_doc.metadata = {
+            "stored_image_uri": (
+                "s3://default-bucket/nrl_collection/test.pdf/page-3.png"
+            ),
+            "content_type": "chart",
+            "filename": "test.pdf",
+            "page_number": 3,
+            "metadata": {"has_text": False},
+        }
+
+        s3_error = S3Error(
+            code=missing_code,
+            message="The specified key does not exist.",
+            resource="/default-bucket/nrl_collection/test.pdf/page-3.png",
+            request_id="test-nrl-request-id",
+            host_id=None,
+            response=None,
+            bucket_name="default-bucket",
+            object_name="nrl_collection/test.pdf/page-3.png",
+        )
+
+        with patch(
+            "nvidia_rag.rag_server.response_generator.get_object_store_operator_instance"
+        ) as mock_object_store_getter:
+            mock_object_store = Mock()
+            mock_object_store.get_object_from_uri.side_effect = s3_error
+            mock_object_store_getter.return_value = mock_object_store
+
+            with caplog.at_level(
+                "WARNING", logger="nvidia_rag.rag_server.response_generator"
+            ):
+                result = prepare_citations_nrl([mock_doc], enable_citations=True)
+
+        # Behavior preserved: missing object → empty content → citation dropped
+        # by the `if not content: continue` guard.
+        assert isinstance(result, Citations)
+        assert result.total_results == 0
+
+        records = [
+            r
+            for r in caplog.records
+            if r.name == "nvidia_rag.rag_server.response_generator"
+        ]
+        warnings = [r for r in records if r.levelname == "WARNING"]
+        errors = [r for r in records if r.levelname == "ERROR"]
+
+        assert errors == [], (
+            "NRL citation builder must NOT emit ERROR for missing objects: "
+            f"got {[r.getMessage() for r in errors]}"
+        )
+        assert len(warnings) == 1, (
+            f"Expected exactly one WARNING, got {len(warnings)}: "
+            f"{[r.getMessage() for r in warnings]}"
+        )
+        assert missing_code in warnings[0].getMessage()
+        assert warnings[0].exc_info is None
 
 
 class TestRetrieveSummaryEdgeCases:


### PR DESCRIPTION
Auto-generated by **agentic-bugfix** for NVBug `6191270`.

- Source branch: `bugfix/nvbug-6191270-20260527-072746`
- Target branch: `develop`
- Bug ID: `6191270`
- Commit author: `agentic-bug-fix`

<details><summary><strong>Full agent report</strong></summary>

# Bug Fix Report — NVBug #6191270 — Intermittent "s3 operation failed" in generation pipeline

- **Report generated:** 2026-05-27T10:11:16Z
- **Bug source:** NVBugs #6191270 (cloned from #6190418)
- **Reporter / requester:** Atharva Kulkarni (atkulkarni@nvidia.com); Assigned: Sumit Bhattacharya
- **Repository:** NVIDIA-AI-Blueprints/rag @ `2562d20c291c745fe7f26cedcccc3a9a4a05b0a5`
- **Branch:** `bugfix/nvbug-6191270-20260527-072746` (tracks `origin/develop`)
- **Fix status:** ✅ Verified (E2E + unit + lint all pass)

## 1. Reported Symptom

> [RAG BP][v2.6.0][RC1] Intermittent error of "s3 operation failed" is observed in generation pipeline
>
> Observations:
> 1. Observed below error in rag-server logs when it tries to **fetch table/chart/image from citations**.
>
> ```
> ERROR:nvidia_rag.rag_server.response_generator:Error pulling content from object storage for image/table/chart for citations: S3 operation failed; code: NoSuchKey, message: The specified key does not exist., resource: /default-bucket/agentic_rag/Global_Multimodal_data.pptx/43.png, request_id: 1778765356442227242, host_id: None, bucket_name: default-bucket, object_name: agentic_rag/Global_Multimodal_data.pptx/43.png
> Traceback (most recent call last):
>   File "/workspace/.venv/lib/python3.13/site-packages/nvidia_rag/rag_server/response_generator.py", line 925, in prepare_citations
>     raw_content = get_object_store_operator_instance().get_object_from_uri(source_location)
>   File "/workspace/.venv/lib/python3.13/site-packages/nvidia_rag/utils/object_store.py", line 110, in get_object_from_uri
>     response = self.client.get_object(bucket_name, object_name)
>   File "/workspace/.venv/lib/python3.13/site-packages/minio/api.py", line 1257, in get_object ...
>   File "/workspace/.venv/lib/python3.13/site-packages/minio/api.py", line 427, in _url_open
>     raise response_error
> minio.error.S3Error: S3 operation failed; code: NoSuchKey, ...
> ```
>
> *Issue is intermittent — observed only once.*
>
> Comment #2 (Atharva Kulkarni): Issue observed again. Probable repro steps:
> 1. Deploy RAG using helm
> 2. Create collection and ingest some documents
> 3. Ask queries, **answer should come without any s3 error in rag-server logs**
> 4. Uninstall RAG helm chart, **without deleting pvcs**
> 5. Reinstall RAG helm chart and ask queries by selecting the same collection which was created earlier

QA's expectation is explicit: queries should still produce an answer, AND no S3 ERROR should appear in rag-server logs.

## 1.5 Custom Instructions

**Source:** inline

**Content:**
```
HEADLESS RUN: when you need a human decision, input, or approval, you MUST call mcp__bugfix-events__request_human_input with a clear `prompt` and `context`, and then poll mcp__bugfix-events__poll_human_input until a reply arrives. Do NOT use AskUserQuestion — it has no responder in this environment and silently returns empty, which causes Track A reproduction to be skipped and forces an unintended Track B (Recommendation-Only) fallback. Apply this rule at every Gap Analysis decision point and before falling back to Track B. Use NVIDIA-Hosted (Cloud) docker deployment and for deploy skills check the skill-source folder for skills path
```

**How honored:**
- Polled `mcp__bugfix-events__poll_human_input` at start (no pending input, expected).
- No `AskUserQuestion` was used at any point. Reproduction Attempt 1 succeeded, so no Gap Analysis prompt was needed.
- Deployment: NVIDIA-Hosted Cloud Docker (`deploy/compose/nvdev.env`, `docker-compose-rag-server.yaml`; cloud NIM endpoints at `https://integrate.api.nvidia.com/v1`).
- Skills path: `skill-source/.agents/skills/rag-blueprint/references/deploy/docker-nvidia-hosted.md` (per `--skills-path skill-source/.agents/skills`).

## 2. Reproduction & Observed Failure Signal

**Trigger used (docker NVIDIA-Hosted, in-cluster simulation of the helm uninstall + retain-PVC scenario):**

1. Pre-existing collection `repro_6191270` in elasticsearch (8 entities: 3 text, 2 table, 3 chart from `multimodal_test.pdf`) with 5 image PNGs in seaweedfs S3 at `s3://default-bucket/repro_6191270/multimodal_test.pdf/{3,4,5,6,7}.png`.
2. Delete one image key (`6.png`) directly via the MinIO Python client — this exactly simulates the runtime state QA describes (vector store retains a citation reference; backing S3 object is gone after a helm reinstall):
   ```python
   from minio import Minio
   c = Minio('seaweedfs:9010', access_key=..., secret_key=..., secure=False)
   c.remove_object('default-bucket', 'repro_6191270/multimodal_test.pdf/6.png')
   ```
3. Send a `/v1/generate` query against the collection with `enable_citations: true`:
   ```bash
   curl -X POST http://localhost:8081/v1/generate -H 'Content-Type: application/json' -d '{
     "messages":[{"role":"user","content":"Tell me about chart 1 and chart 2 in the test document."}],
     "use_knowledge_base": true,
     "collection_names": ["repro_6191270"],
     "enable_citations": true, "stream": false, "max_tokens": 256, "temperature": 0.0, "top_p": 1
   }'
   ```

**Environment:**
- docker compose stack: rag-server, ingestor-server, rag-frontend, elasticsearch, seaweedfs, nv-ingest-ms-runtime, redis
- rag-server image: `nvcr.io/nvstaging/blueprint/rag-server:2.6.0` (rebuilt against this worktree's source)
- Cloud NIMs: `nvidia/nemotron-3-super-120b-a12b` (LLM), `nvidia/llama-nemotron-embed-vl-1b-v2` (embed), `nvidia/llama-nemotron-rerank-1b-v2` (rerank), all via `https://integrate.api.nvidia.com/v1`
- Object storage: SeaweedFS (S3-compatible), single bucket `default-bucket`
- GPU: 1× NVIDIA RTX PRO 6000 Blackwell Workstation Edition (97 887 MiB) — incidental to this bug
- Setup fix during Track 1A: container `NVIDIA_API_KEY` was stale (403 Forbidden). Restarted rag-server with the working shell key sourced from `nvdev.env`.

**NVBug content retrieved (Track 1C):**
- Description + comments: yes (via `scripts/maas/nvbugs_mcp.py get-bug-details --bug-id 6191270 --include-attachments`)
- Attachments fetched: none (MCP exposes metadata only; user did not paste contents because the inline stack trace in the description was sufficient to reproduce and locate the defect)
- Attachments skipped: `rag-server-error-logs.txt` (20 006 B), `ingestor-server-s3-logs.txt` (94 838 B), `nv-ingest-s3-logs.txt` (1 096 B), `rag-server-s3-logs.txt` (1 052 324 B) — recorded as evidence gaps but not blocking, because the canonical stack trace embedded in the description matched the live reproduction line-for-line.

**Failure signal (verbatim from live rag-server logs, Attempt 1):**

```
ERROR:nvidia_rag.rag_server.response_generator:Error pulling content from object storage for image/table/chart for citations: S3 operation failed; code: NoSuchKey, message: The specified key does not exist., resource: /default-bucket/repro_6191270/multimodal_test.pdf/6.png, request_id: 1779875705707566892, host_id: None, bucket_name: default-bucket, object_name: repro_6191270/multimodal_test.pdf/6.png
Traceback (most recent call last):
  File "/workspace/.venv/lib/python3.13/site-packages/nvidia_rag/rag_server/response_generator.py", line 977, in prepare_citations
    raw_content = get_object_store_operator_instance().get_object_from_uri(
  File "/workspace/.venv/lib/python3.13/site-packages/nvidia_rag/utils/object_store.py", line 110, in get_object_from_uri
    raise response_error
minio.error.S3Error: S3 operation failed; code: NoSuchKey, ...
```

The HTTP request itself succeeded — the LLM generated a 382-character answer about the charts. The defect is **log noise**: the missing-object case is logged at ERROR with a full traceback, even though `prepare_citations` already silently handles it and lets the response proceed.

**Layer:** app (rag-server response generator).
**Why this is the root signal (not a downstream re-raise):** the message + traceback originate inside the `prepare_citations` exception handler itself; no upstream caller re-raised. The `logger.exception(...)` is the only ERROR-level emission for this code path. Line drift between the reported v2.6.0.rc1 (line 925) and the current source (line 977) is normal — the call chain is identical.

## 3. Root Cause

`prepare_citations()` (and `prepare_citations_nrl()`) in `src/nvidia_rag/rag_server/response_generator.py` wrap the S3 fetch `get_object_store_operator_instance().get_object_from_uri(source_location)` in `except Exception as e: logger.exception(...)`. `logger.exception` always emits at ERROR with the active traceback. Behaviorally the code already does the right thing — it sets `content = ""`, which the downstream `if content and document_type in [...]` guard uses to drop the citation from the response — but every missing-object event surfaces as an ERROR-with-traceback in rag-server logs. QA's expected behavior is explicit: "answer should come without any s3 error in rag-server logs."

The state that triggers the error (vector-store row referencing an S3 key that does not exist in object storage) arises naturally whenever the vector store's persistence outlives the object store's: helm uninstall without `--delete-pvc` retains Elasticsearch / Milvus persistence but does not always retain the seaweedfs / MinIO bucket. The same shape applies to any environment-cleanup operation that touches the object store but not the vector store, or vice versa.

**Call chain:**
```
POST /v1/generate
  → nvidia_rag.rag_server.main.generate(...)
    → nvidia_rag.rag_server.response_generator.prepare_citations(retrieved_documents, enable_citations=True)
        → for each chart/image/table doc:
            → get_object_store_operator_instance().get_object_from_uri(s3://default-bucket/<col>/<file>/<page>.png)
              → S3ObjectStoreOperator.get_object_from_uri (utils/object_store.py:99)
                → minio.Minio.get_object (api.py:1257)
                  → _url_open raises minio.error.S3Error(code="NoSuchKey")
            ← caught by `except Exception as e` at response_generator.py:995
              → logger.exception(...) emits ERROR + traceback   ← the bug
              → content = ""; SourceMetadata(...) built
        ← citation dropped by `if content and document_type in [...]` guard at line 1037
  → LLM response returned to client (succeeds)
```

The same chain applies to `prepare_citations_nrl()` (LanceDB / NRL variant) at line ~1167, which has a structurally identical `except Exception as exc: logger.exception(...)` block over the same `get_object_from_uri` call. Track A reproduction did not exercise the NRL path (collection used nv-ingest / Elasticsearch, not LanceDB), but R5 in Phase 6 cycle 1 correctly flagged it as in-scope for the bug's expectation: the QA's wording targets the symptom, not the implementation variant.

**Contributing factors:**
- Uncommitted local changes: none at the start of the run (`git diff HEAD` was clean, verified by Phase 2 investigator).
- Secondary bugs producing the same symptom: none. Other `get_object_from_uri` callers in `src/nvidia_rag/rag_server/vlm.py` (lines 403–424, 447–464) use `except Exception: continue` — they swallow silently and emit no log at all, so they are not subject to this bug's symptom.

## 4. Fix Applied

**Files changed:**
| File | Lines | Change |
|---|---|---|
| `src/nvidia_rag/rag_server/response_generator.py` | +40 −0 (import + `prepare_citations`) | Added `from minio.error import S3Error`. Inserted a specialized `except S3Error as e` branch before the existing `except Exception`. When `e.code` is `"NoSuchKey"` or `"NoSuchBucket"`, log a single concise WARNING (no traceback). Any other S3 code falls through to `logger.exception(...)` ERROR + traceback, preserving the original observability for real backend faults. Behavior unchanged: `content = ""` and `SourceMetadata(...)` built identically. |
| `src/nvidia_rag/rag_server/response_generator.py` | +25 (`prepare_citations_nrl`) | Same S3Error split applied to the NRL/LanceDB citation builder, around line 1164. Mirrors `prepare_citations` to keep the contract symmetric. |
| `tests/unit/test_rag_server/test_response_generator.py` | +214 / −0 net new tests | Added `from minio.error import S3Error` and `prepare_citations_nrl` to imports. Added parametrized `test_prepare_citations_object_store_missing_object_logged_as_warning` (NoSuchKey, NoSuchBucket) and `test_prepare_citations_nrl_object_store_missing_object_logged_as_warning` (NoSuchKey, NoSuchBucket), each asserting: `result.total_results == 0`, exactly one WARNING record (filtered by logger name), zero ERROR records, the missing code substring is in the WARNING message, and `warnings[0].exc_info is None`. Added `test_prepare_citations_object_store_other_s3_error_still_logged_as_error` (AccessDenied) asserting one ERROR record with `errors[0].exc_info is not None` — guards against silently downgrading real backend faults. Also a single `ruff format` rewrap at line 856 produced by the project's own pre-commit policy (see §6.5). |

**Diff:**
```diff
diff --git a/src/nvidia_rag/rag_server/response_generator.py b/src/nvidia_rag/rag_server/response_generator.py
index 91b6e79..b7eecbe 100644
--- a/src/nvidia_rag/rag_server/response_generator.py
+++ b/src/nvidia_rag/rag_server/response_generator.py
@@ -37,6 +37,7 @@ from uuid import uuid4

 import bleach
 from langchain_core.documents import Document
+from minio.error import S3Error
 from pydantic import BaseModel, Field, validator
 from pymilvus.exceptions import MilvusException, MilvusUnavailableException

@@ -992,6 +993,35 @@ def prepare_citations(
                             description=doc.page_content,
                             content_metadata=doc.metadata.get("content_metadata"),
                         )
+                except S3Error as e:
+                    # Missing-object errors are an expected condition when the
+                    # vector store retains a citation reference whose backing
+                    # object has been removed from object storage (e.g. after a
+                    # helm uninstall that retained the vector-store PVC but
+                    # cleared the object-store bucket). The request itself is
+                    # not failing — the citation is gracefully skipped by the
+                    # downstream `if content and document_type in [...]` filter
+                    # — so log at WARNING without a traceback to avoid polluting
+                    # rag-server logs with spurious ERROR-level noise.
+                    if e.code in ("NoSuchKey", "NoSuchBucket"):
+                        logger.warning(
+                            "Skipping citation: object missing in object storage "
+                            "(code=%s, resource=%s). The citation will be omitted "
+                            "from the response.",
+                            e.code,
+                            getattr(e, "resource", "<unknown>"),
+                        )
+                    else:
+                        logger.exception(
+                            "Error pulling content from object storage for "
+                            "image/table/chart for citations: %s",
+                            e,
+                        )
+                    content = ""
+                    source_metadata = SourceMetadata(
+                        description=doc.page_content,
+                        content_metadata=doc.metadata.get("content_metadata", {}),
+                    )
                 except Exception as e:
                     logger.exception(
                         f"Error pulling content from object storage for image/table/chart for citations: {e}"
@@ -1134,6 +1164,31 @@ def prepare_citations_nrl(
                         )
                     )
                     content = base64.b64encode(raw_bytes).decode("ascii")
+                except S3Error as exc:
+                    # Mirror the prepare_citations() behavior: missing-object
+                    # errors are an expected condition (vector store retains a
+                    # citation reference whose backing object has been removed
+                    # from object storage). Log at WARNING without a traceback
+                    # so rag-server logs stay clean; downstream guard drops the
+                    # citation via the empty-content check. Other S3Error codes
+                    # still surface at ERROR level so real backend problems are
+                    # not silently downgraded. (NVBug 6191270.)
+                    if exc.code in ("NoSuchKey", "NoSuchBucket"):
+                        logger.warning(
+                            "[Prepare Citations NRL] Skipping citation: object"
+                            " missing in object storage (code=%s, uri=%s)."
+                            " The citation will be omitted from the response.",
+                            exc.code,
+                            stored_image_uri,
+                        )
+                    else:
+                        logger.exception(
+                            "[Prepare Citations NRL] Failed to fetch asset"
+                            " from object storage (uri=%s): %s",
+                            stored_image_uri,
+                            exc,
+                        )
+                    content = ""
                 except Exception as exc:
                     logger.exception(
                         "[Prepare Citations NRL] Failed to fetch asset from object storage"
```

(Test additions follow the same shape and are listed in §5. Full diff at `git diff HEAD`.)

**Why this is minimal and safe:**
- No design change: catch-and-continue architecture is preserved verbatim. Data flow (`content = ""`, `SourceMetadata` with default `content_metadata={}`, downstream citation drop) is identical to pre-fix. Only the log level for the specific known-expected `NoSuchKey` / `NoSuchBucket` subset changes; all other S3 errors still hit `logger.exception(...)` at ERROR with traceback.
- No public API change. No schema change. No new dependency (`minio.error.S3Error` is already a transitive dependency of `minio`, which the codebase uses).
- Scope discipline: only the two functions named in the call chain and their test mirror are touched.

## 5. Tests

- **New / changed tests** in `tests/unit/test_rag_server/test_response_generator.py::TestPrepareCitationsErrorHandling`:
  - `test_prepare_citations_object_store_missing_object_logged_as_warning[NoSuchKey]` — asserts WARNING (not ERROR), `exc_info is None`, code in message, `total_results == 0`.
  - `test_prepare_citations_object_store_missing_object_logged_as_warning[NoSuchBucket]` — same.
  - `test_prepare_citations_object_store_other_s3_error_still_logged_as_error` — asserts ERROR + `exc_info is not None` for `AccessDenied` (regression guard against silent downgrade of real backend faults).
  - `test_prepare_citations_nrl_object_store_missing_object_logged_as_warning[NoSuchKey]` — NRL/LanceDB variant.
  - `test_prepare_citations_nrl_object_store_missing_object_logged_as_warning[NoSuchBucket]` — same.

- **Unit test run (project venv):** `python -m pytest tests/unit/test_rag_server/ tests/unit/test_utils/ --ignore=tests/unit/test_utils/test_vdb/test_elastic_vdb.py -q` → **1160 passed, 1 xfailed, 7 failed**. The 7 failures are pre-existing (same 7 fail at `git stash`-ed HEAD with no fix applied): 4 in `test_lancedb_vdb.py`, 3 in `test_vdb_init.py` related to elasticsearch test fixtures and unrelated to the citation code path. `test_elastic_vdb.py` was skipped because `elastic_transport` module is not installed in the worktree's local venv — pre-existing environment dependency gap, not introduced by the fix.

- **Lint:** `ruff check src/nvidia_rag/rag_server/response_generator.py tests/unit/test_rag_server/test_response_generator.py` → All checks passed. `ruff format --check` → All files already formatted.

## 6. Live E2E Validation

**Replay trigger:** identical to Phase 1 — delete `repro_6191270/multimodal_test.pdf/6.png` from seaweedfs, then send the same `/v1/generate` request with `enable_citations: true`.

**Observed result:**
- HTTP request succeeded, LLM returned a 446-character answer about Chart 1 and Chart 2.
- rag-server logs contained **no ERROR record and no Traceback** for the citation path.
- One **WARNING** record was emitted, exactly the format the fix produces.

**Evidence (verbatim, post-fix logs):**
```
INFO:nvidia_rag.rag_server.response_generator:[Prepare Citations] Length of retrieved documents: 8
WARNING:nvidia_rag.rag_server.response_generator:Skipping citation: object missing in object storage (code=NoSuchKey, resource=/default-bucket/repro_6191270/multimodal_test.pdf/6.png). The citation will be omitted from the response.
INFO:nvidia_rag.rag_server.response_generator:LLM GENERATION COMPLETE
INFO:nvidia_rag.rag_server.response_generator:Final LLM Response:
INFO:nvidia_rag.rag_server.response_generator:  - Length: 446 characters
INFO:nvidia_rag.rag_server.response_generator:  - Content Preview (first 500 chars): Chart 1 displays a list of gadgets (Hammer, Powerdrill, Bluetooth speaker, Minifridge, Premium desk fan) ...
```

Compare to the pre-fix Phase 1 capture: same trigger produced a `ERROR:nvidia_rag.rag_server.response_generator:Error pulling content...` line followed by a 6-line `Traceback (most recent call last): ... raise response_error / minio.error.S3Error: ...`. The fix removes that line and the traceback in favor of one WARNING line. Sanity-checked clean baseline (all 5 PNGs present): no WARNING is emitted at all — confirms the WARNING is only produced for the known-expected condition and is not noise.

## 6.5 Expert Review

**Aggregated verdict:** approve (cycle 2)
**Cycles used:** 2 of 3

| # | Reviewer | Verdict | Findings |
|---|---|---|---|
| R1 | Root-cause linkage | approve (c1 minor → c2 suggestion) | c1: noted `prepare_citations_nrl` had same pattern (addressed in c2). c2: confirmed `vlm.py` callers swallow silently and are not in scope. |
| R2 | Coding conventions | approve | All conventions followed: %-style logging args (matches project convention), import order, comment style, double quotes, type hints. Pre-existing f-string in original `logger.exception` flagged as nit-level project tech-debt, not introduced here. |
| R3 | Generic code quality | approve | All findings nit / suggestion. Defensive `getattr(e, "resource", "<unknown>")` retained. `e.code is None` falls through to `logger.exception` safely. Pre-existing inconsistency in `.get("content_metadata", {})` vs `.get("content_metadata")` is unchanged. |
| R4 | Scope discipline | approve (c1 blocker → c2 nit) | c1: flagged a `ruff format` rewrap at test_response_generator.py:856. c2: re-evaluated with full context — the rewrap is enforced by the project's own pre-commit policy (CLAUDE.md "Run `pre-commit run --all-files` before submitting" — `ruff format` is in `.pre-commit-config.yaml`). Reverting causes `ruff format --check` to fail. Re-classified as in-scope project-policy compliance. |
| R5 | Test adequacy | approve (c1 blocker + 2 majors → c2 approved) | c1 blocker (`prepare_citations_nrl` not covered) addressed in c2 by extending the fix and adding a parametrized NRL regression test. c1 major (missing `exc_info is not None` for AccessDenied) addressed by strengthening the test. c1 major (content_metadata preservation) deemed structurally satisfied by the source-code default `{}` — output-level assertion would be vacuous because the citation is dropped. |
| R7 | Custom instructions compliance | approve | Diff is deployment-agnostic; touches no skill files; no AskUserQuestion usage anywhere; cloud NIM endpoints honored. |

**Non-blocking notes:**
- `src/nvidia_rag/rag_server/response_generator.py:1032` (the original `except Exception` clause, untouched) still uses f-string-style logging (`f"...{e}"`) where the surrounding codebase prefers `%`-style positional args. Pre-existing tech debt; out of scope.
- `src/nvidia_rag/rag_server/response_generator.py:1023` uses `doc.metadata.get("content_metadata", {})` (default `{}`) while the success path uses `.get("content_metadata")` (default `None`). Pre-existing; the new S3Error branch mirrors the existing inconsistency exactly — intentional, to preserve behavior verbatim.
- `_OBJECT_STORE_MISSING_CODES` constant: the literal tuple `("NoSuchKey", "NoSuchBucket")` could be a module-level constant if more sites need to handle the same set later. Single-use today, so left inline.

## 7. Attempt Timeline

| # | Phase | Action | Outcome |
|---|---|---|---|
| 1 | Setup | Verified docker NVIDIA-Hosted stack already healthy; refreshed stale `NVIDIA_API_KEY` in rag-server container by `docker compose up -d --force-recreate rag-server` after sourcing `nvdev.env`. | rag-server, ingestor, ES, seaweedfs, nv-ingest, redis all healthy. |
| 2 | Reproduce (Attempt 1) | Delete `repro_6191270/multimodal_test.pdf/6.png` from seaweedfs → POST `/v1/generate` against `repro_6191270` collection with `enable_citations: true`. | **Reproduced.** Verbatim ERROR + traceback match the NVBug. LLM response still returned (382 chars). Track A confirmed. |
| 3 | Phase 2 Analyze | Three parallel investigators: error-string grep (Explore), git state (general-purpose), existing tests (Explore). Synthesized call chain in orchestrator. | Defect localized to `prepare_citations` `except Exception` + `logger.exception` at line ~995. Working tree clean. Existing test `test_prepare_citations_object_store_exception` covers generic exception path but not specifically NoSuchKey log discipline. |
| 4 | Phase 3 Plan Fix | Classified as patch to existing exception handler — no design change. Plan: narrow handler with `except S3Error` for NoSuchKey/NoSuchBucket → WARNING; preserve generic catch-all. | Approved by guardrail; no human input required. |
| 5 | Phase 4 Fix (cycle 1) | Edit response_generator.py + add 3 new tests. Rebuild + force-recreate rag-server (`needs_rebuild=true` per Track 1B). | Build clean, container healthy. |
| 6 | Phase 5 Validate (cycle 1) | E2E replay → WARNING only, no ERROR, response 446 chars. Unit tests: 1158 passed (1155 baseline + 3 new). Lint: clean (one ruff-format rewrap auto-applied). | Validation green. |
| 7 | Phase 6 Review (cycle 1) | R1, R2, R3, R7 approve. R4 blocker on line-856 rewrap. R5 blocker (`prepare_citations_nrl` not fixed) + 2 majors (exc_info assertion, content_metadata preservation). | Re-enter Phase 3. |
| 8 | Phase 3-5 (cycle 2) | Extended fix to `prepare_citations_nrl`; added 2 parametrized NRL tests; strengthened AccessDenied test with `exc_info is not None`; resolved line-856 hunk as project-policy ruff-format. Rebuild + redeploy. | Unit tests 1160 passed; E2E re-validated; lint clean. |
| 9 | Phase 6 Review (cycle 2) | Consolidated cycle-2 reviewer: approve. R4 nit (line-856 is project-policy enforcement). R1 suggestion (vlm.py callers already swallow silently — out of scope). R5 minor (acknowledged). | Proceed to Phase 7. |

## 8. Incidental Findings

1. **Stale `NVIDIA_API_KEY` in the rag-server container at Phase 1 setup.** The orchestrator's shell key was valid; the container's was 403 Forbidden. Likely a previous run mounted a different key, then the host key rotated. Resolved during setup by `docker compose up -d --force-recreate rag-server` after sourcing `deploy/compose/nvdev.env`. Not a bug in the code under test.

2. **Pre-existing test-environment dep gaps** (unrelated to fix): `elastic_transport` is not installed in the worktree's auto-created venv, so `tests/unit/test_utils/test_vdb/test_elastic_vdb.py` fails to import (collection error). Additionally 7 tests in `test_lancedb_vdb.py` / `test_vdb_init.py` fail at HEAD with the same setup. Reproducible by stashing all changes — these are not introduced by this fix.

3. **`prepare_citations_nrl` warning message format differs from `prepare_citations`.** The NRL variant uses `[Prepare Citations NRL]` prefix and `uri=...` instead of `resource=...`. This mirrors the existing per-function log style (NRL functions already use a `[Prepare Citations NRL]` prefix in their other log lines), so consistency-within-function is preserved at the cost of consistency-across-functions. Acceptable.

4. **f-string vs %-style logger args (`response_generator.py:1032`).** The pre-existing generic `except Exception` clause still uses f-string interpolation in `logger.exception(...)`. The rest of the file's loggers use `%`-style positional args. Pre-existing tech debt — out of scope for this NVBug.

## 9. Follow-ups for the Human

- [ ] Review the diff and `git commit` when satisfied (the skill does not commit per instruction).
- [ ] Set NVBug #6191270 `BugAction` and `Disposition` — intentionally left untouched (the skill never modifies these).
- [ ] Verify the helm-actual repro (uninstall → reinstall same collection) against a Kubernetes cluster when next available, to confirm the symptom is fully eliminated in the original environment shape. The local docker repro is functionally equivalent (same code path, same exception), but the helm-specific PVC retention behavior is environment-dependent.
- [ ] Consider a follow-up PR to migrate the literal tuple `("NoSuchKey", "NoSuchBucket")` to a module constant `_OBJECT_STORE_MISSING_CODES` if more call sites need the same handling (e.g., ingestor-server retrieval paths). Not blocking.

## 10. NVBugs Audit Trail

- **NVBug ID:** 6191270
- **Comment posted:** **no** — `--no-nvbugs-update` flag was supplied at invocation time. The skill recorded this and did not call `nvbugs_mcp.py update-bug`.
- **BugAction / Disposition:** **left unchanged — human to set** (and would have been left unchanged even if a comment had been posted; the skill's contract reserves BugAction/Disposition for the human triager).

</details>
