### PR TITLE
deploy RAG stack directly via brev exec, not Harbor; add TaskOutput t…

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -162,15 +162,35 @@ mkdir -p /tmp/skill-eval/datasets /tmp/skill-eval/results
    done
    ```
 
-   If `RAG_RUNNING=false` and `rag-blueprint/eval/h100.json` exists in
-   the repo, run it first to deploy the self-hosted RAG stack. This
-   happens automatically regardless of which skills are in the PR diff —
-   skill authors do NOT need to declare this dependency in their specs.
-   Once deployed, all subsequent H100 specs reuse the running stack.
+   If `RAG_RUNNING=false`, deploy the RAG stack **directly via brev exec**
+   (do NOT use Harbor for deployment — Harbor is for evaluation only):
 
-   Use the canonical Harbor invocation from § Harbor invocation below.
-   One step at a time, in order. Skip remaining steps if a step's
-   reward < 1.0 (skip-on-prior-fail).
+   ```bash
+   brev exec "$BREV_INSTANCE" -- \
+     "cd /home/nvidia/rag && TAG=latest docker compose \
+       -f deploy/compose/docker-compose-rag-server.yaml \
+       -f deploy/compose/docker-compose-ingestor-server.yaml \
+       -f deploy/compose/vectordb.yaml \
+       -f deploy/compose/nims.yaml \
+       --env-file deploy/compose/.env \
+       up -d --remove-orphans" 2>&1 | tail -10
+
+   # Wait for rag-server health (up to 15 min)
+   DEADLINE=$(( $(date +%s) + 900 ))
+   while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+     brev exec "$BREV_INSTANCE" -- \
+       "curl -sf http://localhost:8081/v1/health" 2>/dev/null && break
+     sleep 30
+   done
+   ```
+
+   Once the stack is healthy, run Harbor trials for the actual skill specs.
+   One step at a time, in order. Skip remaining steps only if reward == 0
+   (complete failure) — partial scores (0 < reward < 1) still run next steps.
+
+   **TaskOutput timeout**: if waiting for a Harbor trial via TaskOutput for
+   more than 90 minutes with no completion signal, stop waiting, mark that
+   step as timed out, and move to the next step. Do NOT wait indefinitely.
 
 6. **Post ONE results comment per `(PR, spec)` batch** after all steps
    complete. Format per § Result comment format. Use:
@@ -290,9 +310,9 @@ uvx --with boto3 harbor run \
   --ak api_base="$ANTHROPIC_BASE_URL/v1" \
   --ae CLAUDE_CODE_DISABLE_THINKING=1 \
   --ae TAG=latest \
-  --environment-build-timeout-multiplier 3.0 \
-  --agent-timeout-multiplier 3.0 \
-  --verifier-timeout-multiplier 3.0 \
+  --environment-build-timeout-multiplier 1.5 \
+  --agent-timeout-multiplier 1.5 \
+  --verifier-timeout-multiplier 1.5 \
   --max-retries 0 -n 1 --yes \
   -o /tmp/skill-eval/results/"$GITHUB_RUN_ID"
 ```

--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -189,8 +189,11 @@ mkdir -p /tmp/skill-eval/datasets /tmp/skill-eval/results
    (complete failure) — partial scores (0 < reward < 1) still run next steps.
 
    **TaskOutput timeout**: if waiting for a Harbor trial via TaskOutput for
-   more than 90 minutes with no completion signal, stop waiting, mark that
-   step as timed out, and move to the next step. Do NOT wait indefinitely.
+   more than 90 minutes with no completion signal, stop waiting, treat the
+   step as `reward = 0` (complete failure), record it as "⏱️ Timed out (90min)"
+   in the results comment, and move to the next step. Since reward = 0, the
+   skip-on-prior-fail logic will skip all subsequent steps for that spec.
+   Do NOT wait indefinitely.
 
 6. **Post ONE results comment per `(PR, spec)` batch** after all steps
    complete. Format per § Result comment format. Use:

--- a/skill-source/.agents/skills/rag-blueprint/eval/h100.json
+++ b/skill-source/.agents/skills/rag-blueprint/eval/h100.json
@@ -14,21 +14,21 @@
       }
     }
   },
