### PR TITLE
feat(helm): support distroless embedding NIMs via direct-PVC storage

### DIFF
--- a/deploy/helm/nvidia-blueprint-rag/embedding-override.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/embedding-override.yaml
@@ -1,0 +1,13 @@
+# Values override: change the default (VLM) embedding NIM image.
+# Default embedding service is nvidia-nim-llama-nemotron-embed-vl-1b-v2
+# (service name nemotron-vlm-embedding-ms), aligned with envVars.APP_EMBEDDINGS_SERVERURL.
+#
+# nemotron-3-embed-1b images are distroless (no shell), which the NIM operator's
+# NIMCache manifest-probe (`sh -c ...`) cannot run. useDirectPvc bypasses the
+# NIMCache and has the NIMService download the model into its own PVC at runtime.
+nimOperator:
+  nvidia-nim-llama-nemotron-embed-vl-1b-v2:
+    useDirectPvc: true
+    image:
+      repository: nvcr.io/nim/nvidia/nemotron-3-embed-1b
+      tag: "2.2.0"

--- a/deploy/helm/nvidia-blueprint-rag/templates/vlm-embed-nim.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/templates/vlm-embed-nim.yaml
@@ -1,5 +1,6 @@
 {{- $nimModel := index .Values.nimOperator "nvidia-nim-llama-nemotron-embed-vl-1b-v2" -}}
 {{- if and (.Capabilities.APIVersions.Has "apps.nvidia.com/v1alpha1") (eq $nimModel.enabled true) }}
+{{- if not $nimModel.useDirectPvc }}
 apiVersion: apps.nvidia.com/v1alpha1
 kind: NIMCache
 metadata:
@@ -21,6 +22,7 @@ spec:
       size: {{ $nimModel.storage.pvc.size | default "50Gi" }}
       volumeAccessMode: {{ $nimModel.storage.pvc.volumeAccessMode | default "ReadWriteMany" }}
 ---
+{{- end }}
 apiVersion: apps.nvidia.com/v1alpha1
 kind: NIMService
 metadata:
@@ -34,8 +36,18 @@ spec:
       - {{ .Values.imagePullSecret.name }}
   authSecret: {{ .Values.ngcApiSecret.name }}
   storage:
+{{- if $nimModel.useDirectPvc }}
+    pvc:
+      create: {{ $nimModel.storage.pvc.create | default true }}
+      {{- if $nimModel.storage.pvc.storageClass }}
+      storageClass: {{ $nimModel.storage.pvc.storageClass }}
+      {{- end }}
+      size: {{ $nimModel.storage.pvc.size | default "50Gi" }}
+      volumeAccessMode: {{ $nimModel.storage.pvc.volumeAccessMode | default "ReadWriteOnce" }}
+{{- else }}
     nimCache:
       name: {{ $nimModel.service.name }}-cache
+{{- end }}
   replicas: {{ $nimModel.replicas | default 1 }}
   {{- with $nimModel.podAnnotations }}
   podAnnotations:

--- a/deploy/helm/nvidia-blueprint-rag/values.yaml
+++ b/deploy/helm/nvidia-blueprint-rag/values.yaml
@@ -932,6 +932,11 @@ nimOperator:
 # NIM VLM Embedding (default embedding service; aligned with envVars.APP_EMBEDDINGS_SERVERURL)
   nvidia-nim-llama-nemotron-embed-vl-1b-v2:
     enabled: true
+    # -- Skip the NIMCache manifest-probe and have the NIMService download the model
+    # directly into its own PVC at runtime. Required for distroless NIM images (e.g.
+    # nemotron-3-embed-1b) whose containers have no shell for the operator's `sh -c`
+    # manifest probe. Leave false to use the shared NIMCache (default behavior).
+    useDirectPvc: false
     # -- Annotations applied to NIM pods (propagated via NIMService.spec.podAnnotations).
     # See nim-llm.podAnnotations above for a Runai fractional GPU example.
     podAnnotations: {}


### PR DESCRIPTION
The default VLM embedding service deploys a NIMCache whose model-manifest probe runs `sh -c "cat .../model_manifest.yaml"` inside the model image. Distroless NIM images such as nvcr.io/nim/nvidia/nemotron-3-embed-1b ship no shell, so that probe fails with "executable file `sh` not found in $PATH" (CreateContainerError) and the embedding NIM never comes up.

Add an opt-in `useDirectPvc` flag to the embedding NIM configuration. When set, the chart skips the NIMCache entirely and provisions a PVC directly on the NIMService, letting the NIM's own entrypoint download the model at runtime — no shell required. Default is false, preserving the existing NIMCache behavior for shell-bearing images.

Changes:
- templates/vlm-embed-nim.yaml: gate the NIMCache resource on `not useDirectPvc`, and switch NIMService storage between `pvc` and `nimCache` accordingly.
- values.yaml: document `useDirectPvc` (default false) under the embedding NIM section.
- embedding-override.yaml: example override deploying nemotron-3-embed-1b with useDirectPvc enabled.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] All commits are signed-off (`git commit -s`) and GPG signed (`git commit -S`).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring embedding services to use direct persistent volume storage for model files.
  * Added a Helm values flag to switch between direct PVC storage and shared cache storage for the embedding service.
  * Updated the Nemotron embedding image override to use version 2.2.0.
* **Bug Fixes**
  * Improved reliability in environments where the shared cache probing behavior isn’t available by enabling direct PVC mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->