### PR TITLE
Helm MIG (H100): promote embedding-VLM to a full GPU

### DIFF
--- a/deploy/helm/mig-slicing/mig-config-h100.yaml
+++ b/deploy/helm/mig-slicing/mig-config-h100.yaml
@@ -14,17 +14,17 @@ data:
       # GPUs 0,1 are MIG-disabled and pass through as full devices so that
       # nim-llm (nemotron-3-super-120b-a12b, vLLM + tensorParallelism=2) gets
       # two physical GPUs with full NVLink for NCCL collectives.
-      # GPUs 2,3 are MIG-sliced for the smaller ingest / embedding / rerank NIMs.
-      custom-h100-llm2full-1x3g40-4x1g10-1x3g40-2x1g20:
+      # GPU 3 is MIG-disabled and dedicated to the embedding-VLM NIM, which
+      # benefits from a full H100 for higher throughput on the vision tower.
+      # GPU 2 is MIG-sliced for OCR + the small ingest NIMs + rerank.
+      custom-h100-llm2full-embed1full-1x2g20-3x1g10-1x1g20:
         - devices: [0, 1]
           mig-enabled: false
         - devices: [2]
           mig-enabled: true
           mig-devices:
-            "3g.40gb": 1
-            "1g.10gb": 4
+            "2g.20gb": 1
+            "1g.10gb": 3
+            "1g.20gb": 1
         - devices: [3]
-          mig-enabled: true
-          mig-devices:
-            "3g.40gb": 1
-            "1g.20gb": 2
+          mig-enabled: false

--- a/deploy/helm/mig-slicing/mig-config-h100.yaml
+++ b/deploy/helm/mig-slicing/mig-config-h100.yaml
@@ -10,21 +10,27 @@ data:
         - devices: all
           mig-enabled: false
 
-      # RAG MIG layout for a 4×H100 80GB node.
+      # RAG MIG layout for a 5×H100 80GB node.
       # GPUs 0,1 are MIG-disabled and pass through as full devices so that
       # nim-llm (nemotron-3-super-120b-a12b, vLLM + tensorParallelism=2) gets
       # two physical GPUs with full NVLink for NCCL collectives.
       # GPU 3 is MIG-disabled and dedicated to the embedding-VLM NIM, which
       # benefits from a full H100 for higher throughput on the vision tower.
-      # GPU 2 is MIG-sliced for OCR + the small ingest NIMs + rerank.
-      custom-h100-llm2full-embed1full-1x2g20-3x1g10-1x1g20:
+      # GPU 2 is MIG-sliced for OCR + the small ingest NIMs.
+      # GPU 4 is MIG-sliced for the reranker (with spare slices reserved
+      # for future workloads).
+      custom-h100-5gpu-llm2full-embed1full:
         - devices: [0, 1]
           mig-enabled: false
         - devices: [2]
           mig-enabled: true
           mig-devices:
-            "2g.20gb": 1
-            "1g.10gb": 3
-            "1g.20gb": 1
+            "3g.40gb": 1
+            "1g.10gb": 4
         - devices: [3]
           mig-enabled: false
+        - devices: [4]
+          mig-enabled: true
+          mig-devices:
+            "3g.40gb": 1
+            "1g.20gb": 2

--- a/deploy/helm/mig-slicing/values-mig-h100.yaml
+++ b/deploy/helm/mig-slicing/values-mig-h100.yaml
@@ -1,10 +1,10 @@
 # MIG-optimized resource configuration for RAG Blueprint on NVIDIA H100 80GB.
-# Pairs with mig-config-h100.yaml (profile: custom-h100-llm2full-1x3g40-4x1g10-1x3g40-2x1g20).
+# Pairs with mig-config-h100.yaml (profile: custom-h100-llm2full-embed1full-1x2g20-3x1g10-1x1g20).
 #
 # GPU layout (4×H100 node):
