### PR TITLE
Reduce Otel batch size

### DIFF
--- a/src/nvidia_rag/utils/observability/tracing/instrumentation.py
+++ b/src/nvidia_rag/utils/observability/tracing/instrumentation.py
@@ -285,7 +285,11 @@ def instrument(app: FastAPI, settings, service_name: str = "rag"):
                 exporter_http, skip_predicates=span_filters
             )
 
-        span_processor = BatchSpanProcessor(exporter_http)
+        span_processor = BatchSpanProcessor(
+            exporter_http,
+            max_export_batch_size=32,
+            max_queue_size=512
+        )
         trace.get_tracer_provider().add_span_processor(
             BaggageSpanProcessor(ALLOW_ALL_BAGGAGE_KEYS)
         )


### PR DESCRIPTION
## Description
Fixes PagerDuty incident [Q190AOYPIHSZ8D](https://nvidia.pagerduty.com/incidents/Q190AOYPIHSZ8D) — `ERROR:opentelemetry.exporter.otlp.proto.http.trace_exporter:Failed to export span batch code: 400, reason: http: request body too large`

### Root Cause

The `BatchSpanProcessor` in `src/nvidia_rag/utils/observability/tracing/instrumentation.py` (line 288) was instantiated with the **default** `max_export_batch_size=512`. When the RAG pipeline processes large documents (e.g., multi-page NVIDIA earnings transcripts), each trace span carries substantial payload in attributes. Batching up to 512 such spans produces an OTLP HTTP request body that exceeds the OpenTelemetry collector's HTTP receiver body size limit (\~4MB default), resulting in HTTP 400 rejections and trace data loss.

### Fix

- **Reduce `max_export_batch_size`** from 512 (default) → **32** to keep individual export payloads well within the OTLP receiver's body size limit.
- **Set `max_queue_size`** to **512** (down from default 2048) to bound in-memory span queue and prevent excessive memory usage during export backpressure.

### Impact

- **Before**: All trace spans from the `rag` namespace on `nim-bp-k8s-oci-lhr-prd3` are dropped (HTTP 400), causing 10+ open PagerDuty incidents on service PEQTOY9.
- **After**: Trace batches will be \~16× smaller, fitting within the OTLP receiver's body limit. Trace data will be exported successfully.
- **No user-facing impact** — the RAG API serves requests normally; this fix restores observability trace export only.

### Files Changed

| File | Change |
|------|--------|
| `src/nvidia_rag/utils/observability/tracing/instrumentation.py` | Reduce `BatchSpanProcessor` batch size from default 512 → 32, queue size 2048 → 512 |


## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.