### PR TITLE
ci(skills-eval): mint Brev auth per-run + fix silent cleanup leak

### DIFF
--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -115,6 +115,27 @@ jobs:
               - '.github/workflows/skills-eval.yml'
               - 'ci/run_skill_eval.sh'
 
+      - name: Authenticate Brev CLI (long-lived API key)
+        # Mints fresh Brev auth at the start of every run so the workflow
+        # does not depend on persistent ~/.brev/credentials.json state on
+        # the self-hosted runner. Fails loudly upfront if the secret is
+        # missing or wrong — instead of failing 4h later at cleanup.
+        if: github.event_name != 'push' || steps.changes.outputs.skills == 'true'
+        env:
+          BREV_API_KEY: ${{ secrets.BREV_API_KEY }}
+          BREV_ORG_ID: org-2wW9qP0o1LFbMHyE2UnAFPIil8H
+        run: |
+          if [ -z "$BREV_API_KEY" ]; then
+            echo "::error::BREV_API_KEY secret not set"
+            exit 1
+          fi
+          brev login --api-key "$BREV_API_KEY" --org-id "$BREV_ORG_ID"
+          if ! brev ls >/dev/null 2>&1; then
+            echo "::error::Brev auth failed: brev ls returned non-zero after login"
+            exit 1
+          fi
+          echo "Brev auth OK"
+
       - name: Run skills eval agent
         id: agent
         if: github.event_name != 'push' || steps.changes.outputs.skills == 'true'
@@ -176,8 +197,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-      - name: Delete GPU Brev VMs on success
-        if: success() && (github.event_name != 'push' || steps.changes.outputs.skills == 'true')
+      - name: Delete GPU Brev VMs
+        # Run on success AND failure — agent crashes are exactly when GPU
+        # cleanup is most needed. Process substitution (not pipe-to-while)
+        # so FAILED=1 inside the loop is visible after the loop exits.
+        if: always() && (github.event_name != 'push' || steps.changes.outputs.skills == 'true')
         run: |
           RECORD="/tmp/brev/started-by-${{ github.run_id }}.txt"
           if [ ! -f "$RECORD" ]; then
@@ -186,11 +210,18 @@ jobs:
           fi
           echo "Waiting 5 min cooldown before deleting VMs..."
           sleep 300
-          sort -u "$RECORD" | while read -r INSTANCE; do
+          FAILED=0
+          while read -r INSTANCE; do
             [ -z "$INSTANCE" ] && continue
             echo "Deleting Brev VM: $INSTANCE"
-            brev delete "$INSTANCE" 2>/dev/null && echo "Deleted $INSTANCE" || echo "Could not delete $INSTANCE (may already be gone)"
-          done
+            if brev delete "$INSTANCE"; then
+              echo "OK Deleted $INSTANCE"
+            else
+              echo "::error::Failed to delete $INSTANCE (exit $?)"
+              FAILED=1
+            fi
+          done < <(sort -u "$RECORD")
+          exit $FAILED
 
       - name: Skip note when no skills/ changes
         if: github.event_name == 'push' && steps.changes.outputs.skills != 'true'

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -69,16 +69,23 @@ jobs:
     steps:
       - name: Pre-checkout cleanup — remove root-owned Docker volumes
         # Must run BEFORE checkout. Root-owned Milvus/MinIO/etcd files from
-        # prior runs block git clean. Docker alpine removes them without sudo.
+        # prior runs block git clean. Docker (running as root inside the
+        # container) removes them. We mount the PARENT dir and `rm` the
+        # target by name — this works even when both the target AND its
+        # parent are root-owned (e.g. when a trial agent's compose file
+        # with a relative bind mount caused Docker to mkdir -p the chain
+        # as root, leaving an empty root-owned dir that the ubuntu runner
+        # can't rmdir because it lacks write on the root-owned parent).
         run: |
           WORKSPACE="${GITHUB_WORKSPACE:-/home/ubuntu/actions-runner/_work/rag/rag}"
