### PR TITLE
chore: update blueprint container registry paths

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -194,6 +194,7 @@ jobs:
 
           # Tag and push to NGC Container Registry
           echo "Pushing rag-server to NGC Container Registry..."
+          docker tag nvcr.io/nvidia/blueprint/rag-server:$TAG nvcr.io/nvstaging/blueprint/rag-server:$TAG
           docker push nvcr.io/nvstaging/blueprint/rag-server:$TAG
           docker tag nvcr.io/nvstaging/blueprint/rag-server:$TAG nvcr.io/nvstaging/blueprint/rag-server:latest
           docker push nvcr.io/nvstaging/blueprint/rag-server:latest
@@ -254,6 +255,7 @@ jobs:
 
           # Tag and push to NGC Container Registry
           echo "Pushing ingestor-server to NGC Container Registry..."
+          docker tag nvcr.io/nvidia/blueprint/ingestor-server:$TAG nvcr.io/nvstaging/blueprint/ingestor-server:$TAG
           docker push nvcr.io/nvstaging/blueprint/ingestor-server:$TAG
           docker tag nvcr.io/nvstaging/blueprint/ingestor-server:$TAG nvcr.io/nvstaging/blueprint/ingestor-server:latest
           docker push nvcr.io/nvstaging/blueprint/ingestor-server:latest
@@ -314,6 +316,7 @@ jobs:
 
           # Tag and push to NGC Container Registry
           echo "Pushing rag-frontend to NGC Container Registry..."
+          docker tag nvcr.io/nvidia/blueprint/rag-frontend:$TAG nvcr.io/nvstaging/blueprint/rag-frontend:$TAG
           docker push nvcr.io/nvstaging/blueprint/rag-frontend:$TAG
           docker tag nvcr.io/nvstaging/blueprint/rag-frontend:$TAG nvcr.io/nvstaging/blueprint/rag-frontend:latest
           docker push nvcr.io/nvstaging/blueprint/rag-frontend:latest

--- a/deploy/compose/docker-compose-ingestor-server.yaml
+++ b/deploy/compose/docker-compose-ingestor-server.yaml
@@ -3,11 +3,13 @@ services:
   # Main ingestor server which is responsible for ingestion
   ingestor-server:
     container_name: ingestor-server
-    image: nvcr.io/nvstaging/blueprint/ingestor-server:${TAG:-2.6.0}
+    image: nvcr.io/nvidia/blueprint/ingestor-server:${TAG:-2.6.0}
     build:
       # Set context to repo's root directory
       context: ../../
       dockerfile: ./src/nvidia_rag/ingestor_server/Dockerfile
+      tags:
+        - nvcr.io/nvstaging/blueprint/ingestor-server:${TAG:-2.6.0}
       args:
         DOWNLOAD_LEGAL_COMPLIANCE: ${DOWNLOAD_LEGAL_COMPLIANCE:-false}
     # start the server on port 8082 with 4 workers for improved latency on concurrent requests.

--- a/deploy/compose/docker-compose-ingestor-server.yaml
+++ b/deploy/compose/docker-compose-ingestor-server.yaml
@@ -8,8 +8,6 @@ services:
       # Set context to repo's root directory
       context: ../../
       dockerfile: ./src/nvidia_rag/ingestor_server/Dockerfile
-      tags:
-        - nvcr.io/nvstaging/blueprint/ingestor-server:${TAG:-2.6.0}
       args:
         DOWNLOAD_LEGAL_COMPLIANCE: ${DOWNLOAD_LEGAL_COMPLIANCE:-false}
     # start the server on port 8082 with 4 workers for improved latency on concurrent requests.

--- a/deploy/compose/docker-compose-rag-server.yaml
+++ b/deploy/compose/docker-compose-rag-server.yaml
@@ -3,11 +3,13 @@ services:
   # Main orchestrator server which stiches together all calls to different services to fulfill the user request
   rag-server:
     container_name: rag-server
-    image: nvcr.io/nvstaging/blueprint/rag-server:${TAG:-2.6.0}
+    image: nvcr.io/nvidia/blueprint/rag-server:${TAG:-2.6.0}
     build:
       # Set context to repo's root directory
       context: ../../
       dockerfile: src/nvidia_rag/rag_server/Dockerfile
+      tags:
+        - nvcr.io/nvstaging/blueprint/rag-server:${TAG:-2.6.0}
       args:
         DOWNLOAD_LEGAL_COMPLIANCE: ${DOWNLOAD_LEGAL_COMPLIANCE:-false}
     # start the server on port 8081 with 8 workers for improved latency on concurrent requests.
