### PR TITLE
Helm: expose podAnnotations on all NIMService templates

### DIFF
--- a/deploy/helm/nvidia-blueprint-rag/templates/embedding-nim.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/templates/embedding-nim.yaml
@@ -41,6 +41,10 @@ spec:
     nimCache:
       name: {{ $nimModel.service.name }}-cache
   replicas: {{ $nimModel.replicas | default 1 }}
+  {{- with $nimModel.podAnnotations }}
+  podAnnotations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
   {{- with $nimModel.nodeSelector }}
   nodeSelector:
 {{ toYaml . | nindent 4 }}

--- a/deploy/helm/nvidia-blueprint-rag/templates/llm-nim.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/templates/llm-nim.yaml
@@ -43,6 +43,10 @@ spec:
   env:
 {{ toYaml $nimLlm.env | nindent 4 }}
   replicas: {{ $nimLlm.replicas | default 1 }}
+  {{- with $nimLlm.podAnnotations }}
+  podAnnotations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
   {{- with $nimLlm.nodeSelector }}
   nodeSelector:
 {{ toYaml . | nindent 4 }}

--- a/deploy/helm/nvidia-blueprint-rag/templates/reranking-nim.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/templates/reranking-nim.yaml
@@ -41,6 +41,10 @@ spec:
     nimCache:
       name: {{ $nimModel.service.name }}-cache
   replicas: {{ $nimModel.replicas | default 1 }}
+  {{- with $nimModel.podAnnotations }}
+  podAnnotations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
   {{- with $nimModel.nodeSelector }}
   nodeSelector:
 {{ toYaml . | nindent 4 }}

--- a/deploy/helm/nvidia-blueprint-rag/templates/vlm-captioning-nim.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/templates/vlm-captioning-nim.yaml
@@ -40,6 +40,10 @@ spec:
   env:
 {{ toYaml $nimVlmCaptioning.env | nindent 4 }}
   replicas: {{ $nimVlmCaptioning.replicas | default 1 }}
+  {{- with $nimVlmCaptioning.podAnnotations }}
+  podAnnotations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
   {{- with $nimVlmCaptioning.nodeSelector }}
   nodeSelector:
 {{ toYaml . | nindent 4 }}

--- a/deploy/helm/nvidia-blueprint-rag/templates/vlm-embed-nim.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/templates/vlm-embed-nim.yaml
@@ -37,6 +37,10 @@ spec:
     nimCache:
       name: {{ $nimModel.service.name }}-cache
   replicas: {{ $nimModel.replicas | default 1 }}
+  {{- with $nimModel.podAnnotations }}
+  podAnnotations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
   {{- with $nimModel.nodeSelector }}
   nodeSelector:
 {{ toYaml . | nindent 4 }}

--- a/deploy/helm/nvidia-blueprint-rag/templates/vlm-nim.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/templates/vlm-nim.yaml
@@ -40,6 +40,10 @@ spec:
   env:
 {{ toYaml $nimVlm.env | nindent 4 }}
   replicas: {{ $nimVlm.replicas | default 1 }}
+  {{- with $nimVlm.podAnnotations }}
+  podAnnotations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
   {{- with $nimVlm.nodeSelector }}
   nodeSelector:
 {{ toYaml . | nindent 4 }}

--- a/deploy/helm/nvidia-blueprint-rag/templates/vlm-reranker-nim.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/templates/vlm-reranker-nim.yaml
@@ -37,6 +37,10 @@ spec:
     nimCache:
       name: {{ $nimModel.service.name }}-cache
   replicas: {{ $nimModel.replicas | default 1 }}
+  {{- with $nimModel.podAnnotations }}
+  podAnnotations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
   {{- with $nimModel.nodeSelector }}
   nodeSelector:
 {{ toYaml . | nindent 4 }}

--- a/deploy/helm/nvidia-blueprint-rag/values.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/values.yaml
@@ -789,6 +789,12 @@ nimOperator:
   nim-llm:
     enabled: true
     replicas: 1