-  "env": "Linux host with 2x H100 80GB, driver 560+, Docker + nvidia-container-toolkit installed. The self-hosted RAG stack is already deployed and running — do NOT redeploy or reconfigure it. All services (rag-server, ingestor-server, local NIMs) are already up. NGC_API_KEY is set. cwd is the repo root.",
+  "env": "Linux host with 2x H100 80GB, driver 560+, Docker + nvidia-container-toolkit installed. The self-hosted RAG stack has been deployed and verified healthy (rag-server on :8081, ingestor-server on :8082, local NIMs on :8999). All services are running. NGC_API_KEY is set. cwd is the repo root.",
   "expects": [
     {
       "query": "The self-hosted RAG stack is already deployed. Use the rag-blueprint skill to verify all services are healthy and report their status. Do NOT redeploy or restart any services.",
       "checks": [
         "`curl -sf -o /dev/null -w '%{http_code}' http://localhost:8081/v1/health` outputs 200",
         "`curl -sf -o /dev/null -w '%{http_code}' http://localhost:8082/v1/health` outputs 200",
-        "`docker ps --format '{{.Names}}' | grep -E '^(rag-server|ingestor-server|milvus-standalone)' | wc -l` outputs a number greater than or equal to 3",
-        "`docker ps --format '{{.Names}}' | grep -E '(nim-llm|nemotron-embed)' | wc -l` outputs a number greater than or equal to 1"
+        "`docker ps --format '{{.Names}}' | grep -E '^(rag-server|ingestor-server)' | wc -l` outputs 2",
+        "`docker ps --format '{{.Names}}' | grep -E '(nim-llm|nemotron-embed|nemotron-vlm)' | wc -l` outputs a number greater than or equal to 1"
       ]
     },
     {
       "query": "Verify the local NIM LLM endpoint is responsive. Send a test completion request to http://localhost:8999/v1/chat/completions and confirm it returns a valid response.",
       "checks": [
-        "`curl -sf -X POST http://localhost:8999/v1/chat/completions -H 'Content-Type: application/json' -d '{\"model\":\"nvidia/llama-3.3-nemotron-super-49b-v1.5\",\"messages\":[{\"role\":\"user\",\"content\":\"Say ok\"}],\"max_tokens\":5}' | python3 -c 'import sys,json; d=json.load(sys.stdin); print(\"ok\" if d.get(\"choices\") else \"fail\")'` outputs ok",
+        "`curl -sf -X POST http://localhost:8999/v1/chat/completions -H 'Content-Type: application/json' -d '{\"model\":\"nvidia/llama-3.3-nemotron-super-49b-v1.5\",\"messages\":[{\"role\":\"user\",\"content\":\"Say ok\"}],\"max_tokens\":5}' | python3 -c 'import sys,json; d=json.load(sys.stdin); print(\"ok\" if d.get(\"choices\") and len(d[\"choices\"]) > 0 else \"fail\")'` outputs ok",
         "The agent's final response confirms the NIM LLM endpoint is healthy and responding"
       ]
     }

--- a/skill-source/.agents/skills/rag-blueprint/eval/h100.json
+++ b/skill-source/.agents/skills/rag-blueprint/eval/h100.json
@@ -14,25 +14,22 @@
       }
     }
   },
