### PR TITLE
ci(cve): GitHub App auth in cve-post + edit-in-place compare-URL comment

### DIFF
--- a/.github/workflows/cve-create-pr.yml
+++ b/.github/workflows/cve-create-pr.yml
@@ -128,14 +128,18 @@ jobs:
         # notification and can open the PR in one click — without having
         # to hunt for the link in the workflow's Summary tab.
         #
-        # Append-only by design: each run leaves its own comment so the
-        # timeline shows "branch X ready" history. Cheap, harmless.
+        # Edit-in-place via marker: a single rolling comment tagged with
+        # <!-- cve-bot-compare-url --> is updated on every run. Same
+        # pattern as ci/post-cve-report.sh uses for <!-- cve-bot-patch -->.
+        # Avoids timeline noise from append-only history (one comment per
+        # branch per click); the prior-run history is still recoverable
+        # from `git branch -r | grep cve-fix/nightly-`.
         if: steps.create.outputs.compare_url != ''
         env:
           COMPARE_URL: ${{ steps.create.outputs.compare_url }}
           BRANCH: ${{ steps.create.outputs.branch_name }}
           COMMIT: ${{ steps.create.outputs.commit_sha }}
-        # Defensive: drop `|| true`-style swallowing — if the comment fails
+        # Defensive: drop `|| true`-style swallowing — if the write fails
         # (e.g., issues:write blocked by org policy after all), we want the
         # workflow to surface that. The branch + commit are still pushed
         # and the URL appears in the workflow Summary, so the maintainer
@@ -144,7 +148,11 @@ jobs:
         # Heredoc body avoids apostrophes to stay portable across bash
         # versions (bash 3.2 misparses `'s` inside $(cat <<EOF)).
         run: |