-#   GPU 0,1 — MIG disabled, full devices  → nim-llm (nemotron-3-super-120b-a12b, vLLM tp=2)
-#   GPU 2   — 1× 3g.40gb + 4× 1g.10gb     → OCR + (graphic, page, table, spare)
-#   GPU 3   — 1× 3g.40gb + 2× 1g.20gb     → embedding-VLM + (rerank, spare)
+#   GPU 0,1 — MIG disabled, full devices            → nim-llm (nemotron-3-super-120b-a12b, vLLM tp=2)
+#   GPU 2   — 1× 2g.20gb + 3× 1g.10gb + 1× 1g.20gb  → OCR + (graphic, page, table) + rerank
+#   GPU 3   — MIG disabled, full device             → embedding-VLM
 #
 # Requires GPU Operator mig-strategy=mixed so the node advertises both
 # nvidia.com/gpu and nvidia.com/mig-* resources simultaneously.
@@ -23,15 +23,15 @@ nv-ingest:
 
   # NV-Ingest NIM Operator overrides
   nimOperator:
-    # OCR — uses 3g.40gb on GPU 2
+    # OCR — uses 2g.20gb on GPU 2
     ocr:
       resources:
         limits:
           nvidia.com/gpu: "0"
-          nvidia.com/mig-3g.40gb: 1
+          nvidia.com/mig-2g.20gb: 1
         requests:
           nvidia.com/gpu: "0"
-          nvidia.com/mig-3g.40gb: 1
+          nvidia.com/mig-2g.20gb: 1
       storage:
         pvc:
           storageClass: ""
@@ -90,21 +90,20 @@ nimOperator:
       pvc:
         storageClass: ""
 
-  # VLM Embedding (default) — uses 3g.40gb on GPU 3.
-  # The vision tower benefits from the extra compute slice vs a 1g.20gb.
+  # VLM Embedding (default) — 1 FULL H100 GPU (no MIG) on GPU 3.
+  # Promoted to a full device so the vision tower has unrestricted compute
+  # and memory bandwidth, improving end-to-end embedding throughput.
   nvidia-nim-llama-nemotron-embed-vl-1b-v2:
     resources:
       limits:
-        nvidia.com/gpu: "0"
-        nvidia.com/mig-3g.40gb: 1
+        nvidia.com/gpu: 1
       requests:
-        nvidia.com/gpu: "0"
-        nvidia.com/mig-3g.40gb: 1
+        nvidia.com/gpu: 1
     storage:
       pvc:
         storageClass: ""
 
-  # Reranking — uses 1g.20gb on GPU 3.
+  # Reranking — uses 1g.20gb on GPU 2.
   nvidia-nim-llama-32-nv-rerankqa-1b-v2:
     resources:
       limits:

--- a/deploy/helm/mig-slicing/values-mig-h100.yaml
+++ b/deploy/helm/mig-slicing/values-mig-h100.yaml
@@ -1,10 +1,11 @@
 # MIG-optimized resource configuration for RAG Blueprint on NVIDIA H100 80GB.
-# Pairs with mig-config-h100.yaml (profile: custom-h100-llm2full-embed1full-1x2g20-3x1g10-1x1g20).
+# Pairs with mig-config-h100.yaml (profile: custom-h100-5gpu-llm2full-embed1full).
 #
-# GPU layout (4×H100 node):
-#   GPU 0,1 — MIG disabled, full devices            → nim-llm (nemotron-3-super-120b-a12b, vLLM tp=2)
-#   GPU 2   — 1× 2g.20gb + 3× 1g.10gb + 1× 1g.20gb  → OCR + (graphic, page, table) + rerank
-#   GPU 3   — MIG disabled, full device             → embedding-VLM
+# GPU layout (5×H100 node):
+#   GPU 0,1 — MIG disabled, full devices  → nim-llm (nemotron-3-super-120b-a12b, vLLM tp=2)
+#   GPU 2   — 1× 3g.40gb + 4× 1g.10gb     → OCR + (graphic, page, table, spare)
+#   GPU 3   — MIG disabled, full device   → embedding-VLM
+#   GPU 4   — 1× 3g.40gb + 2× 1g.20gb     → rerank (+ spare 3g.40gb and 1g.20gb)
 #
 # Requires GPU Operator mig-strategy=mixed so the node advertises both
 # nvidia.com/gpu and nvidia.com/mig-* resources simultaneously.
