### PR TITLE
fix(skills): add resources.platforms.cpu to rag-blueprint nvidia_hosted spec

### DIFF
--- a/skills/rag-blueprint/eval/nvidia_hosted.json
+++ b/skills/rag-blueprint/eval/nvidia_hosted.json
@@ -1,6 +1,14 @@
 {
   "skills": ["rag-blueprint"],
   "platforms": ["cpu"],
+  "resources": {
+    "platforms": {
+      "cpu": {
+        "brev_type": "n2d-standard-4",
+        "description": "GCP n2d-standard-4 (4 vCPU, 16 GB). Fresh Linux host — RAG stack will be deployed by this trial."
+      }
+    }
+  },
   "env": "A Linux host with Docker + Docker Compose plugin installed and running. CPU-only — no NVIDIA GPU or driver present. NVIDIA-hosted deployment: all model inference goes to https://integrate.api.nvidia.com/v1. Required env var: NGC_API_KEY. cwd is the repo root: ${RAG_REPO_ROOT}/. Use deploy/compose/nvdev.env for cloud endpoints. IMPORTANT: use ci/vectordb-cpu.yaml instead of deploy/compose/vectordb.yaml for the vector database — the default uses a GPU Milvus image that fails on CPU-only hosts.",
   "expects": [
     {


### PR DESCRIPTION
## Summary
`skills/rag-blueprint/eval/nvidia_hosted.json` was missing the required `resources.platforms` field. AGENTS.md treats this as a hard schema blocker and the agent silently skips such specs. This has caused every nightly schedule run to evaluate only **5 of 6 legs** — the rag-blueprint CPU spec never actually ran.

## Evidence
- Latest nightly run [28562383757](https://github.com/NVIDIA-AI-Blueprints/rag/actions/runs/28562383757) final line: `DONE: 4/5 specs passed; 1 blocker (rag-blueprint/nvidia_hosted.json missing resources.platforms)`
- Dashboard confirms only 5 legs shown: http://bp-skill-eval-dashboard:8001/app/bp-rag.html
- Sibling specs `rag-eval/eval/nvidia_hosted.json` and `rag-perf/eval/nvidia_hosted.json` both carry the field

## Fix
Add the same `resources.platforms.cpu` block that sibling nvidia_hosted specs already have. The `brev_type` isn't consumed at runtime for cpu specs (LocalEnvironment runs on the rag-skill-validator runner directly), but AGENTS.md line 47-50 performs a presence-check before dispatching.

## Blame
Spec file was created on 2026-05-27 in `8615d30` ("feat(skills): migrate to canonical skills/ path per publishing guide") without the field. Pre-existing, unrelated to PRs #680 / #701.

## Test plan
- [ ] Manually trigger `workflow_dispatch` with `skills=rag-blueprint` after merge — confirm the CPU leg dispatches and completes
- [ ] Next nightly (2026-07-03 02:00 UTC) — confirm 6/6 legs in artifact + dashboard shows 6 legs
- [ ] Backport to `develop` in the next sync PR (spec is broken on `develop` too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new CPU-based hosted evaluation environment for deploying the RAG stack on a fresh Linux host.
  * Included a standard machine configuration to support this hosted setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->