-          gh issue comment "${TRACKER_ISSUE}" --repo "${REPO}" --body "$(cat <<EOF
+          set -euo pipefail
+
+          MARKER='<!-- cve-bot-compare-url -->'
+          BODY="$(cat <<EOF
+          ${MARKER}
           ✅ **CVE auto-fix branch ready** — \`${BRANCH}\` (commit \`${COMMIT:0:8}\`, Verified ✓)
 
           **[➜ Open Pull Request](${COMPARE_URL})**
@@ -152,3 +160,19 @@ jobs:
           _Clicking opens the GitHub compare view with title and body pre-filled. Review the diff, then click **Create pull request**._
           EOF
           )"
+
+          EXISTING_ID="$(
+            gh api "/repos/${REPO}/issues/${TRACKER_ISSUE}/comments" \
+              --paginate \
+              --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" \
+              2>/dev/null | head -1 || true
+          )"
+
+          if [ -n "$EXISTING_ID" ]; then
+            gh api -X PATCH "/repos/${REPO}/issues/comments/${EXISTING_ID}" \
+              -f body="$BODY" --silent
+            echo "Edited existing compare-URL comment id=${EXISTING_ID}"
+          else
+            gh issue comment "${TRACKER_ISSUE}" --repo "${REPO}" --body "$BODY"
+            echo "Created new compare-URL comment (no prior marker found)"
+          fi

--- a/ci/post-cve-report.sh
+++ b/ci/post-cve-report.sh
@@ -9,8 +9,17 @@
 # reviewer verdicts, manifest diff, and the rest of _summary.md live in the
 # GitLab pipeline artifact (linked from the body). One click → full report.
 #
-# Required environment:
-#   GITHUB_PAT             Fine-grained PAT, Issues read/write on the target repo.
+# Required environment (one of two auth modes — App preferred):
+#
+#   --- App mode (preferred — bot identity, you get notifications) ---
+#   NV_RAG_CVE_BOT_APP_ID            GitHub App ID (e.g. 3902749)
+#   NV_RAG_CVE_BOT_INSTALLATION_ID   App installation ID (e.g. 136493854)
+#   NV_RAG_CVE_BOT_PRIVATE_KEY       Path to App's PEM key (GitLab File-type var)
+#
+#   --- Fallback PAT mode (used if App vars are unset) ---
+#   GITHUB_PAT                       Fine-grained PAT, Issues r/w on target repo.
+#
+#   --- Always required ---
 #   TRACKER_ISSUE_NUMBER   Issue number of "Nightly CVE Scan Tracker" (e.g. 617).
 #
 # Optional / GitLab-provided:
@@ -23,10 +32,77 @@
 
 set -euo pipefail
 
-: "${GITHUB_PAT:?GITHUB_PAT is required}"
 : "${TRACKER_ISSUE_NUMBER:?TRACKER_ISSUE_NUMBER is required}"
 GITHUB_REPO="${GITHUB_REPO:-NVIDIA-AI-Blueprints/rag}"
 REPORTS_DIR="${REPORTS_DIR:-cve-fix-reports}"
+
+# Auth: prefer the GitHub App installation token over a personal PAT.
+# When the App env vars are set, mint a short-lived (~9 min) installation
+# token via JWT signed with the App's private key, and use it as GITHUB_PAT
+# for the rest of the script.
+#
+# Why App > PAT:
+#   - Issue edits + comments are attributed to `app/nv-rag-cve-bot` instead
+#     of a human user — so the human gets notifications + no name on Issue
+#   - Token auto-expires (no rotation chore)
+#   - App permissions are pinned at registration; bounded blast radius
+#
+# Fallback path: if App vars are unset (e.g. local dev, pre-migration
+# smoke test), keep using GITHUB_PAT so nothing breaks.
+if [ -n "${NV_RAG_CVE_BOT_APP_ID:-}" ] \
+   && [ -n "${NV_RAG_CVE_BOT_INSTALLATION_ID:-}" ] \
+   && [ -n "${NV_RAG_CVE_BOT_PRIVATE_KEY:-}" ]; then
+  echo "Auth: minting App installation token (app id ${NV_RAG_CVE_BOT_APP_ID})…"
+  GITHUB_PAT="$(python3 - <<'PY'
+import json, os, sys, time, base64, urllib.request, urllib.error
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+
+app_id   = os.environ["NV_RAG_CVE_BOT_APP_ID"]
+inst_id  = os.environ["NV_RAG_CVE_BOT_INSTALLATION_ID"]
+key_path = os.environ["NV_RAG_CVE_BOT_PRIVATE_KEY"]   # GitLab File var = path on disk
+
+with open(key_path, "rb") as fh:
+    pk = serialization.load_pem_private_key(fh.read(), password=None)
+
+now = int(time.time())
+header  = {"typ": "JWT", "alg": "RS256"}
+payload = {"iat": now - 60, "exp": now + 540, "iss": app_id}
+
+def b64(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+signing_input = (
+    b64(json.dumps(header,  separators=(",", ":")).encode()) + "." +
+    b64(json.dumps(payload, separators=(",", ":")).encode())
+)
+sig = pk.sign(signing_input.encode(), padding.PKCS1v15(), hashes.SHA256())
+jwt_token = signing_input + "." + b64(sig)
+
+req = urllib.request.Request(
+    f"https://api.github.com/app/installations/{inst_id}/access_tokens",
+    method="POST",
+    headers={
+        "Authorization": f"Bearer {jwt_token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    },
+)
+try:
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        print(json.loads(resp.read())["token"])
+except urllib.error.HTTPError as e:
+    sys.stderr.write(f"App token mint failed: HTTP {e.code} {e.reason}\n")
+    sys.stderr.write(e.read().decode("utf-8", "replace") + "\n")
+    sys.exit(1)
+PY
+)"
+  export GITHUB_PAT
+  echo "Auth: using App identity (app/nv-rag-cve-bot)."
+else
+  : "${GITHUB_PAT:?Either NV_RAG_CVE_BOT_* (preferred) or GITHUB_PAT must be set}"
+  echo "Auth: WARN — App vars unset, falling back to GITHUB_PAT (personal user)."
+fi
 
 DATE_UTC="$(date -u +%Y-%m-%d)"
 TIMESTAMP_UTC="$(date -u +'%Y-%m-%d %H:%M UTC')"


### PR DESCRIPTION
## Summary

Two related improvements to the nightly CVE pipeline's interaction with Issue #617:

1. **App auth in `cve-post`** (`ci/post-cve-report.sh`) — migrate from personal PAT to the `nv-rag-cve-bot` GitHub App for writes to Issue #617. Removes "Last edited by" personal-name attribution from the rolling tracker body and enables maintainer notifications (GitHub does not notify a user about their own actions; an App is a separate principal).

2. **Edit-in-place compare-URL comment** (`.github/workflows/cve-create-pr.yml`) — replace the append-only "Notify Issue with compare URL" step with a rolling comment tagged by `<!-- cve-bot-compare-url -->`. Same pattern that `ci/post-cve-report.sh` already uses for the `<!-- cve-bot-patch -->` marker. One rolling comment instead of one-per-click-per-branch.

## Change 1: App auth

Code change: when `NV_RAG_CVE_BOT_APP_ID`, `NV_RAG_CVE_BOT_INSTALLATION_ID`, and `NV_RAG_CVE_BOT_PRIVATE_KEY` are set, `ci/post-cve-report.sh` mints a short-lived (~9 min) installation token via RS256 JWT signing and uses it in place of `GITHUB_PAT`. Backwards-compatible fallback to `GITHUB_PAT` if App vars are unset.

The companion GitLab CI change (`apk add python3 py3-cryptography` in `cve-post` + `cve-smoke-test`) is already on the `ci/nightly-cve` branch of `chat-labs/OpenSource/rag` (commit `8edfa6e`).

**App setup (done):**
- App: `nv-rag-cve-bot` (id `3902749`), owned by `NVIDIA-AI-Blueprints` org
- Installation: scoped to `NVIDIA-AI-Blueprints/rag` only
- Permissions: `contents:write`, `issues:write`, `metadata:read`, `pull_requests:write`
- Webhook: disabled
- GitLab CI/CD vars (project-level, `chat-labs/OpenSource/rag`) — added

## Change 2: Edit-in-place comment

**Before:** each successful `workflow_dispatch` click leaves a new comment on Issue #617:
- Same-day re-runs ⇒ duplicate comments (same branch, different commits — earlier SHAs go stale once branch is force-updated)
- 30 nightlies + clicks ⇒ 30+ `github-actions[bot]` comments in the timeline

**After:** one rolling comment, updated in place:
- Same-day re-runs ⇒ silent overwrite, label always matches branch tip
- Multi-day runs ⇒ comment shows latest branch only; older branches still in Git (`git branch -r | grep cve-fix/nightly-`)

## Test plan

- [x] `bash -n`, `shellcheck`, `python3 ast.parse`, `yaml.safe_load` — all clean
- [x] JWT structure validated against a throwaway RSA key
- [x] Live App token mint verified: permissions match plan exactly, scoped to this repo only, token can read Issue #617
- [x] Stub-`gh` end-to-end run of `ci/post-cve-report.sh` — body construction, marker comment, triage link rewrite, reopen, edit all correct
- [x] Real write test on Issue #617: POST comment as App → `user.login='nv-rag-cve-bot[bot]'`, `user.type='Bot'` → DELETE → 404
- [x] `cve-create-pr.yml` extracted `run:` script bash-syntax-clean
- [ ] After merge + pull-mirror sync (~30 min), GitLab `JOB=smoke-test` pipeline → Issue body edit attributes to `app/nv-rag-cve-bot`
- [ ] After merge + a future workflow_dispatch click → new rolling comment appears with marker; second click → existing comment edited (not duplicated)
- [ ] Cleanup of 3 pre-existing `github-actions[bot]` comments on #617 — handled separately after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)