### PR TITLE
docs: prepare RAG 2.6.1 release docs

### DIFF
--- a/docs/agentic-rag.md
+++ b/docs/agentic-rag.md
@@ -149,7 +149,7 @@ Each role has its own env prefix. Docker Compose chains these role-specific sett
 | Seed-gen | Retry follow-up queries | `AGENTIC_SEED_GEN_LLM_SERVERURL` | `AGENTIC_SEED_GEN_LLM_MODEL` | `AGENTIC_SEED_GEN_LLM_APIKEY` |
 | Synthesis | Final answer | `AGENTIC_SYNTHESIS_LLM_SERVERURL` | `AGENTIC_SYNTHESIS_LLM_MODEL` | `AGENTIC_SYNTHESIS_LLM_APIKEY` |
 
-Default Compose values come from the main LLM config: `APP_LLM_SERVERURL` defaults to `nim-llm:8000` and `APP_LLM_MODELNAME` defaults to `nvidia/nemotron-3-super-120b-a12b`. Set `SERVERURL=""` to use the NVIDIA-hosted API. API keys fall back through the role-specific value, `APP_LLM_APIKEY`, and the usual NVIDIA-hosted defaults.
+Default Compose values come from the main LLM config. For self-hosted/on-prem deployments, `APP_LLM_SERVERURL` defaults to `nim-llm:8000` and `APP_LLM_MODELNAME` defaults to `nvidia/nemotron-3-super-120b-a12b`. For NVIDIA-hosted cloud deployments, set each role `SERVERURL` to `""` and use `nvidia/nemotron-3-ultra-550b-a55b` for the LLM model. API keys fall back through the role-specific value, `APP_LLM_APIKEY`, and the usual NVIDIA-hosted defaults.
 
 Per-request `/v1/generate` `model` and `llm_endpoint` values override every agentic role for that request. Omit those fields to use the deployment or role-specific configuration.
 

--- a/docs/change-model.md
+++ b/docs/change-model.md
@@ -15,11 +15,11 @@ To navigate this page more easily, click the outline button at the top of the pa
 
 ### Change the LLM Model
 
-The default LLM is `nvidia/nemotron-3-super-120b-a12b`. To use a different model from the API catalog,
+The default NVIDIA-hosted LLM is `nvidia/nemotron-3-ultra-550b-a55b`. To use a different model from the API catalog,
 specify the model in the `APP_LLM_MODELNAME` environment variable when you start the RAG Server.
 
 ```console
-export APP_LLM_MODELNAME='nvidia/nemotron-3-super-120b-a12b'
+export APP_LLM_MODELNAME='nvidia/nemotron-3-ultra-550b-a55b'
 docker compose -f deploy/compose/docker-compose-rag-server.yaml up -d
 ```
 
@@ -48,7 +48,7 @@ Both names refer to the same underlying model. Use the appropriate name based on
 
 ##### Nemotron 3 Super
 
-`nvidia/nemotron-3-super-120b-a12b` is the default LLM for this blueprint. For hardware requirements and RTX PRO 6000-specific setup, see the [Nemotron 3 Super deployment guide](nemotron3-super-deployment.md).
+`nvidia/nemotron-3-super-120b-a12b` is the default self-hosted/on-prem LLM for this blueprint. For hardware requirements and RTX PRO 6000-specific setup, see the [Nemotron 3 Super deployment guide](nemotron3-super-deployment.md).
 
 ##### Nemotron 3 Ultra
 

