### PR TITLE
release-v2.6.0: sync updates and harden NGC publishing

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -153,18 +153,21 @@ jobs:
           UPLOAD_EXIT_CODE=$?
           set -e
 
-          if [ $UPLOAD_EXIT_CODE -ne 0 ]; then
+          if [ "$UPLOAD_EXIT_CODE" -ne 0 ]; then
             echo "$UPLOAD_OUTPUT"
-            if [[ "$UPLOAD_OUTPUT" == *"already exists"* ]] || [[ "$UPLOAD_OUTPUT" == *"already present"* ]]; then
-              echo "Wheel version still exists after pre-delete; retrying once..."
-              remove_wheel_version
-              ngc registry resource upload-version \
-                "nvstaging/blueprint/nvidia_rag:$ARTIFACTORY_VERSION" \
-                --source "$WHEEL_FILE" \
-                --org nvstaging
-            else
-              exit $UPLOAD_EXIT_CODE
-            fi
+            case "$UPLOAD_OUTPUT" in
+              *"already exists"*|*"already present"*)
+                echo "Wheel version still exists after pre-delete; retrying once..."
+                remove_wheel_version
+                ngc registry resource upload-version \
+                  "nvstaging/blueprint/nvidia_rag:$ARTIFACTORY_VERSION" \
+                  --source "$WHEEL_FILE" \
+                  --org nvstaging
+                ;;
+              *)
+                exit "$UPLOAD_EXIT_CODE"
+                ;;
+            esac
           fi
           
           echo "Wheel published to NGC successfully"
@@ -452,14 +455,17 @@ jobs:
           PUSH_EXIT_CODE=$?
           set -e
 
-          if [ $PUSH_EXIT_CODE -ne 0 ]; then
+          if [ "$PUSH_EXIT_CODE" -ne 0 ]; then
             echo "$PUSH_OUTPUT"
-            if [[ "$PUSH_OUTPUT" == *"already exists"* ]]; then
-              echo "Chart version still exists after pre-delete; retrying once..."
-              remove_chart_version
-              ngc registry chart push "$TARGET" --source "$CHART_TGZ" --org nvstaging
-            else
-              exit $PUSH_EXIT_CODE
-            fi
+            case "$PUSH_OUTPUT" in
+              *"already exists"*)
+                echo "Chart version still exists after pre-delete; retrying once..."
+                remove_chart_version
+                ngc registry chart push "$TARGET" --source "$CHART_TGZ" --org nvstaging
+                ;;
+              *)
+                exit "$PUSH_EXIT_CODE"
+                ;;
+            esac
           fi
           echo "Helm chart published to NGC: $TARGET"

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -112,7 +112,7 @@ jobs:
           NGC_API_KEY: ${{ secrets.CI_NVSTAGING_BLUEPRINT_KEY }}
         run: |
           echo "Installing NGC CLI..."
-          wget --content-disposition https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/4.9.10/files/ngccli_linux.zip -O ngccli_linux.zip
+          wget --content-disposition https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/4.18.0/files/ngccli_linux.zip -O ngccli_linux.zip
           unzip -o ngccli_linux.zip
           chmod u+x ngc-cli/ngc
           
@@ -132,16 +132,40 @@ jobs:
           # Extract just the filename for display
           WHEEL_FILENAME=$(basename "$WHEEL_FILE")
           echo "Wheel filename: $WHEEL_FILENAME"
-          
-          # Remove existing version to overwrite (ignore error if version does not exist)
-          ngc registry resource remove-version "nvstaging/blueprint/nvidia_rag:$ARTIFACTORY_VERSION" --org nvstaging -y 2>/dev/null || true
 
-          # Publish to NGC
+          remove_wheel_version() {
+            # Try both target styles for compatibility across NGC CLI versions.
+            ngc registry resource remove-version "nvstaging/blueprint/nvidia_rag:$ARTIFACTORY_VERSION" -y >/dev/null 2>&1 \
+              || ngc registry resource remove-version "blueprint/nvidia_rag:$ARTIFACTORY_VERSION" --org nvstaging -y >/dev/null 2>&1 \
+              || true
+          }
+
+          # Remove existing version to overwrite (ignore error if version does not exist).
+          remove_wheel_version
+
+          # Publish to NGC. If an old version still exists, remove and retry once.
           echo "Publishing wheel to NGC: nvstaging/blueprint/nvidia_rag:$ARTIFACTORY_VERSION"
