### PR TITLE
chore(release-v2.6.0): cherry-pick latest develop Helm MIG fix

### DIFF
--- a/deploy/helm/mig-slicing/values-mig-rtx6000.yaml
+++ b/deploy/helm/mig-slicing/values-mig-rtx6000.yaml
@@ -94,8 +94,6 @@ nimOperator:
       engine: vllm
       precision: "fp8"
       tensorParallelism: "2"
-      gpus:
-        - product: "rtx6000_blackwell_sv"
 
   # VLM Embedding (default) — uses 1g.24gb on GPU 3
   nvidia-nim-llama-nemotron-embed-vl-1b-v2:


### PR DESCRIPTION
## Summary
- Cherry-pick the latest `origin/develop` change into `release-v2.6.0`.
- Backports PR #648: remove the over-constraining `rtx6000_blackwell_sv` GPU product selector from the RTX 6000 MIG Helm values.

## Details
- Source commit: b35976dba1f5961eda65a85e1a2763d0ba507526
- Cherry-pick commit: 8e984b50081c29681983bbc757816ec6a61af548
- Target branch: `release-v2.6.0`

## Testing
- Not run; config-only Helm values change.