-  "env": "Linux host with 2x H100 80GB, driver 560+, Docker + nvidia-container-toolkit installed. Self-hosted deployment — all model inference runs via local NIMs (nim-llm, nemoretriever-embedding-ms, nemoretriever-ranking-ms). Required env var: NGC_API_KEY for pulling NIM containers from nvcr.io. cwd is the repo root: ${RAG_REPO_ROOT}/. Use deploy/compose/.env which is pre-configured for self-hosted endpoints.",
+  "env": "Linux host with 2x H100 80GB, driver 560+, Docker + nvidia-container-toolkit installed. The self-hosted RAG stack is already deployed and running — do NOT redeploy or reconfigure it. All services (rag-server, ingestor-server, local NIMs) are already up. NGC_API_KEY is set. cwd is the repo root.",
   "expects": [
     {
-      "query": "Deploy NVIDIA RAG Blueprint in self-hosted mode using Docker Compose. Start all services including the local NIM containers for LLM and embedding inference. All containers should reach the Up state before reporting success.",
-      "checks": [
-        "The agent's trajectory shows it read the rag-blueprint SKILL.md before taking action",
-        "The agent's trajectory shows it detected the available GPUs and chose self-hosted deployment mode",
-        "`docker ps --format '{{.Names}}' | grep -E '^(rag-server|ingestor-server|milvus-standalone|milvus-etcd|milvus-minio)$' | wc -l` outputs a number greater than or equal to 5",
-        "`docker ps --format '{{.Names}}' | grep -E '^(nim-llm|nemoretriever-embedding-ms)' | wc -l` outputs a number greater than or equal to 1",
-        "`docker ps --format '{{.Names}}\\t{{.Status}}' | grep -E '(rag-server|ingestor-server|milvus-standalone)' | grep -v 'Up' | wc -l` outputs 0"
-      ]
-    },
-    {
-      "query": "Verify the self-hosted RAG stack is fully operational. Check that the rag-server, ingestor-server, and local NIM endpoints are all healthy and responding.",
+      "query": "The self-hosted RAG stack is already deployed. Use the rag-blueprint skill to verify all services are healthy and report their status. Do NOT redeploy or restart any services.",
       "checks": [
         "`curl -sf -o /dev/null -w '%{http_code}' http://localhost:8081/v1/health` outputs 200",
         "`curl -sf -o /dev/null -w '%{http_code}' http://localhost:8082/v1/health` outputs 200",
-        "`docker ps --format '{{.Names}}\\t{{.Status}}' | grep nim-llm | grep -E 'Up|healthy'` returns at least one matching line",
-        "The agent's final output reports the health status of rag-server, ingestor-server, and the local NIM service with clear per-service indicators"
+        "`docker ps --format '{{.Names}}' | grep -E '^(rag-server|ingestor-server|milvus-standalone)' | wc -l` outputs a number greater than or equal to 3",
+        "`docker ps --format '{{.Names}}' | grep -E '(nim-llm|nemotron-embed)' | wc -l` outputs a number greater than or equal to 1"
+      ]
+    },
+    {
+      "query": "Verify the local NIM LLM endpoint is responsive. Send a test completion request to http://localhost:8999/v1/chat/completions and confirm it returns a valid response.",
+      "checks": [
+        "`curl -sf -X POST http://localhost:8999/v1/chat/completions -H 'Content-Type: application/json' -d '{\"model\":\"nvidia/llama-3.3-nemotron-super-49b-v1.5\",\"messages\":[{\"role\":\"user\",\"content\":\"Say ok\"}],\"max_tokens\":5}' | python3 -c 'import sys,json; d=json.load(sys.stdin); print(\"ok\" if d.get(\"choices\") else \"fail\")'` outputs ok",
+        "The agent's final response confirms the NIM LLM endpoint is healthy and responding"
       ]
     }
   ]

--- a/skill-source/.agents/skills/rag-blueprint/eval/h100.json
+++ b/skill-source/.agents/skills/rag-blueprint/eval/h100.json
@@ -28,7 +28,7 @@
     {
       "query": "Verify the local NIM LLM endpoint is responsive. Send a test completion request to http://localhost:8999/v1/chat/completions and confirm it returns a valid response.",
       "checks": [
-        "`curl -sf -X POST http://localhost:8999/v1/chat/completions -H 'Content-Type: application/json' -d '{\"model\":\"nvidia/llama-3.3-nemotron-super-49b-v1.5\",\"messages\":[{\"role\":\"user\",\"content\":\"Say ok\"}],\"max_tokens\":5}' | python3 -c 'import sys,json; d=json.load(sys.stdin); print(\"ok\" if d.get(\"choices\") and len(d[\"choices\"]) > 0 else \"fail\")'` outputs ok",
+        "`MODEL=$(curl -sf http://localhost:8999/v1/models | python3 -c 'import sys,json; print(json.load(sys.stdin)[\"data\"][0][\"id\"])' 2>/dev/null) && curl -sf -X POST http://localhost:8999/v1/chat/completions -H 'Content-Type: application/json' -d \"{\\\"model\\\":\\\"$MODEL\\\",\\\"messages\\\":[{\\\"role\\\":\\\"user\\\",\\\"content\\\":\\\"Say ok\\\"}],\\\"max_tokens\\\":5}\" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(\"ok\" if d.get(\"choices\") and len(d[\"choices\"]) > 0 else \"fail\")'` outputs ok",
         "The agent's final response confirms the NIM LLM endpoint is healthy and responding"
       ]
     }


### PR DESCRIPTION
…imeout; reduce GPU trial multiplier

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated GPU evaluation workflow to start the local RAG stack, wait for service health, and added an explicit 90-minute timeout that marks stalled trials as failed and advances the workflow
  * Clarified that pre-deployed RAG stacks must not be redeployed or reconfigured during evaluation

* **Configuration**
  * Reduced timeout multipliers for build/agent/verifier from 3.0 to 1.5 for faster feedback
  * Simplified health checks to endpoint and container-presence probes, including local NIM endpoint verification
<!-- end of auto-generated comment: release notes by coderabbit.ai -->