### PR TITLE
docs(helm): document Nemotron 3 Super 120B v2.0.9 image tag and required env

### DIFF
--- a/docs/deploy-helm-from-repo.md
+++ b/docs/deploy-helm-from-repo.md
@@ -103,6 +103,35 @@ If you are working directly with the source Helm chart, and you want to customiz
    Refer to [NIM Model Profile Configuration](model-profiles.md) for using non-default NIM LLM profile.
    :::
 
+   :::{note}
+   **Nemotron 3 Super 120B — version 2.0.9**
+
+   To run the LLM NIM at version `2.0.9`, override the image tag and cap `max_num_seqs`. The `2.0.9` profile is a hybrid Mamba model that defaults to `max_num_seqs=1024`; on a `tensorParallelism=2` (two-GPU) allocation this exceeds the available Mamba cache blocks and the vLLM engine fails during CUDA-graph capture. The NIM configuration schema does not expose `max_num_seqs`, so pass it straight to the engine with `NIM_PASSTHROUGH_ARGS`. Add the following to your values override file (`nvidia-blueprint-rag/values.yaml`) or a separate override included with `-f`:
+
+   ```yaml
+   nimOperator:
+     nim-llm:
+       image:
+         tag: "2.0.9"
+       # The full env list is repeated because Helm replaces list values rather than merging them.
+       env:
+         - name: NIM_HTTP_API_PORT
+           value: "8000"
+         - name: NIM_TRITON_LOG_VERBOSE
+           value: "1"
+         - name: NIM_SERVED_MODEL_NAME
+           value: "nvidia/nemotron-3-super-120b-a12b"
+         - name: NIM_ENABLE_CHUNKED_PREFILL
+           value: "1"
+         - name: NCCL_NVLS_ENABLE
+           value: "0"
+         - name: VLLM_USE_FLASHINFER_MOE_FP8
+           value: "0"
+         - name: NIM_PASSTHROUGH_ARGS
+           value: "--max-num-seqs 384"
+   ```
+   :::
+
    For **RTX PRO 6000** hardware, see the [RTX PRO 6000 setup prerequisites](nemotron3-super-deployment.md#rtx-pro-6000-setup) in the Nemotron 3 Super deployment guide.
 
 

--- a/docs/deploy-helm-from-repo.md
+++ b/docs/deploy-helm-from-repo.md
@@ -96,40 +96,14 @@ If you are working directly with the source Helm chart, and you want to customiz
     ```sh
     helm upgrade --install rag -n rag nvidia-blueprint-rag/ \
     --set imagePullSecret.password=$NGC_API_KEY \
-    --set ngcApiSecret.password=$NGC_API_KEY
+    --set ngcApiSecret.password=$NGC_API_KEY \
+    --set nimOperator.nim-llm.image.tag=2.0.9 \
+    --set 'nimOperator.nim-llm.env[6].name=NIM_PASSTHROUGH_ARGS' \
+    --set-string 'nimOperator.nim-llm.env[6].value=--max-num-seqs 384'
     ```
 
    :::{note}
    Refer to [NIM Model Profile Configuration](model-profiles.md) for using non-default NIM LLM profile.
-   :::
-
-   :::{note}
-   **Nemotron 3 Super 120B — version 2.0.9**
-
-   To run the LLM NIM at version `2.0.9`, override the image tag and cap `max_num_seqs`. The `2.0.9` profile is a hybrid Mamba model that defaults to `max_num_seqs=1024`; on a `tensorParallelism=2` (two-GPU) allocation this exceeds the available Mamba cache blocks and the vLLM engine fails during CUDA-graph capture. The NIM configuration schema does not expose `max_num_seqs`, so pass it straight to the engine with `NIM_PASSTHROUGH_ARGS`. Add the following to your values override file (`nvidia-blueprint-rag/values.yaml`) or a separate override included with `-f`:
-
-   ```yaml
-   nimOperator:
-     nim-llm:
-       image:
-         tag: "2.0.9"
-       # The full env list is repeated because Helm replaces list values rather than merging them.
-       env:
-         - name: NIM_HTTP_API_PORT
-           value: "8000"
-         - name: NIM_TRITON_LOG_VERBOSE
-           value: "1"
-         - name: NIM_SERVED_MODEL_NAME
-           value: "nvidia/nemotron-3-super-120b-a12b"
-         - name: NIM_ENABLE_CHUNKED_PREFILL
-           value: "1"
-         - name: NCCL_NVLS_ENABLE
-           value: "0"
-         - name: VLLM_USE_FLASHINFER_MOE_FP8
-           value: "0"
-         - name: NIM_PASSTHROUGH_ARGS
-           value: "--max-num-seqs 384"
-   ```
    :::
 
    For **RTX PRO 6000** hardware, see the [RTX PRO 6000 setup prerequisites](nemotron3-super-deployment.md#rtx-pro-6000-setup) in the Nemotron 3 Super deployment guide.

--- a/docs/deploy-helm.md
+++ b/docs/deploy-helm.md
@@ -102,40 +102,14 @@ To deploy End-to-End RAG Server and Ingestor Server, use the following procedure
     --username '$oauthtoken' \
     --password "${NGC_API_KEY}" \
     --set imagePullSecret.password=$NGC_API_KEY \
-    --set ngcApiSecret.password=$NGC_API_KEY
+    --set ngcApiSecret.password=$NGC_API_KEY \
+    --set nimOperator.nim-llm.image.tag=2.0.9 \
+    --set 'nimOperator.nim-llm.env[6].name=NIM_PASSTHROUGH_ARGS' \
+    --set-string 'nimOperator.nim-llm.env[6].value=--max-num-seqs 384'
     ```
 
    :::{note}
    Refer to [NIM Model Profile Configuration](model-profiles.md) for using non-default NIM LLM profile.
-   :::
-
-   :::{note}
-   **Nemotron 3 Super 120B — version 2.0.9**
-
-   To run the LLM NIM at version `2.0.9`, override the image tag and cap `max_num_seqs`. The `2.0.9` profile is a hybrid Mamba model that defaults to `max_num_seqs=1024`; on a `tensorParallelism=2` (two-GPU) allocation this exceeds the available Mamba cache blocks and the vLLM engine fails during CUDA-graph capture. The NIM configuration schema does not expose `max_num_seqs`, so pass it straight to the engine with `NIM_PASSTHROUGH_ARGS`. Add the following to a values override file and include it with `-f`:
-
-   ```yaml
-   nimOperator:
-     nim-llm:
-       image:
-         tag: "2.0.9"
-       # The full env list is repeated because Helm replaces list values rather than merging them.
-       env:
-         - name: NIM_HTTP_API_PORT
-           value: "8000"
-         - name: NIM_TRITON_LOG_VERBOSE
-           value: "1"
-         - name: NIM_SERVED_MODEL_NAME
-           value: "nvidia/nemotron-3-super-120b-a12b"
-         - name: NIM_ENABLE_CHUNKED_PREFILL
-           value: "1"
-         - name: NCCL_NVLS_ENABLE
-           value: "0"
-         - name: VLLM_USE_FLASHINFER_MOE_FP8
-           value: "0"
-         - name: NIM_PASSTHROUGH_ARGS
-           value: "--max-num-seqs 384"
-   ```
    :::
 
    For **RTX PRO 6000** hardware, see the [RTX PRO 6000 setup prerequisites](nemotron3-super-deployment.md#rtx-pro-6000-setup) in the Nemotron 3 Super deployment guide.

--- a/docs/deploy-helm.md
+++ b/docs/deploy-helm.md
@@ -109,6 +109,35 @@ To deploy End-to-End RAG Server and Ingestor Server, use the following procedure
    Refer to [NIM Model Profile Configuration](model-profiles.md) for using non-default NIM LLM profile.
    :::
 
+   :::{note}
+   **Nemotron 3 Super 120B — version 2.0.9**
+
+   To run the LLM NIM at version `2.0.9`, override the image tag and cap `max_num_seqs`. The `2.0.9` profile is a hybrid Mamba model that defaults to `max_num_seqs=1024`; on a `tensorParallelism=2` (two-GPU) allocation this exceeds the available Mamba cache blocks and the vLLM engine fails during CUDA-graph capture. The NIM configuration schema does not expose `max_num_seqs`, so pass it straight to the engine with `NIM_PASSTHROUGH_ARGS`. Add the following to a values override file and include it with `-f`:
+
+   ```yaml
+   nimOperator:
+     nim-llm:
+       image:
+         tag: "2.0.9"
+       # The full env list is repeated because Helm replaces list values rather than merging them.
+       env:
+         - name: NIM_HTTP_API_PORT
+           value: "8000"
+         - name: NIM_TRITON_LOG_VERBOSE
+           value: "1"
+         - name: NIM_SERVED_MODEL_NAME
+           value: "nvidia/nemotron-3-super-120b-a12b"
+         - name: NIM_ENABLE_CHUNKED_PREFILL
+           value: "1"
+         - name: NCCL_NVLS_ENABLE
+           value: "0"
+         - name: VLLM_USE_FLASHINFER_MOE_FP8
+           value: "0"
+         - name: NIM_PASSTHROUGH_ARGS
+           value: "--max-num-seqs 384"
+   ```
+   :::
+
    For **RTX PRO 6000** hardware, see the [RTX PRO 6000 setup prerequisites](nemotron3-super-deployment.md#rtx-pro-6000-setup) in the Nemotron 3 Super deployment guide.
 
 

--- a/docs/mig-deployment.md
+++ b/docs/mig-deployment.md
@@ -204,6 +204,9 @@ helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvidia/blueprint/c
   --password "${NGC_API_KEY}" \
   --set imagePullSecret.password=$NGC_API_KEY \
   --set ngcApiSecret.password=$NGC_API_KEY \
+  --set nimOperator.nim-llm.image.tag=2.0.9 \
+  --set 'nimOperator.nim-llm.env[6].name=NIM_PASSTHROUGH_ARGS' \
+  --set-string 'nimOperator.nim-llm.env[6].value=--max-num-seqs 384' \
   -f mig-slicing/values-mig-h100.yaml
 ```
 
@@ -218,41 +221,15 @@ helm upgrade --install rag -n rag https://helm.ngc.nvidia.com/nvidia/blueprint/c
   --password "${NGC_API_KEY}" \
   --set imagePullSecret.password=$NGC_API_KEY \
   --set ngcApiSecret.password=$NGC_API_KEY \
+  --set nimOperator.nim-llm.image.tag=2.0.9 \
+  --set 'nimOperator.nim-llm.env[6].name=NIM_PASSTHROUGH_ARGS' \
+  --set-string 'nimOperator.nim-llm.env[6].value=--max-num-seqs 384' \
   -f mig-slicing/values-mig-rtx6000.yaml
 ```
 :::
 
 :::{note}
 Refer to [NIM Model Profile Configuration](model-profiles.md) for using non-default NIM LLM profile.
-:::
-
-:::{note}
-**Nemotron 3 Super 120B — version 2.0.9**
-
-To run the LLM NIM at version `2.0.9`, override the image tag and cap `max_num_seqs`. In the MIG topology the LLM still runs with `tensorParallelism=2` on the two MIG-disabled NVLink GPUs (GPU 0,1). The `2.0.9` profile is a hybrid Mamba model that defaults to `max_num_seqs=1024`, which exceeds the available Mamba cache blocks on that two-GPU allocation and makes the vLLM engine fail during CUDA-graph capture. The NIM configuration schema does not expose `max_num_seqs`, so pass it straight to the engine with `NIM_PASSTHROUGH_ARGS`. Add the following to your MIG values file (`mig-slicing/values-mig-h100.yaml` or `mig-slicing/values-mig-rtx6000.yaml`):
-
-```yaml
-nimOperator:
-  nim-llm:
-    image:
-      tag: "2.0.9"
-    # The full env list is repeated because Helm replaces list values rather than merging them.
-    env:
-      - name: NIM_HTTP_API_PORT
-        value: "8000"
-      - name: NIM_TRITON_LOG_VERBOSE
-        value: "1"
-      - name: NIM_SERVED_MODEL_NAME
-        value: "nvidia/nemotron-3-super-120b-a12b"
-      - name: NIM_ENABLE_CHUNKED_PREFILL
-        value: "1"
-      - name: NCCL_NVLS_ENABLE
-        value: "0"
-      - name: VLLM_USE_FLASHINFER_MOE_FP8
-        value: "0"
-      - name: NIM_PASSTHROUGH_ARGS
-        value: "--max-num-seqs 384"
-```
 :::
 
 :::{note}

--- a/docs/mig-deployment.md
+++ b/docs/mig-deployment.md
@@ -227,6 +227,35 @@ Refer to [NIM Model Profile Configuration](model-profiles.md) for using non-defa
 :::
 
 :::{note}
+**Nemotron 3 Super 120B — version 2.0.9**
+
+To run the LLM NIM at version `2.0.9`, override the image tag and cap `max_num_seqs`. In the MIG topology the LLM still runs with `tensorParallelism=2` on the two MIG-disabled NVLink GPUs (GPU 0,1). The `2.0.9` profile is a hybrid Mamba model that defaults to `max_num_seqs=1024`, which exceeds the available Mamba cache blocks on that two-GPU allocation and makes the vLLM engine fail during CUDA-graph capture. The NIM configuration schema does not expose `max_num_seqs`, so pass it straight to the engine with `NIM_PASSTHROUGH_ARGS`. Add the following to your MIG values file (`mig-slicing/values-mig-h100.yaml` or `mig-slicing/values-mig-rtx6000.yaml`):
+
+```yaml
+nimOperator:
+  nim-llm:
+    image:
+      tag: "2.0.9"
+    # The full env list is repeated because Helm replaces list values rather than merging them.
+    env:
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+      - name: NIM_TRITON_LOG_VERBOSE
+        value: "1"
+      - name: NIM_SERVED_MODEL_NAME
+        value: "nvidia/nemotron-3-super-120b-a12b"
+      - name: NIM_ENABLE_CHUNKED_PREFILL
+        value: "1"
+      - name: NCCL_NVLS_ENABLE
+        value: "0"
+      - name: VLLM_USE_FLASHINFER_MOE_FP8
+        value: "0"
+      - name: NIM_PASSTHROUGH_ARGS
+        value: "--max-num-seqs 384"
+```
+:::
+
+:::{note}
 Due to a known issue with MIG support, currently the ingestion profile has been scaled down while deploying the chart with MIG slicing.
 This is expected to affect the ingestion performance during bulk ingestion, specifically large bulk ingestion jobs might fail.
 :::


### PR DESCRIPTION
## Summary
Documents how to run the LLM NIM (Nemotron 3 Super 120B) at version **2.0.9** across the Helm deployment guides.

The `2.0.9` profile is a hybrid Mamba model whose default `max_num_seqs=1024` exceeds the available Mamba cache blocks on a `tensorParallelism=2` allocation, causing the vLLM engine to crash during CUDA-graph capture. `max_num_seqs` is not exposed via the NIM config schema, so it must be passed to the engine with `NIM_PASSTHROUGH_ARGS=--max-num-seqs 384`.

## Changes
Adds a note (image tag `2.0.9` + required `env` block) to:
- `docs/deploy-helm.md`
- `docs/deploy-helm-from-repo.md`
- `docs/mig-deployment.md` (notes the tp=2 NVLink GPUs used under MIG)

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Helm deployment instructions to pin Nemotron 3 Super 120B NIM to image tag **2.0.9**.
  * Documented setting **`NIM_PASSTHROUGH_ARGS`** with **`--max-num-seqs 384`** for the vLLM runtime.
  * Refreshed examples for both standard Helm and MIG-based deployments to include the required image/tag and environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->