-          ngc registry resource upload-version \
+          set +e
+          UPLOAD_OUTPUT=$(ngc registry resource upload-version \
             "nvstaging/blueprint/nvidia_rag:$ARTIFACTORY_VERSION" \
             --source "$WHEEL_FILE" \
-            --org nvstaging
+            --org nvstaging 2>&1)
+          UPLOAD_EXIT_CODE=$?
+          set -e
+
+          if [ $UPLOAD_EXIT_CODE -ne 0 ]; then
+            echo "$UPLOAD_OUTPUT"
+            if [[ "$UPLOAD_OUTPUT" == *"already exists"* ]] || [[ "$UPLOAD_OUTPUT" == *"already present"* ]]; then
+              echo "Wheel version still exists after pre-delete; retrying once..."
+              remove_wheel_version
+              ngc registry resource upload-version \
+                "nvstaging/blueprint/nvidia_rag:$ARTIFACTORY_VERSION" \
+                --source "$WHEEL_FILE" \
+                --org nvstaging
+            else
+              exit $UPLOAD_EXIT_CODE
+            fi
+          fi
           
           echo "Wheel published to NGC successfully"
           echo "NGC Resource: nvstaging/blueprint/nvidia_rag:$ARTIFACTORY_VERSION"
@@ -348,7 +372,7 @@ jobs:
           NGC_API_KEY: ${{ secrets.CI_NVSTAGING_BLUEPRINT_KEY }}
         run: |
           echo "Installing NGC CLI..."
-          wget --content-disposition https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/4.9.10/files/ngccli_linux.zip -O ngccli_linux.zip
+          wget --content-disposition https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/4.18.0/files/ngccli_linux.zip -O ngccli_linux.zip
           unzip -o ngccli_linux.zip
           chmod u+x ngc-cli/ngc
           echo "$(pwd)/ngc-cli" >> $GITHUB_PATH
@@ -412,7 +436,30 @@ jobs:
           cd deploy/helm
           CHART_TGZ="nvidia-blueprint-rag-${{ env.HELM_CHART_VERSION }}.tgz"
           TARGET="nvstaging/blueprint/nvidia-blueprint-rag:${{ env.HELM_CHART_VERSION }}"
-          # Remove existing version to overwrite (ignore error if version does not exist)
-          ngc registry chart remove "$TARGET" --org nvstaging -y 2>/dev/null || true
-          ngc registry chart push "$TARGET" --source "$CHART_TGZ" --org nvstaging
+          remove_chart_version() {
+            # Try both target styles for compatibility across NGC CLI versions.
+            ngc registry chart remove "$TARGET" -y >/dev/null 2>&1 \
+              || ngc registry chart remove "nvidia-blueprint-rag:${{ env.HELM_CHART_VERSION }}" --org nvstaging --team blueprint -y >/dev/null 2>&1 \
+              || true
+          }
+
+          # Remove existing version to overwrite (ignore error if version does not exist).
+          remove_chart_version
+
+          # Push once; if NGC still reports "already exists", remove and retry once.
+          set +e
+          PUSH_OUTPUT=$(ngc registry chart push "$TARGET" --source "$CHART_TGZ" --org nvstaging 2>&1)
+          PUSH_EXIT_CODE=$?
+          set -e
+
+          if [ $PUSH_EXIT_CODE -ne 0 ]; then
+            echo "$PUSH_OUTPUT"
+            if [[ "$PUSH_OUTPUT" == *"already exists"* ]]; then
+              echo "Chart version still exists after pre-delete; retrying once..."
+              remove_chart_version
+              ngc registry chart push "$TARGET" --source "$CHART_TGZ" --org nvstaging
+            else
+              exit $PUSH_EXIT_CODE
+            fi
+          fi
           echo "Helm chart published to NGC: $TARGET"

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -439,15 +439,42 @@ jobs:
           cd deploy/helm
           CHART_TGZ="nvidia-blueprint-rag-${{ env.HELM_CHART_VERSION }}.tgz"
           TARGET="nvstaging/blueprint/nvidia-blueprint-rag:${{ env.HELM_CHART_VERSION }}"
+          SHORT_TARGET="nvidia-blueprint-rag:${{ env.HELM_CHART_VERSION }}"
+
+          chart_exists() {
+            ngc registry chart info "$TARGET" >/dev/null 2>&1 \
+              || ngc registry chart info "$SHORT_TARGET" --org nvstaging --team blueprint >/dev/null 2>&1
+          }
+
           remove_chart_version() {
             # Try both target styles for compatibility across NGC CLI versions.
-            ngc registry chart remove "$TARGET" -y >/dev/null 2>&1 \
-              || ngc registry chart remove "nvidia-blueprint-rag:${{ env.HELM_CHART_VERSION }}" --org nvstaging --team blueprint -y >/dev/null 2>&1 \
+            ngc registry chart remove "$TARGET" -y \
+              || ngc registry chart remove "$SHORT_TARGET" --org nvstaging --team blueprint -y \
               || true
           }
 
+          ensure_chart_removed() {
+            ATTEMPT=1
+            while [ "$ATTEMPT" -le 3 ]; do
+              if chart_exists; then
+                echo "Chart version exists; remove attempt $ATTEMPT/3 for $TARGET"
+                remove_chart_version
+                sleep 3
+              else
+                return 0
+              fi
+              ATTEMPT=$((ATTEMPT + 1))
+            done
+
+            if chart_exists; then
+              echo "Unable to remove existing chart version: $TARGET"
+              echo "NGC appears to retain this version; publish cannot overwrite immutable versions."
+              return 1
+            fi
+          }
+
           # Remove existing version to overwrite (ignore error if version does not exist).
