### PR TITLE
[codex] Backport #645 to release-v2.6.0

### DIFF
--- a/deploy/helm/nvidia-blueprint-rag/templates/embedding-nim.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/templates/embedding-nim.yaml
@@ -41,6 +41,10 @@ spec:
     nimCache:
       name: {{ $nimModel.service.name }}-cache
   replicas: {{ $nimModel.replicas | default 1 }}
+  {{- with $nimModel.podAnnotations }}
+  podAnnotations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
   {{- with $nimModel.nodeSelector }}
   nodeSelector:
 {{ toYaml . | nindent 4 }}

--- a/deploy/helm/nvidia-blueprint-rag/templates/llm-nim.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/templates/llm-nim.yaml
@@ -43,6 +43,10 @@ spec:
   env:
 {{ toYaml $nimLlm.env | nindent 4 }}
   replicas: {{ $nimLlm.replicas | default 1 }}
+  {{- with $nimLlm.podAnnotations }}
+  podAnnotations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
   {{- with $nimLlm.nodeSelector }}
   nodeSelector:
 {{ toYaml . | nindent 4 }}

--- a/deploy/helm/nvidia-blueprint-rag/templates/reranking-nim.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/templates/reranking-nim.yaml
@@ -41,6 +41,10 @@ spec:
     nimCache:
       name: {{ $nimModel.service.name }}-cache
   replicas: {{ $nimModel.replicas | default 1 }}
+  {{- with $nimModel.podAnnotations }}
+  podAnnotations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
   {{- with $nimModel.nodeSelector }}
   nodeSelector:
 {{ toYaml . | nindent 4 }}

--- a/deploy/helm/nvidia-blueprint-rag/templates/vlm-captioning-nim.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/templates/vlm-captioning-nim.yaml
@@ -40,6 +40,10 @@ spec:
   env:
 {{ toYaml $nimVlmCaptioning.env | nindent 4 }}
   replicas: {{ $nimVlmCaptioning.replicas | default 1 }}
+  {{- with $nimVlmCaptioning.podAnnotations }}
+  podAnnotations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
   {{- with $nimVlmCaptioning.nodeSelector }}
   nodeSelector:
 {{ toYaml . | nindent 4 }}

--- a/deploy/helm/nvidia-blueprint-rag/templates/vlm-embed-nim.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/templates/vlm-embed-nim.yaml
@@ -37,6 +37,10 @@ spec:
     nimCache:
       name: {{ $nimModel.service.name }}-cache
   replicas: {{ $nimModel.replicas | default 1 }}
+  {{- with $nimModel.podAnnotations }}
+  podAnnotations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
   {{- with $nimModel.nodeSelector }}
   nodeSelector:
 {{ toYaml . | nindent 4 }}

--- a/deploy/helm/nvidia-blueprint-rag/templates/vlm-nim.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/templates/vlm-nim.yaml
@@ -40,6 +40,10 @@ spec:
   env:
 {{ toYaml $nimVlm.env | nindent 4 }}
   replicas: {{ $nimVlm.replicas | default 1 }}
+  {{- with $nimVlm.podAnnotations }}
+  podAnnotations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
   {{- with $nimVlm.nodeSelector }}
   nodeSelector:
 {{ toYaml . | nindent 4 }}

--- a/deploy/helm/nvidia-blueprint-rag/templates/vlm-reranker-nim.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/templates/vlm-reranker-nim.yaml
@@ -37,6 +37,10 @@ spec:
     nimCache:
       name: {{ $nimModel.service.name }}-cache
   replicas: {{ $nimModel.replicas | default 1 }}
+  {{- with $nimModel.podAnnotations }}
+  podAnnotations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
   {{- with $nimModel.nodeSelector }}
   nodeSelector:
 {{ toYaml . | nindent 4 }}

--- a/deploy/helm/nvidia-blueprint-rag/values.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/values.yaml
@@ -789,6 +789,12 @@ nimOperator:
   nim-llm:
     enabled: true
     replicas: 1
