### PR TITLE
ci(cve): edit-in-place compare-URL comment on Issue #617 (no more dupes)

### DIFF
--- a/.github/workflows/cve-create-pr.yml
+++ b/.github/workflows/cve-create-pr.yml
@@ -128,14 +128,18 @@ jobs:
         # notification and can open the PR in one click — without having
         # to hunt for the link in the workflow's Summary tab.
         #
-        # Append-only by design: each run leaves its own comment so the
-        # timeline shows "branch X ready" history. Cheap, harmless.
+        # Edit-in-place via marker: a single rolling comment tagged with
+        # <!-- cve-bot-compare-url --> is updated on every run. Same
+        # pattern as ci/post-cve-report.sh uses for <!-- cve-bot-patch -->.
+        # Avoids timeline noise from append-only history (one comment per
+        # branch per click); the prior-run history is still recoverable
+        # from `git branch -r | grep cve-fix/nightly-`.
         if: steps.create.outputs.compare_url != ''
         env:
           COMPARE_URL: ${{ steps.create.outputs.compare_url }}
           BRANCH: ${{ steps.create.outputs.branch_name }}
           COMMIT: ${{ steps.create.outputs.commit_sha }}
-        # Defensive: drop `|| true`-style swallowing — if the comment fails
+        # Defensive: drop `|| true`-style swallowing — if the write fails
         # (e.g., issues:write blocked by org policy after all), we want the
         # workflow to surface that. The branch + commit are still pushed
         # and the URL appears in the workflow Summary, so the maintainer
@@ -144,7 +148,11 @@ jobs:
         # Heredoc body avoids apostrophes to stay portable across bash
         # versions (bash 3.2 misparses `'s` inside $(cat <<EOF)).
         run: |
-          gh issue comment "${TRACKER_ISSUE}" --repo "${REPO}" --body "$(cat <<EOF
+          set -euo pipefail
+
+          MARKER='<!-- cve-bot-compare-url -->'
+          BODY="$(cat <<EOF
+          ${MARKER}
           ✅ **CVE auto-fix branch ready** — \`${BRANCH}\` (commit \`${COMMIT:0:8}\`, Verified ✓)
 
           **[➜ Open Pull Request](${COMPARE_URL})**
@@ -152,3 +160,19 @@ jobs:
           _Clicking opens the GitHub compare view with title and body pre-filled. Review the diff, then click **Create pull request**._
           EOF
           )"
+
+          EXISTING_ID="$(
+            gh api "/repos/${REPO}/issues/${TRACKER_ISSUE}/comments" \
+              --paginate \
+              --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" \
+              2>/dev/null | head -1 || true
+          )"
+
+          if [ -n "$EXISTING_ID" ]; then
+            gh api -X PATCH "/repos/${REPO}/issues/comments/${EXISTING_ID}" \
+              -f body="$BODY" --silent
+            echo "Edited existing compare-URL comment id=${EXISTING_ID}"
+          else
+            gh issue comment "${TRACKER_ISSUE}" --repo "${REPO}" --body "$BODY"
+            echo "Created new compare-URL comment (no prior marker found)"
+          fi


### PR DESCRIPTION
## Summary

Replace the append-only "Notify Issue with compare URL" step in `cve-create-pr.yml` with an edit-in-place rolling comment, tagged by `<!-- cve-bot-compare-url -->`. Same pattern that `ci/post-cve-report.sh` already uses for the `<!-- cve-bot-patch -->` marker.

Independent of #650 (App auth migration) — purely a UX cleanup of an existing workflow.

## Before

Each successful `workflow_dispatch` click leaves a new comment on Issue #617:
- Same-day re-runs ⇒ duplicate comments (same branch, different commits — earlier SHAs go stale once branch is force-updated)
- 30 nightlies + clicks ⇒ 30+ `github-actions[bot]` comments in the timeline

## After

One rolling comment, updated in place:
- Same-day re-runs ⇒ silent overwrite, label always matches branch tip
- Multi-day runs ⇒ comment shows latest branch only; older branches still in Git (`git branch -r | grep cve-fix/nightly-`)

## What stays the same

- The compare URL itself, the body text, the `Verified ✓` callout
- The `if: steps.create.outputs.compare_url != ''` gate
- The `set -euo pipefail` semantics (no `|| true` swallowing on the write itself)

## Test plan

- [x] YAML parses cleanly
- [x] `bash -n` clean on the extracted `run:` script
- [ ] After merge + a future workflow_dispatch click, verify the new comment appears with the marker
- [ ] After a second click (any day), verify the existing comment is *edited* (not duplicated)
- [ ] Cleanup of the 3 pre-existing `github-actions[bot]` comments on #617 — handled separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)