-          for vol_dir in deploy/compose/volumes ci/volumes ci/deploy/compose; do
+          for vol_dir in deploy/compose/volumes ci/volumes ci/deploy/compose ci/deploy; do
             TARGET="$WORKSPACE/$vol_dir"
-            if [ -d "$TARGET" ]; then
+            if [ -e "$TARGET" ]; then
+              PARENT="$(dirname "$TARGET")"
+              NAME="$(basename "$TARGET")"
               echo "Cleaning $TARGET"
-              docker run --rm -v "$TARGET:/target" alpine \
-                sh -c "rm -rf /target/* /target/.??* 2>/dev/null; exit 0" || true
-              rm -rf "$TARGET" 2>/dev/null || true
+              docker run --rm -v "$PARENT:/parent" alpine \
+                sh -c "rm -rf \"/parent/$NAME\""
             fi
           done
 
@@ -169,18 +176,26 @@ jobs:
           python3 .github/skill-eval/skills_eval_agent.py
 
       - name: Collect results for artifact
+        # Tar ONLY this run's subdir (/tmp/skill-eval/results/<run_id>/), not the whole
+        # results tree. The runner's disk persists between jobs, so /tmp/skill-eval/results/
+        # may also contain leftover subdirs from prior runs. Archiving all of them would
+        # re-upload stale data labeled as the current run — exactly how 06-03's results
+        # ended up in every nightly artifact for 9 days. If the agent didn't write a
+        # subdir for this run_id, there's nothing fresh to upload, so we exit cleanly.
         if: always() && (github.event_name != 'push' || steps.changes.outputs.skills == 'true')
         run: |
-          if [ ! -d /tmp/skill-eval/results ]; then
-            echo "no results dir — agent blocked before running trials"
+          RUN_DIR="/tmp/skill-eval/results/${{ github.run_id }}"
+          if [ ! -d "$RUN_DIR" ]; then
+            echo "no results subdir for this run (${{ github.run_id }}) — nothing to archive"
             exit 0
           fi
-          RESULTS=$(find /tmp/skill-eval/results -maxdepth 3 -name "result.json" 2>/dev/null | head -50 || true)
+          RESULTS=$(find "$RUN_DIR" -maxdepth 3 -name "result.json" 2>/dev/null | head -50 || true)
           if [ -n "$RESULTS" ]; then
-            tar czf /tmp/skills-eval-results.tar.gz -C /tmp/skill-eval results
-            echo "archived $(echo "$RESULTS" | wc -l) result.json files"
+            tar czf /tmp/skills-eval-results.tar.gz \
+              -C /tmp/skill-eval/results "${{ github.run_id }}"
+            echo "archived $(echo "$RESULTS" | wc -l) result.json files for run ${{ github.run_id }}"
           else
-            echo "results dir exists but empty — nothing to archive"
+            echo "results dir exists for this run but no result.json files — nothing to archive"
           fi
 
       - name: Upload results artifact


### PR DESCRIPTION
Adds a long-lived API-key auth step at the start of every workflow run so brev calls never fail on stale ~/.brev/credentials.json. The self-hosted runner's refresh_token expired after ~14 days, leaving brev delete unauthenticated, and the old cleanup loop swallowed the error silently (2>/dev/null + ||) and exited 0.

Also two cleanup fixes that are independent of the auth change:

  - if: success() -> if: always(). Agent crashes are exactly when GPU cleanup is most needed.

  - Replace sort -u | while ... done (loop runs in subshell, FAILED flag was lost) with while ... done < <(sort -u ...) so the loop body runs in the parent shell and exit $FAILED actually fails the step on any brev delete error.

Background: GHA run 26894711065 leaked an H100x2 (rag-eval-gpu-0491531) for 12+ hours because all three failure modes above stacked.

Requires repo secret BREV_API_KEY to be set; the step fails loudly with ::error::BREV_API_KEY secret not set if it's missing.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU VM cleanup to run even when the workflow fails, with clearer failure reporting if any VM deletions error.
  * Refined results artifact collection to package only the current run’s results, skipping cleanly when no results are present.

* **Chores**
  * Added a Brev CLI authentication validation step for Skills Eval using a long-lived API key, with early failure if credentials are missing or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->