### PR TITLE
ci(skills-eval): wire schedule to MANUAL_FULL_SWEEP + sync dispatch picker

### DIFF
--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -32,16 +32,9 @@ on:
         type: choice
         options:
           - "*"
-          - rag-deploy-blueprint
-          - rag-ingest-documents
-          - rag-query-knowledge
-          - rag-configure-infrastructure
-          - rag-configure-retrieval
-          - rag-evaluate-quality
-          - rag-manage-mcp
-          - rag-troubleshoot-blueprint
-          - rag-enable-vlm
-          - rag-enable-guardrails
+          - rag-blueprint
+          - rag-eval
+          - rag-perf
 
 permissions:
   contents: write
@@ -169,9 +162,11 @@ jobs:
           export GITHUB_RUN_ID="${{ github.run_id }}"
           # PYTHONPATH lets uvx harbor resolve envs.*:*Environment from skill-eval/
           export PYTHONPATH="${GITHUB_WORKSPACE}/skill-eval:${PYTHONPATH:-}"
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "schedule" ]; then
+            # Schedule events never populate `inputs`, so INPUT_SKILLS is empty
+            # there — default to "*" so the agent enumerates all skills.
             export MANUAL_FULL_SWEEP=1
-            export MANUAL_SKILLS_FILTER="${INPUT_SKILLS}"
+            export MANUAL_SKILLS_FILTER="${INPUT_SKILLS:-*}"
           fi
           python3 .github/skill-eval/skills_eval_agent.py
 


### PR DESCRIPTION
## Summary
Two independent fixes in `.github/workflows/skills-eval.yml`:

1. **Schedule trigger now exports `MANUAL_FULL_SWEEP=1`** (same as `workflow_dispatch` already does). Before this, nightly runs crashed with `FATAL: PR_NUMBER not set in environment` — see GHA run [28214488174](https://github.com/NVIDIA-AI-Blueprints/rag/actions/runs/28214488174).

2. **`workflow_dispatch` picker** now lists the 3 skills that actually exist on disk (`rag-blueprint`, `rag-eval`, `rag-perf`) instead of 10 phantom names left over from an old taxonomy. The LLM already enumerates `skills/*/eval/*.json` itself, so the stale picker was a UX trap — anyone picking an old name got a silent `BLOCKED`. Closes the gotcha documented at `ONBOARDING.md:487-492`.

## Local verification (all green)
- **YAML + workflow lint**: parses clean, picker has exactly 4 options (`*` + 3 real skills).
- **Bash conditional simulation**: confirmed `event_name=schedule` now sets `MANUAL_FULL_SWEEP=1`, `MANUAL_SKILLS_FILTER=*`; `event_name=push` still leaves them unset.
- **Python agent dry-run**: reproduced the old `FATAL: PR_NUMBER` without the fix; with the fix the agent gets past the `_require` gate.

## Why this is independent of #680
PR #680 fixed Brev auth + cleanup. Both passed cleanly on run 28214488174 (no GPU leak). This PR fixes the *next* failure exposed once cleanup stopped silently swallowing errors.

## Test plan
- [ ] Trigger `workflow_dispatch` on this branch — confirm picker only shows `*`, `rag-blueprint`, `rag-eval`, `rag-perf`, and the agent reaches `[agent] starting` instead of `FATAL: PR_NUMBER`.
- [ ] First nightly after merge (2026-06-27 02:00 UTC) — confirm no `FATAL: PR_NUMBER` in logs.
- [ ] After 7 days — audit `brev ls` for any leaked `rag-eval-gpu-*` instances (still expected: zero).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduled runs now use the same skill-selection behavior as manual runs, defaulting to all skills when no selection is provided.
  * The skill selector list was simplified to the currently supported options while still allowing all skills to be selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->