-          remove_chart_version
+          ensure_chart_removed
 
           # Push once; if NGC still reports "already exists", remove and retry once.
           set +e
@@ -460,7 +487,7 @@ jobs:
             case "$PUSH_OUTPUT" in
               *"already exists"*)
                 echo "Chart version still exists after pre-delete; retrying once..."
-                remove_chart_version
+                ensure_chart_removed
                 ngc registry chart push "$TARGET" --source "$CHART_TGZ" --org nvstaging
                 ;;
               *)

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -132,22 +132,49 @@ jobs:
           # Extract just the filename for display
           WHEEL_FILENAME=$(basename "$WHEEL_FILE")
           echo "Wheel filename: $WHEEL_FILENAME"
+          TARGET="nvstaging/blueprint/nvidia_rag:$ARTIFACTORY_VERSION"
+          SHORT_TARGET="blueprint/nvidia_rag:$ARTIFACTORY_VERSION"
+
+          wheel_exists() {
+            ngc registry resource info "$TARGET" >/dev/null 2>&1 \
+              || ngc registry resource info "$SHORT_TARGET" --org nvstaging >/dev/null 2>&1
+          }
 
           remove_wheel_version() {
             # Try both target styles for compatibility across NGC CLI versions.
-            ngc registry resource remove-version "nvstaging/blueprint/nvidia_rag:$ARTIFACTORY_VERSION" -y >/dev/null 2>&1 \
-              || ngc registry resource remove-version "blueprint/nvidia_rag:$ARTIFACTORY_VERSION" --org nvstaging -y >/dev/null 2>&1 \
+            ngc registry resource remove-version "$TARGET" -y \
+              || ngc registry resource remove-version "$SHORT_TARGET" --org nvstaging -y \
               || true
           }
 
-          # Remove existing version to overwrite (ignore error if version does not exist).
-          remove_wheel_version
+          ensure_wheel_removed() {
+            ATTEMPT=1
+            while [ "$ATTEMPT" -le 3 ]; do
+              if wheel_exists; then
+                echo "Wheel version exists; remove attempt $ATTEMPT/3 for $TARGET"
+                remove_wheel_version
+                sleep 3
+              else
+                return 0
+              fi
+              ATTEMPT=$((ATTEMPT + 1))
+            done
+
+            if wheel_exists; then
+              echo "Unable to remove existing wheel version: $TARGET"
+              echo "NGC appears to retain this version; publish cannot overwrite immutable versions."
+              return 1
+            fi
+          }
+
+          # Remove existing version to overwrite.
+          ensure_wheel_removed
 
           # Publish to NGC. If an old version still exists, remove and retry once.
-          echo "Publishing wheel to NGC: nvstaging/blueprint/nvidia_rag:$ARTIFACTORY_VERSION"
+          echo "Publishing wheel to NGC: $TARGET"
           set +e
           UPLOAD_OUTPUT=$(ngc registry resource upload-version \
-            "nvstaging/blueprint/nvidia_rag:$ARTIFACTORY_VERSION" \
+            "$TARGET" \
             --source "$WHEEL_FILE" \
             --org nvstaging 2>&1)
           UPLOAD_EXIT_CODE=$?
@@ -158,9 +185,9 @@ jobs:
             case "$UPLOAD_OUTPUT" in
               *"already exists"*|*"already present"*)
                 echo "Wheel version still exists after pre-delete; retrying once..."
-                remove_wheel_version
+                ensure_wheel_removed
                 ngc registry resource upload-version \
-                  "nvstaging/blueprint/nvidia_rag:$ARTIFACTORY_VERSION" \
+                  "$TARGET" \
                   --source "$WHEEL_FILE" \
                   --org nvstaging
                 ;;
@@ -171,7 +198,7 @@ jobs:
           fi
           
           echo "Wheel published to NGC successfully"
-          echo "NGC Resource: nvstaging/blueprint/nvidia_rag:$ARTIFACTORY_VERSION"
+          echo "NGC Resource: $TARGET"
 
   # ============================================================================
   # PUBLISH RAG SERVER CONTAINER


### PR DESCRIPTION
## Summary
- bring in release-relevant updates already on this branch: H100 MIG slicing value/config adjustments and OpenTelemetry batch-size tuning
- harden NGC wheel and Helm artifact publishing in CI by removing stale versions and retrying once on duplicate-version errors
- upgrade workflow-installed NGC CLI from 4.9.10 to 4.18.0 for better registry command compatibility

## Test plan
- [ ] Run `Publish Artifacts` with `helm-chart-only` and verify chart push succeeds even when the target version already exists
- [ ] Run `Publish Artifacts` with `wheel-only` and verify wheel upload succeeds even when the target version already exists
- [ ] Confirm non-duplicate NGC errors still fail fast in both publish steps