@@ -260,11 +262,13 @@ services:
   # Sample UI container which interacts with APIs exposed by rag-server container
   rag-frontend:
     container_name: rag-frontend
-    image: nvcr.io/nvstaging/blueprint/rag-frontend:${TAG:-2.6.0}
+    image: nvcr.io/nvidia/blueprint/rag-frontend:${TAG:-2.6.0}
     build:
       # Set context to repo's root directory
       context: ../../frontend
       dockerfile: ./Dockerfile
+      tags:
+        - nvcr.io/nvstaging/blueprint/rag-frontend:${TAG:-2.6.0}
       args:
         # Environment variables for Vite build
         VITE_API_CHAT_URL: ${VITE_API_CHAT_URL:-http://rag-server:8081/v1}

--- a/deploy/compose/docker-compose-rag-server.yaml
+++ b/deploy/compose/docker-compose-rag-server.yaml
@@ -8,8 +8,6 @@ services:
       # Set context to repo's root directory
       context: ../../
       dockerfile: src/nvidia_rag/rag_server/Dockerfile
-      tags:
-        - nvcr.io/nvstaging/blueprint/rag-server:${TAG:-2.6.0}
       args:
         DOWNLOAD_LEGAL_COMPLIANCE: ${DOWNLOAD_LEGAL_COMPLIANCE:-false}
     # start the server on port 8081 with 8 workers for improved latency on concurrent requests.
@@ -267,8 +265,6 @@ services:
       # Set context to repo's root directory
       context: ../../frontend
       dockerfile: ./Dockerfile
-      tags:
-        - nvcr.io/nvstaging/blueprint/rag-frontend:${TAG:-2.6.0}
       args:
         # Environment variables for Vite build
         VITE_API_CHAT_URL: ${VITE_API_CHAT_URL:-http://rag-server:8081/v1}

--- a/deploy/helm/nvidia-blueprint-rag/values.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/values.yaml
@@ -66,7 +66,7 @@ apiKeysSecret:
 
 # -- RAG server container image
 image:
-  repository: nvcr.io/nvstaging/blueprint/rag-server
+  repository: nvcr.io/nvidia/blueprint/rag-server
   tag: "2.6.0"
   pullPolicy: Always
 
@@ -340,7 +340,7 @@ ingestor-server:
     password: ""
 
   image:
-    repository: nvcr.io/nvstaging/blueprint/ingestor-server
+    repository: nvcr.io/nvidia/blueprint/ingestor-server
     tag: "2.6.0"
     pullPolicy: Always
 
@@ -554,7 +554,7 @@ frontend:
   replicaCount: 1
 
   image:
-    repository: nvcr.io/nvstaging/blueprint/rag-frontend
+    repository: nvcr.io/nvidia/blueprint/rag-frontend
     pullPolicy: IfNotPresent
     tag: "2.6.0"
 

--- a/deploy/workbench/compose.yaml
+++ b/deploy/workbench/compose.yaml
@@ -196,7 +196,7 @@ services:
   # Main ingestor server which is responsible for ingestion
   ingestor-server:
     container_name: ingestor-server
-    image: nvcr.io/nvstaging/blueprint/ingestor-server:${TAG:-2.6.0}
+    image: nvcr.io/nvidia/blueprint/ingestor-server:${TAG:-2.6.0}
     build:
       # Set context to repo's root directory
       context: ../../
@@ -428,7 +428,7 @@ services:
   # Main orchestrator server which stiches together all calls to different services to fulfill the user request
   rag-server:
     container_name: rag-server
-    image: nvcr.io/nvstaging/blueprint/rag-server:${TAG:-2.6.0}
+    image: nvcr.io/nvidia/blueprint/rag-server:${TAG:-2.6.0}
     build:
       # Set context to repo's root directory
       context: ../../
@@ -599,7 +599,7 @@ services:
   # Sample UI container which interacts with APIs exposed by rag-server container
   rag-frontend:
     container_name: rag-frontend
-    image: nvcr.io/nvstaging/blueprint/rag-frontend:${TAG:-2.6.0}
+    image: nvcr.io/nvidia/blueprint/rag-frontend:${TAG:-2.6.0}
     build:
       # Set context to repo's root directory
       context: ../../frontend

--- a/docs/deploy-helm-openshift.md
+++ b/docs/deploy-helm-openshift.md
@@ -194,7 +194,7 @@ To deploy the RAG Blueprint on OpenShift, use the following procedure.
     # Pull and untar the chart from NGC. The NGC package ships with the
     # nv-ingest subchart already extracted under charts/nv-ingest/, so the
     # sed below can edit the template file in place.
-    helm pull https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
+    helm pull https://helm.ngc.nvidia.com/nvidia/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
       --username '$oauthtoken' --password "$NGC_API_KEY" \
       --untar --untardir /tmp
 

--- a/docs/deploy-helm.md
+++ b/docs/deploy-helm.md
@@ -98,7 +98,7 @@ To deploy End-to-End RAG Server and Ingestor Server, use the following procedure
 2. Install the Helm chart by running the following command.
 
     ```sh
-    helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
+    helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvidia/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
     --username '$oauthtoken' \
     --password "${NGC_API_KEY}" \
     --set imagePullSecret.password=$NGC_API_KEY \
@@ -233,7 +233,7 @@ Port-forwarding is provided as a quick method to try out the UI. However, large 
 To change an existing deployment, after you modify the [`values.yaml`](../deploy/helm/nvidia-blueprint-rag/values.yaml) file, run the following code.
 
 ```sh
-helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
+helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvidia/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
 --username '$oauthtoken' \
 --password "${NGC_API_KEY}" \
 --set imagePullSecret.password=$NGC_API_KEY \

--- a/docs/mig-deployment.md
+++ b/docs/mig-deployment.md
@@ -199,7 +199,7 @@ You should see output similar to the following.
 Run the following code to install the RAG Blueprint Helm Chart.
 
 ```bash
-helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
+helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvidia/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
   --username '$oauthtoken' \
   --password "${NGC_API_KEY}" \
   --set imagePullSecret.password=$NGC_API_KEY \
@@ -213,7 +213,7 @@ helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprin
 If you are deploying on NVIDIA RTX6000 Pro GPUs (instead of H100 GPUs), use [`values-mig-rtx6000.yaml`](../deploy/helm/mig-slicing/values-mig-rtx6000.yaml) and [`mig-config-rtx6000.yaml`](../deploy/helm/mig-slicing/mig-config-rtx6000.yaml) which include the RTX6000-specific MIG profiles and NIM LLM model configuration.
 
 ```sh
-helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
+helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvidia/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
   --username '$oauthtoken' \
   --password "${NGC_API_KEY}" \
   --set imagePullSecret.password=$NGC_API_KEY \

--- a/docs/retrieval-only-deployment.md
+++ b/docs/retrieval-only-deployment.md
@@ -241,7 +241,7 @@ In the v2.6.0 chart, the embedding and reranking NIMs are enabled by default; th
 ### Option A: --set flag
 
 ```bash
-helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
+helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvidia/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
   --username '$oauthtoken' \
   --password "${NGC_API_KEY}" \
   --set nimOperator.nim-llm.enabled=false \
@@ -290,7 +290,7 @@ nv-ingest:
 Apply the chart with the values override:
 
 ```bash
-helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
+helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvidia/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
   --username '$oauthtoken' \
   --password "${NGC_API_KEY}" \
   --set imagePullSecret.password=$NGC_API_KEY \

--- a/docs/text_only_ingest.md
+++ b/docs/text_only_ingest.md
@@ -132,7 +132,7 @@ Additionally, disable **table extraction**, **chart extraction**, and **image ex
 2. Apply the chart with the modified values, disabling the nv-ingest CV NIMs you no longer need:
 
    ```bash
-   helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
+   helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvidia/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \
      --username '$oauthtoken' \
      --password "${NGC_API_KEY}" \
      --values deploy/helm/nvidia-blueprint-rag/values.yaml \

--- a/tests/integration/test_cases/multimodal_query.py
+++ b/tests/integration/test_cases/multimodal_query.py
@@ -95,7 +95,7 @@ Helm Deployment:
 
     2. Deploy or upgrade the chart:
 
-        helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvstaging/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \\
+        helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvidia/blueprint/charts/nvidia-blueprint-rag-v2.6.0.tgz \\
           --username '$oauthtoken' \\
           --password "${NGC_API_KEY}" \\
           --set imagePullSecret.password=$NGC_API_KEY \\


### PR DESCRIPTION
Summary: update public RAG Blueprint container image and Helm chart paths from nvstaging/blueprint to nvidia/blueprint. CI publishing still pushes to nvstaging/blueprint by explicitly docker-tagging the locally built nvidia/blueprint images in the publish workflow before push. Validation: git diff --check; rg scan confirmed no nvstaging references in docs/deploy/helm/tests; docker compose config confirms compose renders nvidia/blueprint runtime images without compose build.tags.