--- a/docs/custom-metadata.md
+++ b/docs/custom-metadata.md
@@ -22,7 +22,7 @@ The [NVIDIA RAG Blueprint](readme.md) features **advanced metadata filtering wit
 config = {
     "filter_expression_generator": {
         "enable_filter_generator": True,
-        "model_name": "nvidia/nemotron-3-super-120b-a12b",
+        "model_name": "nvidia/nemotron-3-ultra-550b-a55b",
         "temperature": 0.1,
         "max_tokens": 1024
     }
@@ -524,7 +524,7 @@ Elasticsearch filters use the `metadata.content_metadata.field_name` format and 
 # Configuration file (config.yaml)
 filter_expression_generator:
   enable_filter_generator: true  # Set to true to enable filter generation (default is false)
-  model_name: "nvidia/nemotron-3-super-120b-a12b"
+  model_name: "nvidia/nemotron-3-ultra-550b-a55b"
   server_url: ""  # Leave empty for default endpoint
   temperature: 0.1  # Low temperature for consistent results
   top_p: 0.9
@@ -548,7 +548,7 @@ metadata:
 export ENABLE_FILTER_GENERATOR=true
 
 # LLM configuration
-export APP_FILTEREXPRESSIONGENERATOR_MODELNAME="nvidia/nemotron-3-super-120b-a12b"
+export APP_FILTEREXPRESSIONGENERATOR_MODELNAME="nvidia/nemotron-3-ultra-550b-a55b"
 export APP_FILTEREXPRESSIONGENERATOR_SERVERURL=""
 
 # Note: Metadata configuration is not currently exposed via environment variables
@@ -783,4 +783,3 @@ This comprehensive documentation covers the advanced metadata filtering system w
 - **Configuration Management**: Flexible setup via environment variables
 
 This documentation provides everything needed to implement and use the advanced metadata filtering system with natural language generation capabilities in production environments.
-

--- a/docs/multiturn.md
+++ b/docs/multiturn.md
@@ -199,6 +199,7 @@ You can enable query rewriting at runtime by setting `enable_query_rewriting: Tr
 1. Configure for cloud-hosted model:
    ```bash
    export APP_QUERYREWRITER_SERVERURL=""
+   export APP_QUERYREWRITER_MODELNAME="nvidia/nemotron-3-ultra-550b-a55b"
    export ENABLE_QUERYREWRITER="True"
    export CONVERSATION_HISTORY="5"
    docker compose -f deploy/compose/docker-compose-rag-server.yaml up -d

--- a/docs/python-client.md
+++ b/docs/python-client.md
@@ -246,7 +246,9 @@ config_ingestor = NvidiaRAGConfig.from_yaml("config.yaml")
 # Update config for cloud deployment if using Option 2
 if DEPLOYMENT_MODE == "cloud":
     config_ingestor.embeddings.server_url = "https://integrate.api.nvidia.com/v1"
+    config_ingestor.llm.model_name = "nvidia/nemotron-3-ultra-550b-a55b"
     config_ingestor.llm.server_url = ""  # Empty uses NVIDIA API catalog
+    config_ingestor.summarizer.model_name = "nvidia/nemotron-3-ultra-550b-a55b"
     config_ingestor.summarizer.server_url = ""  # Empty uses NVIDIA API catalog
 else:
     config_ingestor.embeddings.server_url = "http://nemotron-embedding-ms:8000/v1"
@@ -359,7 +361,7 @@ from nvidia_rag.utils.configuration import NvidiaRAGConfig
 
 # config_rag = NvidiaRAGConfig.from_dict({
 #     "llm": {
-#         "model_name": "nvidia/nemotron-3-super-120b-a12b",
+#         "model_name": "nvidia/nemotron-3-ultra-550b-a55b",
 #         "server_url": "",
 #     },
 #     "embeddings": {
@@ -378,6 +380,7 @@ config_rag = NvidiaRAGConfig.from_yaml("config.yaml")
 if DEPLOYMENT_MODE == "cloud":
     config_rag.embeddings.server_url = "https://integrate.api.nvidia.com/v1"
     config_rag.ranking.server_url = ""  # Empty uses NVIDIA API catalog
+    config_rag.llm.model_name = "nvidia/nemotron-3-ultra-550b-a55b"
     config_rag.llm.server_url = ""  # Empty uses NVIDIA API catalog
 
 # Initialize NvidiaRAG with config

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -7,6 +7,27 @@
 This documentation contains the release notes for [NVIDIA RAG Blueprint](readme.md).
 
 
+## Release 2.6.1 (2026-08-06)
+
+This release focuses on model-default documentation and configuration updates. The default NVIDIA-hosted cloud endpoint model changes from Nemotron 3 Super to Nemotron 3 Ultra, and the default self-hosted/on-prem Nemotron 3 Super image is updated to the latest validated 2.0.9 version. This release does not update the RAG Blueprint application container images, Helm chart version, or Python library package version.
+
+### Highlights
+
+This release includes the following key updates:
+
+- **Default cloud endpoint model changed:** NVIDIA-hosted cloud endpoint examples now use `nvidia/nemotron-3-ultra-550b-a55b` instead of `nvidia/nemotron-3-super-120b-a12b`. This applies to the LLM, query rewriter, filter expression generator, summarization, reflection, and agentic RAG role examples.
+- **Default on-prem model updated:** Self-hosted/on-prem deployments that use Nemotron 3 Super now reference `nvcr.io/nim/nvidia/nemotron-3-super-120b-a12b:2.0.9` instead of `1.8.0`. Docker Compose, Helm, MIG, and model-profile examples are updated, including the required `NIM_PASSTHROUGH_ARGS=--max-num-seqs 384` Helm override.
+- Added Docker Compose environment overlays for Nemotron 3 Ultra local and NVIDIA-hosted deployments.
+- Added migration instructions for `nvcr.io/nim/nvidia/nemotron-3-embed-1b:2.2.1`, including Docker Compose, library mode, hosted endpoint API key configuration, 2048-dimensional embeddings, and re-ingestion guidance.
+- Restored Workbench compose image paths to the public `nvcr.io/nvidia/blueprint` registry organization.
+
+### Fixed Known Issues
+
+The following known issues have been resolved in this release:
+
+- Fixed scheduled skills evaluation runs so they execute full sweeps, archive only current-run results, and clean up Brev GPU instances on both success and failure.
+- Fixed NVIDIA-hosted `rag-blueprint` skill evaluation coverage by adding the missing CPU resource metadata.
+
 
 ## Release 2.6.0 (2026-05-30)
 

--- a/docs/self-reflection.md
+++ b/docs/self-reflection.md
@@ -125,7 +125,7 @@ If you don't have sufficient GPU resources for on-premises deployment, you can u
    export REFLECTION_LLM_SERVERURL=""
 
    # Choose the reflection model (options below)
-   export REFLECTION_LLM="nvidia/nemotron-3-super-120b-a12b"  # Default option
+   export REFLECTION_LLM="nvidia/nemotron-3-ultra-550b-a55b"  # Default NVIDIA-hosted option
    # export REFLECTION_LLM="meta/llama-3.1-405b-instruct"  # Alternative option
    ```
 

--- a/docs/summarization.md
+++ b/docs/summarization.md
@@ -316,7 +316,7 @@ For more details on customizing these prompts, see [Prompt Customization Guide](
 
 **Environment Variables:**
 
-- **SUMMARY_LLM**: The model name to use for summarization (default: `nvidia/nemotron-3-super-120b-a12b`)
+- **SUMMARY_LLM**: The model name to use for summarization with NVIDIA-hosted endpoints (default: `nvidia/nemotron-3-ultra-550b-a55b`)
 - **SUMMARY_LLM_SERVERURL**: The server URL hosting the summarization model (default: empty, uses NVIDIA hosted API)
 - **SUMMARY_LLM_MAX_CHUNK_LENGTH**: Maximum chunk size in **tokens** for document processing (default: `9000`)
 - **SUMMARY_CHUNK_OVERLAP**: Overlap between chunks for summarization in **tokens** (default: `400`)
@@ -327,7 +327,7 @@ For more details on customizing these prompts, see [Prompt Customization Guide](
 ### Example Configuration
 
 ```bash
-export SUMMARY_LLM="nvidia/nemotron-3-super-120b-a12b"
+export SUMMARY_LLM="nvidia/nemotron-3-ultra-550b-a55b"
 export SUMMARY_LLM_SERVERURL=""
 export SUMMARY_LLM_MAX_CHUNK_LENGTH=9000
 export SUMMARY_CHUNK_OVERLAP=400


### PR DESCRIPTION
## Summary

- Add the RAG 2.6.1 changelog and release notes.
- Emphasize the two primary model-default updates:
  - NVIDIA-hosted cloud endpoint examples now use `nvidia/nemotron-3-ultra-550b-a55b`.
  - Self-hosted/on-prem Nemotron 3 Super references use `nvcr.io/nim/nvidia/nemotron-3-super-120b-a12b:2.0.9`.
- Update cloud-hosted documentation examples for LLM, query rewriting, filter expression generation, summarization, reflection, agentic RAG roles, Python client, and performance guidance.

## Notes

- This is a docs/configuration guidance update only.
- No RAG Blueprint application container tags, Helm chart versions, or Python library package versions were changed.

## Validation

- `git diff --check origin/main..HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated NVIDIA-hosted deployment examples and default configurations to use the Nemotron 3 Ultra model.
  * Clarified per-role Agentic RAG settings, query rewriting, reflection, summarization, filtering, and Python client configuration.
  * Documented that Nemotron 3 Super remains the default for self-hosted and on-premises deployments.
  * Added version 2.6.1 release notes covering deployment overlays, embedding migration guidance, restored registry paths, and evaluation fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->