### PR TITLE
fix(helm): route nv-ingest OTEL endpoint via otelEnvVars to stop duplicate env

### DIFF
--- a/deploy/helm/nvidia-blueprint-rag/values.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/values.yaml
@@ -1167,7 +1167,6 @@ nv-ingest:
     MINIO_BUCKET: "nv-ingest"
     MINIO_ACCESS_KEY: "seaweedfsadmin"
     MINIO_SECRET_KEY: "seaweedfsadmin"
-    OTEL_EXPORTER_OTLP_ENDPOINT: "otel-collector:4317"
     MODEL_PREDOWNLOAD_PATH: "/workspace/models/"
     INSTALL_AUDIO_EXTRACTION_DEPS: "true"
     COMPONENTS_TO_READY_CHECK: "ALL"
@@ -1205,6 +1204,13 @@ nv-ingest:
     # Audio service
     AUDIO_GRPC_ENDPOINT: nv-ingest-riva-nim:50051
     AUDIO_INFER_PROTOCOL: grpc
+
+  # OTel endpoint must be routed through otelEnvVars (not envVars). The nv-ingest subchart's
+  # OTel fallback guard only inspects otelEnvVars; supplying the key via envVars instead made
+  # the guard fire as well, rendering OTEL_EXPORTER_OTLP_ENDPOINT twice and breaking server-side
+  # apply / Rancher Fleet / strict admission. See issue #687.
+  otelEnvVars:
+    OTEL_EXPORTER_OTLP_ENDPOINT: "otel-collector:4317"
 
   # NV-Ingest uses SeaweedFS via MINIO_* env vars for S3-compatible artifact storage.
   milvusDeployed: false

--- a/tests/unit/test_compose_helm_parity/env_parity_exemptions.yaml
+++ b/tests/unit/test_compose_helm_parity/env_parity_exemptions.yaml
@@ -47,6 +47,9 @@ envMissingKeyExemptions:
         - NGC_API_KEY
         - NVIDIA_API_KEY
         - NVIDIA_BUILD_API_KEY
+        # Routed through Helm nv-ingest.otelEnvVars (not envVars) to avoid a duplicate
+        # OTEL_EXPORTER_OTLP_ENDPOINT render in the nv-ingest subchart. See issue #687.
+        - OTEL_EXPORTER_OTLP_ENDPOINT
 
 # Image parity exemptions allow skipping image repo/tag parity for selected services
 imageParityExemptions:

--- a/tests/unit/test_compose_helm_parity/test_otel_endpoint_dedup.py
+++ b/tests/unit/test_compose_helm_parity/test_otel_endpoint_dedup.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for issue #687.
+
+The nv-ingest subchart renders the ``OTEL_EXPORTER_OTLP_ENDPOINT`` env var twice when the key
+is supplied via the parent chart's ``nv-ingest.envVars`` map: once from the subchart's generic
+``envVars`` loop and once from its OTel fallback (whose guard only inspects ``otelEnvVars``).
+The duplicate env entry is rejected by server-side apply / Rancher Fleet / strict admission.
+
+The fix routes the endpoint through ``nv-ingest.otelEnvVars`` instead, so the subchart's
+fallback guard sees the key and emits it exactly once. These tests assert the values.yaml is
+shaped so the duplicate cannot be rendered.
+"""
+
+from pathlib import Path
+
+import yaml
+
+OTEL_ENDPOINT_KEY = "OTEL_EXPORTER_OTLP_ENDPOINT"
+
+
+def _load_values() -> dict:
+    repo_root = Path(__file__).resolve().parents[3]
+    values_path = repo_root / "deploy/helm/nvidia-blueprint-rag/values.yaml"
+    with values_path.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def test_otel_endpoint_not_in_nv_ingest_envvars() -> None:
+    """The endpoint must NOT live in nv-ingest.envVars (it would render entry #1)."""
+    values = _load_values()
+    env_vars = values.get("nv-ingest", {}).get("envVars", {}) or {}
+    assert OTEL_ENDPOINT_KEY not in env_vars, (
+        f"{OTEL_ENDPOINT_KEY} must not be in nv-ingest.envVars; routing it there causes the "
+        "duplicate OTEL env entry (issue #687). Move it to nv-ingest.otelEnvVars."
+    )
+
+
+def test_otel_endpoint_in_nv_ingest_otelenvvars() -> None:
+    """The endpoint must live in nv-ingest.otelEnvVars exactly once, with its value preserved."""
+    values = _load_values()
+    otel_env_vars = values.get("nv-ingest", {}).get("otelEnvVars", {}) or {}
+    assert OTEL_ENDPOINT_KEY in otel_env_vars, (
+        f"{OTEL_ENDPOINT_KEY} must be defined in nv-ingest.otelEnvVars so the subchart's OTel "
+        "fallback guard sees it and renders it exactly once (issue #687)."
+    )
+    assert otel_env_vars[OTEL_ENDPOINT_KEY] == "otel-collector:4317", (
+        "OTEL endpoint value must be preserved as 'otel-collector:4317'."
+    )


### PR DESCRIPTION
## Description

Fixes #687.

The rendered `Deployment/<release>-nv-ingest` contains two `OTEL_EXPORTER_OTLP_ENDPOINT` env
entries, which is rejected by server-side apply, Rancher Fleet, and any strict-admission tool
(`duplicate entries for key [name="OTEL_EXPORTER_OTLP_ENDPOINT"]`).

**Root cause:** the parent chart supplies the endpoint through `nv-ingest.envVars`, so the
nv-ingest subchart emits it once from its generic `envVars` loop. The subchart's OTel fallback
then emits it *again*, because that fallback's guard only checks `otelEnvVars`
(`not (index .Values.otelEnvVars "OTEL_EXPORTER_OTLP_ENDPOINT")`) — it never sees the key that
arrived via `envVars`, so the guard stays true and the fallback fires.

**Fix (the issue's preferred Option B):** move `OTEL_EXPORTER_OTLP_ENDPOINT` out of
`nv-ingest.envVars` into a new `nv-ingest.otelEnvVars` map. The subchart's fallback guard now
sees the key and stands down, so the endpoint renders exactly once. The value
(`otel-collector:4317`) is unchanged. This is the only in-repo fix, since the nv-ingest subchart
template lives in the remote `nemo-microservices` chart, not this repository (Options A and C in
the issue would have to be made upstream there).

## Changes

- `deploy/helm/nvidia-blueprint-rag/values.yaml` — relocate the OTel endpoint to
  `nv-ingest.otelEnvVars`.
- `tests/unit/test_compose_helm_parity/test_otel_endpoint_dedup.py` — regression test asserting
  the endpoint is in `otelEnvVars` and not `envVars`.
- `tests/unit/test_compose_helm_parity/env_parity_exemptions.yaml` — exempt the relocated key
  from the compose↔Helm env-parity check (still delivered to the container, now via
  `otelEnvVars`).

## Verification

- `pytest tests/unit/test_compose_helm_parity/` — green (new regression test + the existing
  compose↔Helm parity test).
- Rendered the issue's exact subchart guard logic against a local stub chart: **2**
  `OTEL_EXPORTER_OTLP_ENDPOINT` entries before the change, **1** after.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OpenTelemetry endpoint configuration so it is handled in the correct settings section, preventing duplicate environment entries in deployed services.
  * Preserved the existing collector endpoint value while improving deployment reliability.

* **Tests**
  * Added regression coverage to verify the OpenTelemetry endpoint appears only once in the expected configuration path.
  * Updated parity checks to account for the corrected environment variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->