### PR TITLE
Helm MIG (RTX 6000): drop nim-llm gpus product selector

### DIFF
--- a/deploy/helm/mig-slicing/values-mig-rtx6000.yaml
+++ b/deploy/helm/mig-slicing/values-mig-rtx6000.yaml
@@ -94,8 +94,6 @@ nimOperator:
       engine: vllm
       precision: "fp8"
       tensorParallelism: "2"
-      gpus:
-        - product: "rtx6000_blackwell_sv"
 
   # VLM Embedding (default) — uses 1g.24gb on GPU 3
   nvidia-nim-llama-nemotron-embed-vl-1b-v2:


### PR DESCRIPTION
Remove the `gpus: [- product: "rtx6000_blackwell_sv"]` selector from nimOperator.nim-llm.model. The remaining engine/precision/tensorParallelism (vllm / fp8 / tp2) already matches profile a89dbe9e… on its own, and keeping the product selector was over-constraining model selection without adding correctness.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.