@@ -23,15 +24,15 @@ nv-ingest:
 
   # NV-Ingest NIM Operator overrides
   nimOperator:
-    # OCR — uses 2g.20gb on GPU 2
+    # OCR — uses 3g.40gb on GPU 2
     ocr:
       resources:
         limits:
           nvidia.com/gpu: "0"
-          nvidia.com/mig-2g.20gb: 1
+          nvidia.com/mig-3g.40gb: 1
         requests:
           nvidia.com/gpu: "0"
-          nvidia.com/mig-2g.20gb: 1
+          nvidia.com/mig-3g.40gb: 1
       storage:
         pvc:
           storageClass: ""
@@ -103,7 +104,7 @@ nimOperator:
       pvc:
         storageClass: ""
 
-  # Reranking — uses 1g.20gb on GPU 2.
+  # Reranking — uses 1g.20gb on GPU 4.
   nvidia-nim-llama-32-nv-rerankqa-1b-v2:
     resources:
       limits:

--- a/docs/mig-deployment.md
+++ b/docs/mig-deployment.md
@@ -114,7 +114,7 @@ Edit the MIG configuration file [`mig-config-h100.yaml`](../deploy/helm/mig-slic
 The default configuration assumes a 4×H100 80GB node and reserves two full GPUs for the LLM while MIG-slicing the rest for the smaller NIMs.
 
 :::{note}
-The default LLM `nemotron-3-super-120b-a12b` runs with vLLM and `tensorParallelism=2`, which needs two physical GPUs with NVLink. Those two GPUs are kept MIG-disabled. The remaining two GPUs are MIG-sliced: GPU 2 hosts the ingest NIMs (OCR + page/graphic/table), and GPU 3 hosts the embedding-VLM and reranker. This requires the `mixed` MIG strategy (already set in Step 1) so the node advertises both `nvidia.com/gpu` and `nvidia.com/mig-*` resources.
+The default LLM `nemotron-3-super-120b-a12b` runs with vLLM and `tensorParallelism=2`, which needs two physical GPUs with NVLink. Those two GPUs are kept MIG-disabled. GPU 3 is also MIG-disabled and dedicated as a full GPU to the embedding-VLM NIM for higher throughput on the vision tower. GPU 2 is MIG-sliced to host OCR + page/graphic/table + the reranker. This requires the `mixed` MIG strategy (already set in Step 1) so the node advertises both `nvidia.com/gpu` and `nvidia.com/mig-*` resources.
 :::
 
 ```yaml
@@ -130,19 +130,17 @@ data:
         - devices: all
           mig-enabled: false
 
-      custom-h100-llm2full-1x3g40-4x1g10-1x3g40-2x1g20:
+      custom-h100-llm2full-embed1full-1x2g20-3x1g10-1x1g20:
         - devices: [0, 1]
           mig-enabled: false
         - devices: [2]
           mig-enabled: true
           mig-devices:
-            "3g.40gb": 1
-            "1g.10gb": 4
+            "2g.20gb": 1
+            "1g.10gb": 3
+            "1g.20gb": 1
         - devices: [3]
-          mig-enabled: true
-          mig-devices:
-            "3g.40gb": 1
-            "1g.20gb": 2
+          mig-enabled: false
 ```
 
 Apply the custom MIG configuration configMap to the node and update the ClusterPolicy, by running the following code.
@@ -157,7 +155,7 @@ kubectl patch clusterpolicies.nvidia.com/cluster-policy \
 Label the node with MIG configuration, by running the following code.
 
 ```bash
-kubectl label nodes <node-name> nvidia.com/mig.config=custom-h100-llm2full-1x3g40-4x1g10-1x3g40-2x1g20 --overwrite
+kubectl label nodes <node-name> nvidia.com/mig.config=custom-h100-llm2full-embed1full-1x2g20-3x1g10-1x1g20 --overwrite
 ```
 
 :::{important}
@@ -184,10 +182,10 @@ You should see output similar to the following.
 
 ```json
 "nvidia.com/mig.config.state": "success"
-"nvidia.com/gpu.count": "2"
-"nvidia.com/mig-1g.10gb.count": "4"
-"nvidia.com/mig-1g.20gb.count": "2"
-"nvidia.com/mig-3g.40gb.count": "2"
+"nvidia.com/gpu.count": "3"
+"nvidia.com/mig-2g.20gb.count": "1"
+"nvidia.com/mig-1g.10gb.count": "3"
+"nvidia.com/mig-1g.20gb.count": "1"
 ```
 
 
@@ -243,20 +241,20 @@ You should see output similar to the following.
 
 ```
 Resource                                    Requested   Limit    Allocatable  Free
-nvidia.com/gpu                              (100%) 2.0  (100%) 2.0     2.0        0.0
-└─ nim-llm-...                             2.0     2.0
+nvidia.com/gpu                              (100%) 3.0  (100%) 3.0     3.0        0.0
+├─ nim-llm-...                             2.0     2.0
+└─ nemotron-vlm-embedding-ms-...           1.0     1.0
 
-nvidia.com/mig-1g.10gb                      (75%) 3.0   (75%) 3.0     4.0        1.0
+nvidia.com/mig-2g.20gb                      (100%) 1.0  (100%) 1.0     1.0        0.0
+└─ nemotron-ocr-v1-...                     1.0     1.0
+
+nvidia.com/mig-1g.10gb                      (100%) 3.0  (100%) 3.0     3.0        0.0
 ├─ nemotron-graphic-elements-v1-...        1.0     1.0
 ├─ nemotron-page-elements-v3-...           1.0     1.0
 └─ nemotron-table-structure-v1-...         1.0     1.0
 
-nvidia.com/mig-1g.20gb                      (50%) 1.0   (50%) 1.0     2.0        1.0
+nvidia.com/mig-1g.20gb                      (100%) 1.0  (100%) 1.0     1.0        0.0
 └─ nemotron-ranking-ms-...                 1.0     1.0
-
-nvidia.com/mig-3g.40gb                      (100%) 2.0  (100%) 2.0     2.0        0.0
-├─ nemotron-ocr-v1-...                     1.0     1.0
-└─ nemotron-vlm-embedding-ms-...           1.0     1.0
 ```
 
 
@@ -276,18 +274,15 @@ You should see output similar to the following.
 GPU 0: NVIDIA H100 80GB HBM3 (UUID: ...)
 GPU 1: NVIDIA H100 80GB HBM3 (UUID: ...)
 GPU 2: NVIDIA H100 80GB HBM3 (UUID: ...)
-  MIG 3g.40gb     Device 0: ...
+  MIG 2g.20gb     Device 0: ...
   MIG 1g.10gb     Device 1: ...
   MIG 1g.10gb     Device 2: ...
   MIG 1g.10gb     Device 3: ...
-  MIG 1g.10gb     Device 4: ...
+  MIG 1g.20gb     Device 4: ...
 GPU 3: NVIDIA H100 80GB HBM3 (UUID: ...)
-  MIG 3g.40gb     Device 0: ...
-  MIG 1g.20gb     Device 1: ...
-  MIG 1g.20gb     Device 2: ...
 ```
 
-GPUs 0 and 1 are reported as whole devices because MIG is disabled on them — they are reserved for `nim-llm` (vLLM tp=2).
+GPUs 0, 1, and 3 are reported as whole devices because MIG is disabled on them — GPUs 0 and 1 are reserved for `nim-llm` (vLLM tp=2), and GPU 3 is dedicated to the embedding-VLM NIM.
 
 
 

--- a/docs/mig-deployment.md
+++ b/docs/mig-deployment.md
@@ -111,10 +111,10 @@ For monitoring deployment progress, refer to [Deploy on Kubernetes with Helm](./
 ## Step 2: Apply the MIG configuration
 
 Edit the MIG configuration file [`mig-config-h100.yaml`](../deploy/helm/mig-slicing/mig-config-h100.yaml) to adjust the slicing pattern as needed.
-The default configuration assumes a 4×H100 80GB node and reserves two full GPUs for the LLM while MIG-slicing the rest for the smaller NIMs.
+The default configuration assumes a 5×H100 80GB node and reserves three full GPUs (two for the LLM and one for the embedding-VLM) while MIG-slicing the rest for the smaller NIMs.
 
 :::{note}
-The default LLM `nemotron-3-super-120b-a12b` runs with vLLM and `tensorParallelism=2`, which needs two physical GPUs with NVLink. Those two GPUs are kept MIG-disabled. GPU 3 is also MIG-disabled and dedicated as a full GPU to the embedding-VLM NIM for higher throughput on the vision tower. GPU 2 is MIG-sliced to host OCR + page/graphic/table + the reranker. This requires the `mixed` MIG strategy (already set in Step 1) so the node advertises both `nvidia.com/gpu` and `nvidia.com/mig-*` resources.
+The default LLM `nemotron-3-super-120b-a12b` runs with vLLM and `tensorParallelism=2`, which needs two physical GPUs with NVLink. Those two GPUs (GPU 0,1) are kept MIG-disabled. GPU 3 is also MIG-disabled and dedicated as a full GPU to the embedding-VLM NIM for higher throughput on the vision tower. GPU 2 is MIG-sliced to host OCR + page/graphic/table, and GPU 4 is MIG-sliced to host the reranker. This requires the `mixed` MIG strategy (already set in Step 1) so the node advertises both `nvidia.com/gpu` and `nvidia.com/mig-*` resources.
 :::
 
 ```yaml
@@ -130,17 +130,21 @@ data:
         - devices: all
           mig-enabled: false
 
-      custom-h100-llm2full-embed1full-1x2g20-3x1g10-1x1g20:
+      custom-h100-5gpu-llm2full-embed1full:
         - devices: [0, 1]
           mig-enabled: false
         - devices: [2]
           mig-enabled: true
           mig-devices:
-            "2g.20gb": 1
-            "1g.10gb": 3
-            "1g.20gb": 1
+            "3g.40gb": 1
+            "1g.10gb": 4
         - devices: [3]
           mig-enabled: false
+        - devices: [4]
+          mig-enabled: true
+          mig-devices:
+            "3g.40gb": 1
+            "1g.20gb": 2
 ```
 
 Apply the custom MIG configuration configMap to the node and update the ClusterPolicy, by running the following code.
@@ -155,7 +159,7 @@ kubectl patch clusterpolicies.nvidia.com/cluster-policy \
 Label the node with MIG configuration, by running the following code.
 
 ```bash
-kubectl label nodes <node-name> nvidia.com/mig.config=custom-h100-llm2full-embed1full-1x2g20-3x1g10-1x1g20 --overwrite
+kubectl label nodes <node-name> nvidia.com/mig.config=custom-h100-5gpu-llm2full-embed1full --overwrite
 ```
 
 :::{important}
@@ -183,9 +187,9 @@ You should see output similar to the following.
 ```json
 "nvidia.com/mig.config.state": "success"
 "nvidia.com/gpu.count": "3"
-"nvidia.com/mig-2g.20gb.count": "1"
-"nvidia.com/mig-1g.10gb.count": "3"
-"nvidia.com/mig-1g.20gb.count": "1"
+"nvidia.com/mig-3g.40gb.count": "2"
+"nvidia.com/mig-1g.10gb.count": "4"
+"nvidia.com/mig-1g.20gb.count": "2"
 ```
 
 
@@ -245,15 +249,15 @@ nvidia.com/gpu                              (100%) 3.0  (100%) 3.0     3.0      
 ├─ nim-llm-...                             2.0     2.0
 └─ nemotron-vlm-embedding-ms-...           1.0     1.0
 
-nvidia.com/mig-2g.20gb                      (100%) 1.0  (100%) 1.0     1.0        0.0
+nvidia.com/mig-3g.40gb                      (50%) 1.0   (50%) 1.0     2.0        1.0
 └─ nemotron-ocr-v1-...                     1.0     1.0
 
-nvidia.com/mig-1g.10gb                      (100%) 3.0  (100%) 3.0     3.0        0.0
+nvidia.com/mig-1g.10gb                      (75%) 3.0   (75%) 3.0     4.0        1.0
 ├─ nemotron-graphic-elements-v1-...        1.0     1.0
 ├─ nemotron-page-elements-v3-...           1.0     1.0
 └─ nemotron-table-structure-v1-...         1.0     1.0
 
-nvidia.com/mig-1g.20gb                      (100%) 1.0  (100%) 1.0     1.0        0.0
+nvidia.com/mig-1g.20gb                      (50%) 1.0   (50%) 1.0     2.0        1.0
 └─ nemotron-ranking-ms-...                 1.0     1.0
 ```
 
@@ -274,15 +278,19 @@ You should see output similar to the following.
 GPU 0: NVIDIA H100 80GB HBM3 (UUID: ...)
 GPU 1: NVIDIA H100 80GB HBM3 (UUID: ...)
 GPU 2: NVIDIA H100 80GB HBM3 (UUID: ...)
-  MIG 2g.20gb     Device 0: ...
+  MIG 3g.40gb     Device 0: ...
   MIG 1g.10gb     Device 1: ...
   MIG 1g.10gb     Device 2: ...
   MIG 1g.10gb     Device 3: ...
-  MIG 1g.20gb     Device 4: ...
+  MIG 1g.10gb     Device 4: ...
 GPU 3: NVIDIA H100 80GB HBM3 (UUID: ...)
+GPU 4: NVIDIA H100 80GB HBM3 (UUID: ...)
+  MIG 3g.40gb     Device 0: ...
+  MIG 1g.20gb     Device 1: ...
+  MIG 1g.20gb     Device 2: ...
 ```
 
-GPUs 0, 1, and 3 are reported as whole devices because MIG is disabled on them — GPUs 0 and 1 are reserved for `nim-llm` (vLLM tp=2), and GPU 3 is dedicated to the embedding-VLM NIM.
+GPUs 0, 1, and 3 are reported as whole devices because MIG is disabled on them — GPUs 0 and 1 are reserved for `nim-llm` (vLLM tp=2), and GPU 3 is dedicated to the embedding-VLM NIM. GPU 4 is MIG-sliced and currently hosts only the reranker (1× 1g.20gb); the remaining 3g.40gb and second 1g.20gb slices are spare capacity for future workloads.
 
 
 


### PR DESCRIPTION
Reshape the H100 MIG layout so the embedding-VLM NIM gets a dedicated full H100 instead of a 3g.40gb slice, improving vision-tower throughput.

  GPU 0,1 — full devices                           → nim-llm (vLLM tp=2)
  GPU 2   — 1x 2g.20gb + 3x 1g.10gb + 1x 1g.20gb   → OCR + (graphic, page, table) + rerank
  GPU 3   — full device                            → embedding-VLM (NEW)

Rerank keeps its 1g.20gb slice (now on GPU 2). OCR drops from 3g.40gb to 2g.20gb to make room for rerank's slice on GPU 2 (no spare slots remain). MIG profile renamed to
custom-h100-llm2full-embed1full-1x2g20-3x1g10-1x1g20 and docs (mig-deployment.md) updated to match the new layout and verification output.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.