### PR TITLE
docs: align Brev notebook link with main

### DIFF
--- a/docs/notebooks.md
+++ b/docs/notebooks.md
@@ -124,7 +124,7 @@ Use the following notebooks to learn how to how to extend the system with custom
 
 Use the following notebook for cloud deployment scenarios.
 
-- [launchable.ipynb](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/notebooks/launchable.ipynb) – A deployment-ready notebook intended to run in a [Brev environment](https://console.brev.dev/environment/new). To learn more about Brev, refer to [Brev](https://docs.nvidia.com/brev/latest/about-brev.html). Follow the instructions for running Jupyter notebooks in a cloud-based environment based on the hardware requirements specified in the launchable.
+- [launchable.ipynb](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/notebooks/launchable.ipynb) – A deployment-ready notebook intended to run in a [Brev environment](https://console.brev.dev/environment/new). To learn more about Brev, refer to [Brev](https://developer.nvidia.com/brev). Follow the instructions for running Jupyter notebooks in a cloud-based environment based on the hardware requirements specified in the launchable.
 
 
 ## Related Topics


### PR DESCRIPTION
## Summary
- Align docs/notebooks.md Brev reference with origin/main by using https://developer.nvidia.com/brev.
- Keep develop staging namespaces and signed skill-eval files unchanged.

## Audit Notes
- Rechecked origin/develop against origin/main and origin/release-v2.6.0 after PR #674 merged.
- A neutral read-only audit also flagged the signed skill-eval files as different from main; those remain unchanged because they are signature-sensitive and were previously preserved as develop-wins unless a separate signing flow is requested.
- Remaining differences versus main are intentional staging/public path differences, publish-artifact namespace policy differences, signed skill-eval content, or whitespace-only/develop wording deltas.

## Validation
- git diff --check
- rg conflict marker scan
- python3 docs/scripts/verify_doc_version_manifest.py
- git diff --exit-code origin/main -- docs/notebooks.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Brev documentation reference link to point to the latest resource location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->