+    # -- Annotations applied to NIM pods (propagated via NIMService.spec.podAnnotations).
+    # Useful for integrations like Runai fractional GPUs, e.g.:
+    #   podAnnotations:
+    #     gpu-fraction: "0.25"
+    #     gpu-fraction-num-devices: "1"
+    podAnnotations: {}
     service:
       name: "nim-llm"
     image:
@@ -882,6 +888,9 @@ nimOperator:
   nvidia-nim-llama-nemotron-embed-1b-v2:
     enabled: false
     replicas: 1
+    # -- Annotations applied to NIM pods (propagated via NIMService.spec.podAnnotations).
+    # See nim-llm.podAnnotations above for a Runai fractional GPU example.
+    podAnnotations: {}
     service:
       name: "nemotron-embedding-ms"
     image:
@@ -923,6 +932,9 @@ nimOperator:
 # NIM VLM Embedding (default embedding service; aligned with envVars.APP_EMBEDDINGS_SERVERURL)
   nvidia-nim-llama-nemotron-embed-vl-1b-v2:
     enabled: true
+    # -- Annotations applied to NIM pods (propagated via NIMService.spec.podAnnotations).
+    # See nim-llm.podAnnotations above for a Runai fractional GPU example.
+    podAnnotations: {}
     service:
       name: "nemotron-vlm-embedding-ms"
     image:
@@ -961,6 +973,9 @@ nimOperator:
   nvidia-nim-llama-nemotron-rerank-1b-v2:
     enabled: true
     replicas: 1
+    # -- Annotations applied to NIM pods (propagated via NIMService.spec.podAnnotations).
+    # See nim-llm.podAnnotations above for a Runai fractional GPU example.
+    podAnnotations: {}
     service:
       name: "nemotron-ranking-ms"
     image:
@@ -995,6 +1010,9 @@ nimOperator:
   nvidia-nim-llama-nemotron-rerank-vl-1b-v2:
     enabled: false
     replicas: 1
+    # -- Annotations applied to NIM pods (propagated via NIMService.spec.podAnnotations).
+    # See nim-llm.podAnnotations above for a Runai fractional GPU example.
+    podAnnotations: {}
     service:
       name: "nemotron-ranking-vl-ms"
     image:
@@ -1029,6 +1047,9 @@ nimOperator:
   nim-vlm:
     enabled: false
     replicas: 1
+    # -- Annotations applied to NIM pods (propagated via NIMService.spec.podAnnotations).
+    # See nim-llm.podAnnotations above for a Runai fractional GPU example.
+    podAnnotations: {}
     service:
       name: "nim-vlm"
     image:
@@ -1063,6 +1084,9 @@ nimOperator:
   nim-vlm-captioning:
     enabled: false
     replicas: 1
+    # -- Annotations applied to NIM pods (propagated via NIMService.spec.podAnnotations).
+    # See nim-llm.podAnnotations above for a Runai fractional GPU example.
+    podAnnotations: {}
     service:
       name: "nim-vlm-captioning"
     image:


### PR DESCRIPTION
Plumb a per-NIM podAnnotations field from values.yaml through to NIMService.spec.podAnnotations so users can attach pod-level annotations to NIM workloads. Default is {} (omits the field), so existing deployments render identically.

Primary motivator is Runai fractional GPU saving-mode, which requires both gpu-fraction-style annotations on the pod AND fractional GPU resources, e.g.:

  nimOperator:
    nim-llm:
      podAnnotations:
        gpu-fraction: "0.25"
        gpu-fraction-num-devices: "1"
      resources:
        limits:   { runai.com/gpu: 1 }
        requests: { runai.com/gpu: 1 }

Templates touched: llm-nim, embedding-nim, reranking-nim, vlm-nim, vlm-captioning-nim, vlm-embed-nim, vlm-reranker-nim. Each gains the podAnnotations: {} default and a usage comment in values.yaml.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.