+    # -- Annotations applied to NIM pods (propagated via NIMService.spec.podAnnotations).
+    # Useful for integrations like Runai fractional GPUs, e.g.:
+    #   podAnnotations:
+    #     gpu-fraction: "0.25"
+    #     gpu-fraction-num-devices: "1"
+    podAnnotations: {}
     service:
       name: "nim-llm"
     image:
@@ -882,6 +888,9 @@ nimOperator:
   nvidia-nim-llama-nemotron-embed-1b-v2:
     enabled: false
     replicas: 1
+    # -- Annotations applied to NIM pods (propagated via NIMService.spec.podAnnotations).
+    # See nim-llm.podAnnotations above for a Runai fractional GPU example.
+    podAnnotations: {}
     service:
       name: "nemotron-embedding-ms"
     image:
@@ -923,6 +932,9 @@ nimOperator:
 # NIM VLM Embedding (default embedding service; aligned with envVars.APP_EMBEDDINGS_SERVERURL)
   nvidia-nim-llama-nemotron-embed-vl-1b-v2:
     enabled: true
+    # -- Annotations applied to NIM pods (propagated via NIMService.spec.podAnnotations).
+    # See nim-llm.podAnnotations above for a Runai fractional GPU example.
+    podAnnotations: {}
     service:
       name: "nemotron-vlm-embedding-ms"
     image:
@@ -961,6 +973,9 @@ nimOperator:
   nvidia-nim-llama-nemotron-rerank-1b-v2:
     enabled: true
     replicas: 1
+    # -- Annotations applied to NIM pods (propagated via NIMService.spec.podAnnotations).
+    # See nim-llm.podAnnotations above for a Runai fractional GPU example.
+    podAnnotations: {}
     service:
       name: "nemotron-ranking-ms"
     image:
@@ -995,6 +1010,9 @@ nimOperator:
   nvidia-nim-llama-nemotron-rerank-vl-1b-v2:
     enabled: false
     replicas: 1
+    # -- Annotations applied to NIM pods (propagated via NIMService.spec.podAnnotations).
+    # See nim-llm.podAnnotations above for a Runai fractional GPU example.
+    podAnnotations: {}
     service:
       name: "nemotron-ranking-vl-ms"
     image:
@@ -1029,6 +1047,9 @@ nimOperator:
   nim-vlm:
     enabled: false
     replicas: 1
+    # -- Annotations applied to NIM pods (propagated via NIMService.spec.podAnnotations).
+    # See nim-llm.podAnnotations above for a Runai fractional GPU example.
+    podAnnotations: {}
     service:
       name: "nim-vlm"
     image:
@@ -1063,6 +1084,9 @@ nimOperator:
   nim-vlm-captioning:
     enabled: false
     replicas: 1
+    # -- Annotations applied to NIM pods (propagated via NIMService.spec.podAnnotations).
+    # See nim-llm.podAnnotations above for a Runai fractional GPU example.
+    podAnnotations: {}
     service:
       name: "nim-vlm-captioning"
     image:


### PR DESCRIPTION
## Summary

Backports NVIDIA-AI-Blueprints/rag#645 onto `release-v2.6.0`.

This cherry-picks `ab4cddf430a7d8c8e3e05c2e64685ad5aeeaf1e3` to expose per-NIM `podAnnotations` in the Helm chart NIMService templates and adds default/commented values entries for each affected NIM.

## Validation

- `git diff --check origin/release-v2.6.0..HEAD`
- `helm lint deploy/helm/nvidia-blueprint-rag` (passes; Helm reports the existing warning that dependency charts are not vendored)

`helm template` could not be completed in this checkout because the chart dependencies are not vendored and Helm dependency fetch for `https://helm.ngc.nvidia.com/nvidia/nemo-microservices` returned `403 Forbidden`.
