### PR TITLE
ci(cve): mirror Phase-3 PR-creation workflow to main

### DIFF
--- a/.github/scripts/cve-create-pr.sh
+++ b/.github/scripts/cve-create-pr.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Create a signed commit + branch + PR for the workspace edits that were
+# just applied by the cve-create-pr.yml workflow.
+#
+# Why the Git Data API instead of `git commit -S && git push`:
+# the repo policy (CONTRIBUTING.md) requires both -s (DCO) and -S (GPG).
+# Locally we have no GPG key. Commits created via the REST API are
+# auto-signed by github-actions[bot] (Verified ✓), so we go through the
+# API for the commit and let git just handle the working-tree state.
+#
+# Required environment (set by the calling workflow):
+#   GH_TOKEN          GitHub token with contents:write + pull-requests:write
+#   REPO              owner/repo, e.g. NVIDIA-AI-Blueprints/rag
+#   TRACKER_ISSUE     Issue number to link back to (e.g. 617)
+# Optional:
+#   PATCH_FILE        Path to the applied patch (logged in PR body for
+#                     traceability). Default: /tmp/cve-fix.patch
+
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${REPO:?REPO is required}"
+: "${TRACKER_ISSUE:?TRACKER_ISSUE is required}"
+PATCH_FILE="${PATCH_FILE:-/tmp/cve-fix.patch}"
+
+DATE_UTC="$(date -u +%Y-%m-%d)"
+BRANCH="cve-fix/nightly-${DATE_UTC}"
+PARENT_SHA="$(git rev-parse HEAD)"
+
+echo "Target branch: ${BRANCH}"
+echo "Parent commit:  ${PARENT_SHA}"
+
+# ---------------------------------------------------------------------------
+# Idempotency: if a PR is already open for this branch, print and exit clean.
+# ---------------------------------------------------------------------------
+EXISTING_PR_URL="$(
+  gh api "/repos/${REPO}/pulls?head=${REPO%%/*}:${BRANCH}&state=open" \
+    --jq '.[0].html_url // empty' 2>/dev/null || true
+)"
+if [ -n "$EXISTING_PR_URL" ]; then
+  echo "✓ PR already exists for ${BRANCH}: ${EXISTING_PR_URL}"
+  echo "Re-clicks the same day are idempotent."
+  echo "pr_url=${EXISTING_PR_URL}" >> "${GITHUB_OUTPUT:-/dev/null}" 2>/dev/null || true
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Collect modified + added + deleted files.
+# git diff vs HEAD captures everything `git apply` produced.
+# ---------------------------------------------------------------------------
+CHANGED_FILES=()
+DELETED_FILES=()
+while IFS=$'\t' read -r status path; do
+  case "$status" in
+    A|M|R*|C*|T) CHANGED_FILES+=("$path") ;;
+    D)           DELETED_FILES+=("$path") ;;
+  esac
+done < <(git diff --name-status HEAD)
+
+if [ "${#CHANGED_FILES[@]}" -eq 0 ] && [ "${#DELETED_FILES[@]}" -eq 0 ]; then
+  echo "::error::No changes in workspace — git apply produced no diff."
+  exit 1
+fi
+
+echo "Modified/added files: ${#CHANGED_FILES[@]}"
+echo "Deleted files:        ${#DELETED_FILES[@]}"
+
+# ---------------------------------------------------------------------------
+# Build tree entries. For modified/added files, upload as a blob via API
+# (base64 to handle binary safely) and reference the returned SHA. For
+# deleted files, the tree entry has sha = null.
+# ---------------------------------------------------------------------------
+TREE_ENTRIES_FILE="$(mktemp)"
+trap 'rm -f "$TREE_ENTRIES_FILE"' EXIT
+echo "[]" > "$TREE_ENTRIES_FILE"
+
+append_entry() {
+  # $1 = path, $2 = sha-or-null
+  local path="$1" sha="$2"
+  local entry
+  if [ "$sha" = "null" ]; then
+    entry="$(jq -nc --arg p "$path" '{path:$p, mode:"100644", type:"blob", sha:null}')"
+  else
+    entry="$(jq -nc --arg p "$path" --arg s "$sha" '{path:$p, mode:"100644", type:"blob", sha:$s}')"
+  fi
+  jq --argjson e "$entry" '. + [$e]' "$TREE_ENTRIES_FILE" > "${TREE_ENTRIES_FILE}.tmp"
+  mv "${TREE_ENTRIES_FILE}.tmp" "$TREE_ENTRIES_FILE"
+}
+
+# Iterate guards: `for X in "${arr[@]}"` triggers `set -u` on empty arrays
+# in older bash (3.2 on macOS, also workflows pinned to legacy bash).
+# Skip the loop entirely when the array is empty.
+if [ "${#CHANGED_FILES[@]}" -gt 0 ]; then
+  for FILE in "${CHANGED_FILES[@]}"; do
+    echo "  uploading blob: ${FILE} ($(wc -c < "$FILE") bytes)"
+    BLOB_SHA="$(
+      jq -nc --arg c "$(base64 < "$FILE" | tr -d '\n')" \
+        '{content:$c, encoding:"base64"}' \
+      | gh api -X POST "/repos/${REPO}/git/blobs" --input - --jq '.sha'
+    )"
+    append_entry "$FILE" "$BLOB_SHA"
+  done
+fi
+
+if [ "${#DELETED_FILES[@]}" -gt 0 ]; then
+  for FILE in "${DELETED_FILES[@]}"; do
+    echo "  marking deletion: ${FILE}"
+    append_entry "$FILE" "null"
+  done
+fi
+
+# ---------------------------------------------------------------------------
+# Create tree (based on develop's HEAD tree) → commit → branch ref → PR.
+# ---------------------------------------------------------------------------
+BASE_TREE_SHA="$(gh api "/repos/${REPO}/git/commits/${PARENT_SHA}" --jq '.tree.sha')"
+echo "Base tree: ${BASE_TREE_SHA}"
+
+NEW_TREE_SHA="$(
+  jq -nc --arg base "$BASE_TREE_SHA" --slurpfile entries "$TREE_ENTRIES_FILE" \
+    '{base_tree:$base, tree:$entries[0]}' \
+  | gh api -X POST "/repos/${REPO}/git/trees" --input - --jq '.sha'
+)"
+echo "New tree:  ${NEW_TREE_SHA}"
+
+COMMIT_MESSAGE="$(cat <<EOF
+fix(deps): nightly CVE auto-fix ${DATE_UTC}
+
+Generated by agentic-cve-fix against NSPECT-S62Q-PZUD.
+Linked Issue: ${REPO}#${TRACKER_ISSUE}
+
+See the linked Issue and the GitLab pipeline artifact for the per-CVE
+reasoning and reviewer verdicts.
+
+Signed-off-by: cve-bot <noreply@github.com>
+EOF
+)"
+
+NEW_COMMIT_SHA="$(
+  jq -nc \
+    --arg msg "$COMMIT_MESSAGE" \
+    --arg tree "$NEW_TREE_SHA" \
+    --arg parent "$PARENT_SHA" \
+    '{message:$msg, tree:$tree, parents:[$parent]}' \
+  | gh api -X POST "/repos/${REPO}/git/commits" --input - --jq '.sha'
+)"
+echo "New commit: ${NEW_COMMIT_SHA}"
+
+# Create branch (or update if it already exists from an earlier click today).
+REF_PATH="refs/heads/${BRANCH}"
+if gh api "/repos/${REPO}/git/${REF_PATH}" --silent 2>/dev/null; then
+  echo "Branch ${BRANCH} exists — updating ref."
+  jq -nc --arg sha "$NEW_COMMIT_SHA" '{sha:$sha, force:true}' \
+    | gh api -X PATCH "/repos/${REPO}/git/${REF_PATH}" --input - --silent
+else
+  echo "Creating branch ${BRANCH}."
+  jq -nc --arg ref "refs/heads/${BRANCH}" --arg sha "$NEW_COMMIT_SHA" \
+    '{ref:$ref, sha:$sha}' \
+    | gh api -X POST "/repos/${REPO}/git/refs" --input - --silent
+fi
+
+# Open the PR.
+PR_BODY="$(cat <<EOF
+Auto-generated by the nightly CVE scan pipeline.
+
+- **Linked Issue:** #${TRACKER_ISSUE}
+- **Source patch:** the marker patch comment on #${TRACKER_ISSUE}
+- **Branch:** \`${BRANCH}\`
+- **Parent:** \`${PARENT_SHA}\`
+
+See the per-CVE reasoning in the linked GitLab pipeline artifact
+(linked from the Issue body).
+EOF
+)"
+
+PR_URL="$(
+  gh pr create \
+    --repo "${REPO}" \
+    --base develop \
+    --head "${BRANCH}" \
+    --title "fix(deps): nightly CVE auto-fix ${DATE_UTC}" \
+    --body "$PR_BODY"
+)"
+echo "✓ Opened PR: ${PR_URL}"
+echo "pr_url=${PR_URL}" >> "${GITHUB_OUTPUT:-/dev/null}" 2>/dev/null || true

--- a/.github/workflows/cve-create-pr.yml
+++ b/.github/workflows/cve-create-pr.yml
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: CVE — Create PR from latest scan
+
+# Triggered manually from Issue #617's "Create PR" button. Reads the latest
+# CVE patch from a marker comment on Issue #617 (posted nightly by the
+# GitLab cve-post job), applies it to develop, opens a PR.
+#
+# Commits are created via the Git Data API (gh api), which means they are
+# auto-signed by github-actions[bot] (Verified ✓ badge). No local GPG
+# config or bot key needed.
+#
+# Permissions:
+#   contents: write       — push the cve-fix/nightly-* branch
+#   pull-requests: write  — open the PR
+# Default GITHUB_TOKEN is sufficient (no new secrets).
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: cve-create-pr
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  create-pr:
+    name: Create PR from latest CVE patch
+    runs-on: blueprints-skills-eval-runner
+    timeout-minutes: 15
+
+    env:
+      GH_TOKEN: ${{ github.token }}
+      TRACKER_ISSUE: "617"
+      REPO: ${{ github.repository }}
+
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v5
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: Ensure gh CLI is on PATH
+        # The runner does not ship with gh. Install once per job to a
+        # workflow-scoped temp dir; if an admin later installs gh
+        # system-wide, this step becomes a near-instant no-op.
+        # Pinned version for reproducibility.
+        run: |
+          set -euo pipefail
+          if command -v gh >/dev/null 2>&1; then
+            echo "gh already installed: $(gh --version | head -1)"
+            exit 0
+          fi
+          GH_VERSION="2.62.0"
+          # Tarball layout: gh_<ver>_linux_amd64/bin/gh
+          # `--strip-components=1` flattens that prefix into $RUNNER_TEMP.
+          curl -fsSL \
+            "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+            | tar -xz -C "$RUNNER_TEMP" --strip-components=1 'gh_'"${GH_VERSION}"'_linux_amd64/bin/gh'
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/bin/gh" --version | head -1
+
+      - name: Extract patch from Issue #${{ env.TRACKER_ISSUE }} marker comment
+        run: |
+          set -euo pipefail
+
+          # Find the single comment marked with our HTML marker. The
+          # cve-post job (GitLab) edit-or-creates one of these per Issue.
+          COMMENT_BODY="$(
+            gh api "/repos/${REPO}/issues/${TRACKER_ISSUE}/comments" \
+              --paginate \
+              --jq '.[] | select(.body | contains("<!-- cve-bot-patch -->")) | .body' \
+              | head -c 200000
+          )"
+
+          if [ -z "$COMMENT_BODY" ]; then
+            echo "::error::No marker comment found on Issue #${TRACKER_ISSUE}."
+            echo "Expected a comment containing '<!-- cve-bot-patch -->' from the nightly cve-post job."
+            exit 1
+          fi
+
+          # Extract the patch between the first ```diff and the next ```.
+          echo "$COMMENT_BODY" | awk '
+            /^```diff[[:space:]]*$/ { in_block = 1; next }
+            /^```[[:space:]]*$/ && in_block { exit }
+            in_block { print }
+          ' > /tmp/cve-fix.patch
+
+          if [ ! -s /tmp/cve-fix.patch ]; then
+            echo "::error::Patch block was empty — the marker comment may be the 'too large' fallback variant."
+            echo "Look for a GitLab artifact link inside the comment and fetch it manually."
+            echo "$COMMENT_BODY" | grep -oE 'https://gitlab-master[^)[:space:]]+' || true
+            exit 1
+          fi
+
+          echo "Extracted patch: $(wc -c < /tmp/cve-fix.patch) bytes"
+
+      - name: Apply patch to develop
+        run: |
+          set -euo pipefail
+          git apply --3way /tmp/cve-fix.patch
+          echo "Files modified:"
+          git status --porcelain
+
+      - name: Create signed commit, push branch, open PR
+        run: bash .github/scripts/cve-create-pr.sh
+        env:
+          PATCH_FILE: /tmp/cve-fix.patch


### PR DESCRIPTION
## Why this PR targets `main`

GitHub Actions' `workflow_dispatch` requires the workflow file on the **default branch** (which is `main` for this repo). Last night, PR #636 landed the Phase-3 nightly-CVE flow on `develop` — but the manually-clicked "Create PR" button on Issue #617 won't fire until the workflow file is also on `main`.

This PR mirrors only the two GHA pieces onto `main`. The cve-post script stays on `develop` (GitLab clones it from there).

## Files added

| File | Role |
|---|---|
| `.github/workflows/cve-create-pr.yml` | `workflow_dispatch` entry point. Runs on `blueprints-skills-eval-runner`. Reads the marker comment on #617, applies the patch to develop, hands off to the script |
| `.github/scripts/cve-create-pr.sh` | Git Data API dance: blobs → tree → commit → ref → PR. Idempotent on same-day re-clicks |

Same content as the develop-side files merged in #636 — no functional changes, just relocated for the dispatch requirement.

## Verification done before this PR

| Item | Method | Outcome |
|---|---|---|
| Bash/YAML syntax | shellcheck + python yaml parse | clean |
| Mock-test of the 8-call Git Data API sequence | local mocked gh | passes |
| Runner reachability (`blueprints-skills-eval-runner`) | live probe — reaches `gitlab-master.nvidia.com` + `api.github.com` | confirmed |
| `gh` CLI install pattern (runner has no `gh` pre-installed) | live probe v2 — tarball-to-RUNNER_TEMP/bin works | confirmed |

## Remaining live-test items (will run after this merges)

- First end-to-end `workflow_dispatch` execution against a real marker comment on #617
- Patch extraction via real `gh api` (not mocked) — minor risk on awk pattern matching real Markdown
- Branch + PR creation via Git Data API end-to-end

## How to test after merge

1. Wait for tonight's GitLab `cve-scan` (or trigger pipeline manually) — produces a marker comment with the patch on #617
2. On #617, click **🚀 Create PR from these fixes** → opens the Actions UI
3. Click **Run workflow** → check that a PR opens against `develop` with a signed commit

If anything fails, follow-up commits go on this branch (workflow infra) or via another PR to `develop` (cve-post script changes).

## Related

- Plan: `/Users/ricsingh/.claude/plans/optimized-pondering-stallman.md`
- Tracker Issue: #617
- Develop-side PR: #636