### PR TITLE
ci(cve-pr): mirror edit-in-place compare-URL comment to main

### DIFF
--- a/.github/workflows/cve-create-pr.yml
+++ b/.github/workflows/cve-create-pr.yml
@@ -128,14 +128,18 @@ jobs:
         # notification and can open the PR in one click — without having
         # to hunt for the link in the workflow's Summary tab.
         #
-        # Append-only by design: each run leaves its own comment so the
-        # timeline shows "branch X ready" history. Cheap, harmless.
+        # Edit-in-place via marker: a single rolling comment tagged with
+        # <!-- cve-bot-compare-url --> is updated on every run. Same
+        # pattern as ci/post-cve-report.sh uses for <!-- cve-bot-patch -->.
+        # Avoids timeline noise from append-only history (one comment per
+        # branch per click); the prior-run history is still recoverable
+        # from `git branch -r | grep cve-fix/nightly-`.
         if: steps.create.outputs.compare_url != ''
         env:
           COMPARE_URL: ${{ steps.create.outputs.compare_url }}
           BRANCH: ${{ steps.create.outputs.branch_name }}
           COMMIT: ${{ steps.create.outputs.commit_sha }}
-        # Defensive: drop `|| true`-style swallowing — if the comment fails
+        # Defensive: drop `|| true`-style swallowing — if the write fails
         # (e.g., issues:write blocked by org policy after all), we want the
         # workflow to surface that. The branch + commit are still pushed
         # and the URL appears in the workflow Summary, so the maintainer
@@ -144,7 +148,11 @@ jobs:
         # Heredoc body avoids apostrophes to stay portable across bash
         # versions (bash 3.2 misparses `'s` inside $(cat <<EOF)).
         run: |
-          gh issue comment "${TRACKER_ISSUE}" --repo "${REPO}" --body "$(cat <<EOF
+          set -euo pipefail
+
+          MARKER='<!-- cve-bot-compare-url -->'
+          BODY="$(cat <<EOF
+          ${MARKER}
           ✅ **CVE auto-fix branch ready** — \`${BRANCH}\` (commit \`${COMMIT:0:8}\`, Verified ✓)
 
           **[➜ Open Pull Request](${COMPARE_URL})**
@@ -152,3 +160,19 @@ jobs:
           _Clicking opens the GitHub compare view with title and body pre-filled. Review the diff, then click **Create pull request**._
           EOF
           )"
+
+          EXISTING_ID="$(
+            gh api "/repos/${REPO}/issues/${TRACKER_ISSUE}/comments" \
+              --paginate \
+              --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" \
+              2>/dev/null | head -1 || true
+          )"
+
+          if [ -n "$EXISTING_ID" ]; then
+            gh api -X PATCH "/repos/${REPO}/issues/comments/${EXISTING_ID}" \
+              -f body="$BODY" --silent
+            echo "Edited existing compare-URL comment id=${EXISTING_ID}"
+          else
+            gh issue comment "${TRACKER_ISSUE}" --repo "${REPO}" --body "$BODY"
+            echo "Created new compare-URL comment (no prior marker found)"
+          fi


### PR DESCRIPTION
## Summary

Mirror to `main` of the edit-in-place compare-URL comment fix from #650 (develop). Keeps the `cve-create-pr.yml` workflow consistent across branches so a `workflow_dispatch` run from either branch produces the same behavior — one rolling `<!-- cve-bot-compare-url -->` comment on Issue #617 instead of one new comment per click.

Same pattern as the previous mirror (#643 → main), single cherry-pick from develop's commit \`38b0c5e\`.

## Change

Replace the append-only \`gh issue comment\` call in the "Notify Issue with compare URL" step with find-existing-marker-then-PATCH-or-POST logic. Same pattern that \`ci/post-cve-report.sh\` already uses for the \`<!-- cve-bot-patch -->\` marker.

## Test plan

- [x] YAML parses cleanly on the cherry-picked file
- [x] \`bash -n\` clean on the extracted \`run:\` script
- [x] Stub-\`gh\` end-to-end run of the new logic — both branches verified (create-new path + edit-existing path) on develop side (covered in #650)
- [ ] After merge, a future workflow_dispatch run from \`main\` produces a single rolling comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)