### PR TITLE
[codex] fix guardrails output streaming

### DIFF
--- a/deploy/compose/nemoguardrails/config-store/nemoguard/config.yml
+++ b/deploy/compose/nemoguardrails/config-store/nemoguard/config.yml
@@ -17,5 +17,7 @@ rails:
       - content safety check input $model=content_safety
       - topic safety check input $model=topic_control
   output:
+    streaming:
+      enabled: true
     flows:
       - content safety check output $model=content_safety

--- a/docs/nemo-guardrails.md
+++ b/docs/nemo-guardrails.md
@@ -72,6 +72,10 @@ To deploy all guardrails services on your own dedicated hardware, use the follow
    # export NIM_ENDPOINT_URL=<your-custom-nim-endpoint-url>
    ```
 
+   If the RAG server uses a custom on-prem LLM endpoint through
+   `APP_LLM_SERVERURL`, set `NIM_ENDPOINT_URL` for the Guardrails microservice to
+   the same OpenAI-compatible base URL ending in `/v1`.
+
 2. Set the environment variable to enable guardrails by running the following code.
 
     ```bash
@@ -202,6 +206,37 @@ If you are using notebooks or APIs to interact directly with `rag-server`, set `
 
 
 ## Troubleshooting
+
+### `stream_async()` Error with Output Rails
+
+The RAG server streams responses by default. If NeMo Guardrails is enabled with
+output rails, the active Guardrails configuration must also enable streaming for
+output rails. Otherwise, the Guardrails microservice can log the following error:
+
+```text
+stream_async() cannot be used when output rails are configured but rails.output.streaming.enabled is False
+```
+
+For self-hosted Guardrails, verify that
+`deploy/compose/nemoguardrails/config-store/nemoguard/config.yml` includes:
+
+```yaml
+rails:
+  output:
+    streaming:
+      enabled: true
+```
+
+After updating the file, restart the Guardrails microservice:
+
+```bash
+docker compose -f deploy/compose/docker-compose-nemo-guardrails.yaml up -d --no-deps nemo-guardrails-microservice
+```
+
+The `Failed to export traces to localhost:4317` messages are OpenTelemetry
+export warnings. They do not cause the `stream_async()` failure. Start the
+observability profile or disable trace export if you want to remove those
+warnings.
 
 ### GPU Device ID Issues
 

--- a/tests/unit/test_guardrails_config.py
+++ b/tests/unit/test_guardrails_config.py
@@ -1,0 +1,28 @@
+"""Checks for deployable NeMo Guardrails configurations."""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GUARDRAILS_CONFIG_DIR = (
+    REPO_ROOT / "deploy/compose/nemoguardrails/config-store"
+)
+
+
+def _load_config(config_name: str) -> dict[str, Any]:
+    config_path = GUARDRAILS_CONFIG_DIR / config_name / "config.yml"
+    with config_path.open(encoding="utf-8") as config_file:
+        return yaml.safe_load(config_file)
+
+
+def test_guardrails_output_rails_enable_streaming() -> None:
+    """RAG server streams by default, so output rails must support streaming."""
+    for config_name in ("nemoguard", "nemoguard_cloud"):
+        config = _load_config(config_name)
+
+        assert (
+            config["rails"]["output"]["streaming"]["enabled"] is True
+        ), f"{config_name} must enable rails.output.streaming"


### PR DESCRIPTION
## Summary

- Enable `rails.output.streaming.enabled` for the self-hosted `nemoguard` config.
- Document the `stream_async()` failure mode and the restart step for the Guardrails microservice.
- Note that custom on-prem LLM deployments must set `NIM_ENDPOINT_URL` for the Guardrails microservice separately from the RAG server endpoint.
- Add a unit test that keeps both self-hosted and cloud Guardrails configs compatible with the RAG server streaming path.

## Root Cause

The default RAG server streams responses through the Guardrails microservice. The cloud Guardrails config already enabled output-rail streaming, but the self-hosted `nemoguard` config had output rails without `rails.output.streaming.enabled: true`, causing NeMo Guardrails to reject `stream_async()` calls.

## Validation

- `uv run pytest tests/unit/test_guardrails_config.py`
- `git diff --cached --check` before commit